### PR TITLE
Database models for Disruptions and Alerts

### DIFF
--- a/server/data/alert.ts
+++ b/server/data/alert.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+
+/**
+ * Represents a disruption alert from the PTV API. May or may not correlate to
+ * an actual disruption shown on the site (e.g. we may choose to ignore some,
+ * split some alerts into multiple separate disruptions, or combine multiple
+ * alerts into a single disruption). Allows us to track which alerts we've seen
+ * before, which ones we've processed, etc.
+ */
+export class Alert {
+  constructor(
+    readonly id: string,
+    readonly state: "new" | "processed" | "ignored" | "updated",
+    readonly data: AlertData,
+    readonly updatedData: AlertData | null,
+    readonly appearedAt: Date,
+    readonly processedAt: Date | null,
+    readonly updatedAt: Date | null,
+    readonly ignoreFutureUpdates: boolean,
+    readonly deleteAt: Date | null,
+  ) {}
+}
+
+/**
+ * Represents the data published in a PTV API disruption alert at a moment in
+ * time. If an alert is updated by PTV after it was already published, the alert
+ * will have two instances of this class: one for the original data, and one for
+ * the updated data (enables us to show the diff to the admin).
+ */
+export class AlertData {
+  constructor(
+    readonly title: string,
+    readonly description: string,
+    readonly url: string,
+    readonly startsAt: Date | null,
+    readonly endsAt: Date | null,
+    readonly affectedLinePtvIds: number[],
+    readonly affectedStationPtvIds: number[],
+  ) {}
+
+  static readonly bson = z
+    .object({
+      title: z.string(),
+      description: z.string(),
+      url: z.string(),
+      startsAt: z.date().nullable(),
+      endsAt: z.date().nullable(),
+      affectedLinePtvIds: z.number().array(),
+      affectedStationPtvIds: z.number().array(),
+    })
+    .transform(
+      (x) =>
+        new AlertData(
+          x.title,
+          x.description,
+          x.url,
+          x.startsAt,
+          x.endsAt,
+          x.affectedLinePtvIds,
+          x.affectedStationPtvIds,
+        ),
+    );
+
+  toBson(): z.input<typeof AlertData.bson> {
+    return {
+      title: this.title,
+      description: this.description,
+      url: this.url,
+      startsAt: this.startsAt,
+      endsAt: this.endsAt,
+      affectedLinePtvIds: this.affectedLinePtvIds,
+      affectedStationPtvIds: this.affectedStationPtvIds,
+    };
+  }
+}

--- a/server/data/alert.ts
+++ b/server/data/alert.ts
@@ -10,7 +10,6 @@ import { z } from "zod";
 export class Alert {
   constructor(
     readonly id: string,
-    readonly state: "new" | "processed" | "ignored" | "updated",
     readonly data: AlertData,
     readonly updatedData: AlertData | null,
     readonly appearedAt: Date,
@@ -18,7 +17,37 @@ export class Alert {
     readonly updatedAt: Date | null,
     readonly ignoreFutureUpdates: boolean,
     readonly deleteAt: Date | null,
-  ) {}
+  ) {
+    if ((this.updatedAt == null) !== (this.updatedData == null)) {
+      throw new Error(
+        "Cannot have one of updatedAt or updatedData be null/set without the other.",
+      );
+    }
+    if (this.processedAt == null) {
+      if (this.updatedData != null) {
+        throw new Error(
+          "Cannot have updatedData set without processedAt being set.",
+        );
+      }
+      if (this.ignoreFutureUpdates) {
+        throw new Error(
+          "Cannot have ignoreFutureUpdates set without processedAt being set.",
+        );
+      }
+    }
+  }
+
+  getState() {
+    if (this.processedAt === null) {
+      return "new";
+    } else if (this.ignoreFutureUpdates) {
+      return "ignored";
+    } else if (this.updatedData !== null) {
+      return "updated";
+    } else {
+      return "processed";
+    }
+  }
 }
 
 /**

--- a/server/data/disruption.ts
+++ b/server/data/disruption.ts
@@ -1,0 +1,32 @@
+import { StationClosureDisruptionData } from "./disruptions/station-closure";
+
+/**
+ * Represents a curated disruption, ready for display on the site. Not to be
+ * confused with an Alert, which is the raw data from the PTV API, which may or
+ * may not be useful to us. ("Curated" here doesn't assume manual curation, it
+ * could be automated in some cases.)
+ */
+export class Disruption {
+  constructor(
+    readonly id: string,
+    // TODO: Becomes:
+    // ```
+    // readonly data:
+    //   | StationClosureDisruptionData
+    //   | NoCityLoopDisruptionData
+    //   | BusReplacementsDisruptionData
+    //   | etc.
+    // ```
+    // as more types are added.
+    readonly data: StationClosureDisruptionData,
+    readonly sourceAlertIds: string[],
+  ) {}
+}
+
+/**
+ * The base class for disruption data, which will change depending on the type
+ * of disruption occurring.
+ */
+export abstract class DisruptionData<T extends string> {
+  constructor(readonly type: T) {}
+}

