### PR TITLE
Temporarily display historical alerts count on Admin page

### DIFF
--- a/pages/admin/+Page.tsx
+++ b/pages/admin/+Page.tsx
@@ -4,13 +4,31 @@ import { Text } from "../../components/core/Text";
 import { Column } from "../../components/core/Column";
 import { PageCenterer } from "../../components/common/PageCenterer";
 import { PagePadding } from "../../components/common/PagePadding";
+import { useData } from "vike-react/useData";
+import { Data } from "./+data";
 
 export default function Page() {
+  // TODO: This is temporary. Saves me having to check the prod database all the
+  // time though. If you're here to work on the Admin page, free free to move
+  // all this to another place or delete it.
+  const { historicalAlertsCount, historicalAlertsAvgPerDay } = useData<Data>();
+
   return (
     <PageCenterer>
       <PagePadding>
-        <Column>
+        <Column className="gap-4">
           <Text style="title">Admin</Text>
+          <Text>
+            {historicalAlertsCount}{" "}
+            {historicalAlertsCount === 1
+              ? "historical alert"
+              : "historical alerts"}{" "}
+            recorded so far.
+          </Text>
+          <Text>
+            That&apos;s an average of {historicalAlertsAvgPerDay.toFixed(2)} per
+            day.
+          </Text>
         </Column>
       </PagePadding>
     </PageCenterer>

--- a/pages/admin/+data.ts
+++ b/pages/admin/+data.ts
@@ -1,0 +1,34 @@
+import { PageContext } from "vike/types";
+import { HISTORICAL_ALERTS } from "../../server/database/models/models";
+
+const historicalRecordsStartDate = Date.parse("2025-03-02");
+const millisInADay = 1000 * 60 * 60 * 24;
+
+export type Data = {
+  // TODO: This is temporary. Saves me having to check the prod database all the
+  // time though. If you're here to work on the Admin page, free free to move
+  // all this to another place or delete it.
+  historicalAlertsCount: number;
+  historicalAlertsAvgPerDay: number;
+};
+
+export async function data(pageContext: PageContext): Promise<Data> {
+  const { app } = pageContext.custom;
+
+  const historicalAlertsCount = await app.database
+    .of(HISTORICAL_ALERTS)
+    .count();
+
+  const daysSinceRecordsBegan =
+    (Date.now() - historicalRecordsStartDate) / millisInADay;
+
+  // Very crude average. Includes the initial dump of alerts, many of which
+  // probably existed long before the 2nd of March!
+  const historicalAlertsAvgPerDay =
+    historicalAlertsCount / daysSinceRecordsBegan;
+
+  return {
+    historicalAlertsCount,
+    historicalAlertsAvgPerDay,
+  };
+}

--- a/pages/commute/+Page.tsx
+++ b/pages/commute/+Page.tsx
@@ -18,7 +18,7 @@ export default function Page() {
         <Column align="left">
           {commute != null && (
             <>
-              <Text style="title">Is It Buses...</Text>
+              <Text style="title">Is it buses...</Text>
               <Spacer h="4" />
               <Text>
                 between <b>{commute.stationAName}</b> and{" "}

--- a/pages/trip/DisplayTripPage.tsx
+++ b/pages/trip/DisplayTripPage.tsx
@@ -34,7 +34,7 @@ export function DisplayTripPage(props: DisplayTripPageProps) {
       <PageCenterer>
         <PagePadding>
           <Column>
-            <Text style="title">Is It Buses...</Text>
+            <Text style="title">Is it buses...</Text>
             <Spacer h="4" />
             <Text>
               between <b>{props.data.stationA.name}</b> and{" "}


### PR DESCRIPTION
- Display the number of historical alerts we've tracked since https://github.com/dan-schel/train-disruptions/pull/39 was deployed on the Admin page, as well as a crude estimate at the average per day.
- Unrelated: Fix capitalization of "Is it buses..." on commute and trip pages.