### PR TITLE
Improve narrow screen support on overview page

### DIFF
--- a/components/core/Column.tsx
+++ b/components/core/Column.tsx
@@ -7,6 +7,7 @@ export type ColumnProps = {
   className?: string;
   align?: "stretch" | "left" | "center" | "right";
   justify?: "top" | "center" | "bottom" | "space-between";
+  wrap?: boolean;
 };
 
 /**
@@ -35,7 +36,15 @@ export function Column(props: ColumnProps) {
   }[props.justify ?? "top"];
 
   return (
-    <Tag className={clsx("flex flex-col", justify, align, props.className)}>
+    <Tag
+      className={clsx(
+        "flex flex-col",
+        justify,
+        align,
+        { "flex-wrap": props.wrap },
+        props.className,
+      )}
+    >
       {props.children}
     </Tag>
   );

--- a/components/core/Row.tsx
+++ b/components/core/Row.tsx
@@ -7,6 +7,7 @@ export type RowProps = {
   className?: string;
   align?: "stretch" | "top" | "center" | "bottom";
   justify?: "left" | "center" | "right" | "space-between";
+  wrap?: boolean;
 };
 
 /**
@@ -35,7 +36,15 @@ export function Row(props: RowProps) {
   }[props.justify ?? "left"];
 
   return (
-    <Tag className={clsx("flex flex-row", justify, align, props.className)}>
+    <Tag
+      className={clsx(
+        "flex flex-row",
+        justify,
+        align,
+        { "flex-wrap": props.wrap },
+        props.className,
+      )}
+    >
       {props.children}
     </Tag>
   );

--- a/components/navigation/MobileNavBar.tsx
+++ b/components/navigation/MobileNavBar.tsx
@@ -5,7 +5,7 @@ import { Grid } from "../core/Grid";
 
 export function MobileNavBar() {
   return (
-    <nav className="fixed right-0 bottom-0 left-0 z-50 border-t border-t-slate-200 bg-white md:hidden">
+    <nav className="fixed right-0 bottom-0 left-0 z-50 min-w-(--page-min-width) border-t border-t-slate-200 bg-white md:hidden">
       <Grid className="auto-cols-[1fr] grid-flow-col px-4">
         {[overview, myCommute, admin, settings].map((route) => (
           <MobileTabButton key={route.name} tab={route} />

--- a/layouts/LayoutDefault.tsx
+++ b/layouts/LayoutDefault.tsx
@@ -17,7 +17,7 @@ export default function LayoutDefault({
   }
 
   return (
-    <Column className="min-h-screen">
+    <Column className="min-h-screen w-[max(100vw,var(--page-min-width))] overflow-x-hidden">
       <DesktopNavBar />
       <MobileNavBar />
       <With flexGrow="1" className="pb-16 md:pt-12 md:pb-0">

--- a/layouts/LayoutDefault.tsx
+++ b/layouts/LayoutDefault.tsx
@@ -6,7 +6,6 @@ import { DesktopNavBar } from "../components/navigation/DesktopNavBar";
 import { MobileNavBar } from "../components/navigation/MobileNavBar";
 import { Column } from "../components/core/Column";
 import { With } from "../components/core/With";
-import clsx from "clsx";
 
 export default function LayoutDefault({
   children,
@@ -17,13 +16,8 @@ export default function LayoutDefault({
     throw new Error("Layout expects one child.");
   }
 
-  // Prevents pages which cannot shrink down to `--page-min-width` (20rem) from
-  // affecting fixed position elements (e.g. the mobile nav bar).
-  const handleOverwidth =
-    "w-[max(100vw,var(--page-min-width))] overflow-x-hidden";
-
   return (
-    <Column className={clsx("min-h-screen", handleOverwidth)}>
+    <Column className="min-h-screen">
       <DesktopNavBar />
       <MobileNavBar />
       <With flexGrow="1" className="pb-16 md:pt-12 md:pb-0">

--- a/layouts/LayoutDefault.tsx
+++ b/layouts/LayoutDefault.tsx
@@ -6,6 +6,7 @@ import { DesktopNavBar } from "../components/navigation/DesktopNavBar";
 import { MobileNavBar } from "../components/navigation/MobileNavBar";
 import { Column } from "../components/core/Column";
 import { With } from "../components/core/With";
+import clsx from "clsx";
 
 export default function LayoutDefault({
   children,
@@ -16,8 +17,13 @@ export default function LayoutDefault({
     throw new Error("Layout expects one child.");
   }
 
+  // Prevents pages which cannot shrink down to `--page-min-width` (20rem) from
+  // affecting fixed position elements (e.g. the mobile nav bar).
+  const handleOverwidth =
+    "w-[max(100vw,var(--page-min-width))] overflow-x-hidden";
+
   return (
-    <Column className="min-h-screen w-[max(100vw,var(--page-min-width))] overflow-x-hidden">
+    <Column className={clsx("min-h-screen", handleOverwidth)}>
       <DesktopNavBar />
       <MobileNavBar />
       <With flexGrow="1" className="pb-16 md:pt-12 md:pb-0">

--- a/layouts/tailwind.css
+++ b/layouts/tailwind.css
@@ -44,6 +44,11 @@
   flex-shrink: 0;
 }
 
+html {
+  --page-min-width: 20rem;
+  min-width: var(--page-min-width);
+}
+
 /* Always use pointer cursor on buttons. */
 @layer base {
   button:not(:disabled),

--- a/pages/index/+Page.tsx
+++ b/pages/index/+Page.tsx
@@ -28,15 +28,19 @@ export default function Page() {
           <Spacer h="6" />
 
           {/* TODO: determine the options for both selects */}
-          <Row align="center" className="gap-1.5">
-            <Text>Show</Text>
-            <select className="w-35 rounded border border-black">
-              <option value={"all"}>all disruptions</option>
-            </select>
-            <Text>occurring</Text>
-            <select className="w-30 rounded border border-black">
-              <option value={"now"}>right now</option>
-            </select>
+          <Row align="center" className="max-w-md gap-1.5" wrap>
+            <Row align="center" className="flex-grow gap-1.5">
+              <Text>Show</Text>
+              <select className="flex-grow rounded border border-black">
+                <option value={"all"}>all disruptions</option>
+              </select>
+            </Row>
+            <Row align="center" className="flex-grow gap-1.5">
+              <Text>occurring</Text>
+              <select className="flex-grow rounded border border-black">
+                <option value={"now"}>right now</option>
+              </select>
+            </Row>
           </Row>
           <Spacer h="4" />
 


### PR DESCRIPTION
- Fix "Show [all disruptions 🔽] occuring [right now 🔽]" component from forcing the page to be wider than a typical phone screen.
- Define minimum supported page width of 20rem, and prevent over-width pages from affecting mobile nav bar positioning/size.
- Add `flex-wrap` support to `<Column>` and `<Row>`.