--- a/server/data/disruptions/station-closure.ts
+++ b/server/data/disruptions/station-closure.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import { DisruptionData } from "../disruption";
+
+/**
+ * A single station is closed. (Trains may be continuing to run express through
+ * the station.)
+ */
+export class StationClosureDisruptionData extends DisruptionData<"station-closed"> {
+  constructor(
+    readonly stationId: number,
+    readonly startsAt: Date,
+    readonly endsAt: Date,
+  ) {
+    super("station-closed");
+  }
+
+  static readonly bson = z
+    .object({
+      type: z.literal("station-closed"),
+      stationId: z.number(),
+      startsAt: z.date(),
+      endsAt: z.date(),
+    })
+    .transform(
+      (x) =>
+        new StationClosureDisruptionData(x.stationId, x.startsAt, x.endsAt),
+    );
+
+  toBson(): z.input<typeof StationClosureDisruptionData.bson> {
+    return {
+      type: "station-closed",
+      stationId: this.stationId,
+      startsAt: this.startsAt,
+      endsAt: this.endsAt,
+    };
+  }
+}

--- a/server/data/disruptions/station-closure.ts
+++ b/server/data/disruptions/station-closure.ts
@@ -5,18 +5,18 @@ import { DisruptionData } from "../disruption";
  * A single station is closed. (Trains may be continuing to run express through
  * the station.)
  */
-export class StationClosureDisruptionData extends DisruptionData<"station-closed"> {
+export class StationClosureDisruptionData extends DisruptionData<"station-closure"> {
   constructor(
     readonly stationId: number,
     readonly startsAt: Date,
     readonly endsAt: Date,
   ) {
-    super("station-closed");
+    super("station-closure");
   }
 
   static readonly bson = z
     .object({
-      type: z.literal("station-closed"),
+      type: z.literal("station-closure"),
       stationId: z.number(),
       startsAt: z.date(),
       endsAt: z.date(),
@@ -28,7 +28,7 @@ export class StationClosureDisruptionData extends DisruptionData<"station-closed
 
   toBson(): z.input<typeof StationClosureDisruptionData.bson> {
     return {
-      type: "station-closed",
+      type: "station-closure",
       stationId: this.stationId,
       startsAt: this.startsAt,
       endsAt: this.endsAt,

--- a/server/database/models/alert.ts
+++ b/server/database/models/alert.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { Alert, AlertData } from "../../data/alert";
+import { DatabaseModel } from "../lib/general/database-model";
+
+export class AlertModel extends DatabaseModel<
+  Alert,
+  string,
+  z.input<typeof AlertModel.schema>
+> {
+  static instance = new AlertModel();
+
+  private static schema = z.object({
+    state: z.enum(["new", "processed", "ignored", "updated"]),
+    data: AlertData.bson,
+    updatedData: AlertData.bson.nullable(),
+    appearedAt: z.date(),
+    processedAt: z.date().nullable(),
+    updatedAt: z.date().nullable(),
+    ignoreFutureUpdates: z.boolean(),
+    deleteAt: z.date().nullable(),
+  });
+
+  private constructor() {
+    super("alerts");
+  }
+
+  getId(item: Alert): string {
+    return item.id;
+  }
+
+  serialize(item: Alert): z.input<typeof AlertModel.schema> {
+    return {
+      state: item.state,
+      data: item.data.toBson(),
+      updatedData: item.updatedData?.toBson() ?? null,
+      appearedAt: item.appearedAt,
+      processedAt: item.processedAt,
+      updatedAt: item.updatedAt,
+      ignoreFutureUpdates: item.ignoreFutureUpdates,
+      deleteAt: item.deleteAt,
+    };
+  }
+
+  deserialize(id: string, item: unknown): Alert {
+    const parsed = AlertModel.schema.parse(item);
+    return new Alert(
+      id,
+      parsed.state,
+      parsed.data,
+      parsed.updatedData,
+      parsed.appearedAt,
+      parsed.processedAt,
+      parsed.updatedAt,
+      parsed.ignoreFutureUpdates,
+      parsed.deleteAt,
+    );
+  }
+}

--- a/server/database/models/alert.ts
+++ b/server/database/models/alert.ts
@@ -10,7 +10,9 @@ export class AlertModel extends DatabaseModel<
   static instance = new AlertModel();
 
   private static schema = z.object({
+    // Entirely calculated from other fields, but included for ease of querying.
     state: z.enum(["new", "processed", "ignored", "updated"]),
+
     data: AlertData.bson,
     updatedData: AlertData.bson.nullable(),
     appearedAt: z.date(),
@@ -30,7 +32,8 @@ export class AlertModel extends DatabaseModel<
 
   serialize(item: Alert): z.input<typeof AlertModel.schema> {
     return {
-      state: item.state,
+      state: item.getState(),
+
       data: item.data.toBson(),
       updatedData: item.updatedData?.toBson() ?? null,
       appearedAt: item.appearedAt,
@@ -45,7 +48,6 @@ export class AlertModel extends DatabaseModel<
     const parsed = AlertModel.schema.parse(item);
     return new Alert(
       id,
-      parsed.state,
       parsed.data,
       parsed.updatedData,
       parsed.appearedAt,

--- a/server/database/models/disruption.ts
+++ b/server/database/models/disruption.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import { DatabaseModel } from "../lib/general/database-model";
+import { Disruption } from "../../data/disruption";
+import { StationClosureDisruptionData } from "../../data/disruptions/station-closure";
+
+export class DisruptionModel extends DatabaseModel<
+  Disruption,
+  string,
+  z.input<typeof DisruptionModel.schema>
+> {
+  static instance = new DisruptionModel();
+
+  private static schema = z.object({
+    // TODO: Becomes:
+    // ```
+    // data: z.union([
+    //   StationClosureDisruptionData.bson,
+    //   NoCityLoopDisruptionData.bson,
+    //   BusReplacementsDisruptionData.bson,
+    //   etc.
+    // ])
+    // ```
+    // as more types are added.
+    data: StationClosureDisruptionData.bson,
+    sourceAlertIds: z.string().array(),
+  });
+
+  private constructor() {
+    super("alerts");
+  }
+
+  getId(item: Disruption): string {
+    return item.id;
+  }
+
+  serialize(item: Disruption): z.input<typeof DisruptionModel.schema> {
+    return {
+      data: item.data.toBson(),
+      sourceAlertIds: item.sourceAlertIds,
+    };
+  }
+
+  deserialize(id: string, item: unknown): Disruption {
+    const parsed = DisruptionModel.schema.parse(item);
+    return new Disruption(id, parsed.data, parsed.sourceAlertIds);
+  }
+}

--- a/server/database/models/disruption.ts
+++ b/server/database/models/disruption.ts
@@ -37,6 +37,8 @@ export class DisruptionModel extends DatabaseModel<
     return {
       data: item.data.toBson(),
       sourceAlertIds: item.sourceAlertIds,
+      // TODO: There's probably other (computed) fields we could add to make
+      // queries more efficient, e.g. the date range, or the affected lines.
     };
   }
 


### PR DESCRIPTION
- Adds database model for `Alerts`.
  - "Alerts" = Disruption messages we have received from the PTV API. We track them because we'll want to know which we've processed, which we're ignoring, etc.
- Adds database model for `Disruptions`.
  - "Disruptions" = The curated disruptions (including those curated automatically) which we display on the site. These won't always correlate 1:1 with PTV's "Alerts", but will be based on them.
  - Disruptions will have some shared fields (at least, in the future, no doubt), but also have data which is polymorphic. E.g. "Station Closure" is one type of disruption, but we will have many of these in future.