### PR TITLE
Fix bug causing line page to not render

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,7 +32,7 @@ const customRules = {
     "react/self-closing-comp": "warn",
 
     // Ensure return type of +data hooks checks against JsonSerializable.
-    "custom/ensure-data-serializable": "error",
+    "custom/ensure-data-serializable": "warn",
 
     // TODO: Consider other lint rules from
     // https://github.com/jsx-eslint/eslint-plugin-react?tab=readme-ov-file#list-of-supported-rules

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import react from "eslint-plugin-react/configs/recommended.js";
 import reactHooks from "eslint-plugin-react-hooks";
 import globals from "globals";
 import tseslint from "typescript-eslint";
+import custom from "./scripts/eslint/index.js";
 
 // Philosophy: Reserve errors for situations where the code will not run or
 // compile. Everything else is a warning. Warnings will still cause CI to fail,
@@ -11,6 +12,9 @@ import tseslint from "typescript-eslint";
 // putting red squigglies all over the place.
 
 const customRules = {
+  plugins: {
+    custom,
+  },
   rules: {
     // Ignore unused variables if they start with underscores.
     "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
@@ -26,6 +30,9 @@ const customRules = {
 
     // Warn if <Thing></Thing> can be changed to <Thing />.
     "react/self-closing-comp": "warn",
+
+    // Ensure return type of +data hooks checks against JsonSerializable.
+    "custom/ensure-data-serializable": "error",
 
     // TODO: Consider other lint rules from
     // https://github.com/jsx-eslint/eslint-plugin-react?tab=readme-ov-file#list-of-supported-rules

--- a/pages/admin/+data.ts
+++ b/pages/admin/+data.ts
@@ -1,5 +1,6 @@
 import { PageContext } from "vike/types";
 import { HISTORICAL_ALERTS } from "../../server/database/models/models";
+import { JsonSerializable } from "../../shared/json-serializable";
 
 const historicalRecordsStartDate = Date.parse("2025-03-02");
 const millisInADay = 1000 * 60 * 60 * 24;
@@ -12,7 +13,9 @@ export type Data = {
   historicalAlertsAvgPerDay: number;
 };
 
-export async function data(pageContext: PageContext): Promise<Data> {
+export async function data(
+  pageContext: PageContext,
+): Promise<Data & JsonSerializable> {
   const { app } = pageContext.custom;
 
   const historicalAlertsCount = await app.database

--- a/pages/commute/+data.ts
+++ b/pages/commute/+data.ts
@@ -1,4 +1,5 @@
 import { PageContext } from "vike/types";
+import { JsonSerializable } from "../../shared/json-serializable";
 
 export type Data = {
   commute: {
@@ -7,7 +8,7 @@ export type Data = {
   } | null;
 };
 
-export function data(pageContext: PageContext): Data {
+export function data(pageContext: PageContext): Data & JsonSerializable {
   const { app, settings } = pageContext.custom;
 
   if (settings.commute == null) {

--- a/pages/index/+data.ts
+++ b/pages/index/+data.ts
@@ -1,4 +1,5 @@
 import { PageContext } from "vike/types";
+import { JsonSerializable } from "../../shared/json-serializable";
 
 export type Line = {
   id: number;
@@ -12,7 +13,7 @@ export type Data = {
 
 const SortByNameDesc = (a: Line, b: Line) => a.name.localeCompare(b.name);
 
-export function data(pageContext: PageContext): Data {
+export function data(pageContext: PageContext): Data & JsonSerializable {
   const { app } = pageContext.custom;
 
   const suburban = app.lines

--- a/pages/line/@id/+Page.tsx
+++ b/pages/line/@id/+Page.tsx
@@ -1,22 +1,13 @@
 import React from "react";
+
 import { useData } from "vike-react/useData";
-
 import { Data } from "./+data";
-
 import { Text } from "../../../components/core/Text";
 import { Column } from "../../../components/core/Column";
 import { PageCenterer } from "../../../components/common/PageCenterer";
 import { PagePadding } from "../../../components/common/PagePadding";
 import { BackNavigation } from "../../../components/navigation/BackNavigation";
 import { Calendar } from "../../../components/calendar/Calendar";
-
-/**
- * TODO: Handle scenarios where the provided id doesn't correspond to a line.
- *
- * Options:
- * - Show an error page
- * - Navigate back straight away
- */
 
 export default function Page() {
   const { line } = useData<Data>();
@@ -27,7 +18,7 @@ export default function Page() {
       <PageCenterer>
         <PagePadding>
           <Column className="gap-4">
-            {line ? (
+            {line != null ? (
               <>
                 <Text style="title">Is it buses...</Text>
                 <Text>

--- a/pages/line/@id/+data.ts
+++ b/pages/line/@id/+data.ts
@@ -1,14 +1,44 @@
-import { DataAsync } from "vike/types";
-import { lines } from "../../../server/data/static/lines";
+import { PageContext } from "vike/types";
+import { parseIntNull } from "@dan-schel/js-utils";
+import { LineCollection } from "../../../server/data/static/line-collection";
 import { Line } from "../../../server/data/static/line";
 
-export { data };
 export type Data = {
-  line: Line | null;
+  line: {
+    name: string;
+  } | null;
 };
 
-const data: DataAsync = async (pageContext): Promise<Data> => {
-  const line = lines.get(parseInt(pageContext.routeParams.id));
+export function data(pageContext: PageContext): Data {
+  const { app } = pageContext.custom;
 
-  return { line };
-};
+  const line = tryGetLine(app.lines, pageContext.routeParams.id);
+
+  if (line == null) {
+    return {
+      line: null,
+    };
+  }
+
+  return {
+    line: {
+      name: line.name,
+    },
+  };
+}
+
+function tryGetLine(
+  lines: LineCollection,
+  idStr: string | null | undefined,
+): Line | null {
+  if (idStr == null) {
+    return null;
+  }
+
+  const id = parseIntNull(idStr);
+  if (id == null) {
+    return null;
+  }
+
+  return lines.get(id);
+}

--- a/pages/line/@id/+data.ts
+++ b/pages/line/@id/+data.ts
@@ -2,6 +2,7 @@ import { PageContext } from "vike/types";
 import { parseIntNull } from "@dan-schel/js-utils";
 import { LineCollection } from "../../../server/data/static/line-collection";
 import { Line } from "../../../server/data/static/line";
+import { JsonSerializable } from "../../../shared/json-serializable";
 
 export type Data = {
   line: {
@@ -9,7 +10,7 @@ export type Data = {
   } | null;
 };
 
-export function data(pageContext: PageContext): Data {
+export function data(pageContext: PageContext): Data & JsonSerializable {
   const { app } = pageContext.custom;
 
   const line = tryGetLine(app.lines, pageContext.routeParams.id);

--- a/pages/trip/+data.ts
+++ b/pages/trip/+data.ts
@@ -3,6 +3,7 @@ import { PageContext } from "vike/types";
 import { StationCollection } from "../../server/data/static/station-collection";
 import { Station } from "../../server/data/static/station";
 import { Settings } from "../../shared/settings";
+import { JsonSerializable } from "../../shared/json-serializable";
 
 export type ChooseData = {
   type: "choose";
@@ -27,7 +28,7 @@ export type DisplayData = {
 
 export type Data = ChooseData | DisplayData;
 
-export function data(pageContext: PageContext): Data {
+export function data(pageContext: PageContext): Data & JsonSerializable {
   const { app, settings } = pageContext.custom;
   const to = tryGetStation(app.stations, pageContext.urlParsed.search.to);
   const from = tryGetStation(app.stations, pageContext.urlParsed.search.from);

--- a/scripts/eslint/ensure-data-serializable.js
+++ b/scripts/eslint/ensure-data-serializable.js
@@ -1,0 +1,87 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+const ensureDataSerializable = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    type: "problem",
+    messages: {
+      violation:
+        "Always append `& JsonSerializable` to the return type of +data functions, e.g. `Data & JsonSerializable`.",
+      violationPromise:
+        "Always append `& JsonSerializable` to the return type of +data functions, e.g. `Promise<Data & JsonSerializable>`.",
+    },
+    schema: [],
+    fixable: "code",
+  },
+  create: (context) => {
+    if (!context.filename.endsWith("+data.ts")) {
+      return {};
+    }
+
+    return {
+      FunctionDeclaration: (node) => {
+        if (node.id.name !== "data") {
+          return;
+        }
+
+        const returnType = node.returnType.typeAnnotation;
+        const valid =
+          isIntersectionWithJsonSerializable(returnType) ||
+          isPromiseWithJsonSerializable(returnType);
+
+        if (!valid) {
+          if (isPromise(returnType)) {
+            const promiseParam = returnType.typeArguments.params[0];
+
+            context.report({
+              loc: promiseParam.loc,
+              messageId: "violationPromise",
+              fix: (fixer) => {
+                return fixer.insertTextAfter(
+                  promiseParam,
+                  " & JsonSerializable",
+                );
+              },
+            });
+          } else {
+            context.report({
+              loc: returnType.loc,
+              messageId: "violation",
+              fix(fixer) {
+                return fixer.insertTextAfter(returnType, " & JsonSerializable");
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+  defaultOptions: [],
+});
+
+function isIntersectionWithJsonSerializable(returnType) {
+  return (
+    returnType.type === "TSIntersectionType" &&
+    returnType.types.some(
+      (x) =>
+        x.type === "TSTypeReference" && x.typeName.name === "JsonSerializable",
+    )
+  );
+}
+
+function isPromise(returnType) {
+  return (
+    returnType.type === "TSTypeReference" &&
+    returnType.typeName.name === "Promise" &&
+    returnType.typeArguments &&
+    returnType.typeArguments.params.length === 1
+  );
+}
+
+function isPromiseWithJsonSerializable(returnType) {
+  return (
+    isPromise(returnType) &&
+    isIntersectionWithJsonSerializable(returnType.typeArguments.params[0])
+  );
+}
+
+export default ensureDataSerializable;

--- a/scripts/eslint/index.js
+++ b/scripts/eslint/index.js
@@ -1,0 +1,13 @@
+import ensureDataSerializable from "./ensure-data-serializable.js";
+
+const plugin = {
+  meta: {
+    name: "custom",
+    version: "1.0.0",
+  },
+  rules: {
+    "ensure-data-serializable": ensureDataSerializable,
+  },
+};
+
+export default plugin;

--- a/shared/json-serializable.ts
+++ b/shared/json-serializable.ts
@@ -1,0 +1,8 @@
+export type JsonSerializable =
+  | undefined
+  | string
+  | number
+  | boolean
+  | null
+  | { [field: string]: JsonSerializable }
+  | readonly JsonSerializable[];


### PR DESCRIPTION
- Currently the line page is failing to render.
- This is because we try to send the entire `Line` object to the frontend, rather than something that is convertible to JSON.
- The fix is:
  ```diff
    export type Data = {
  -   line: Line;
  +   line: {
  +     name: string;
  +   } | null;
    };
  ```
- Errors displayed in console:
  <img width="400" src="https://github.com/user-attachments/assets/f75128eb-9a95-4730-b133-b83e98f81b3a">
- I had a go at writing a custom ESLint rule to catch this in the future. It forces the return type to include `& JsonSerializable`, which means that more complex objects cannot be returned. Seems to work! 🎉
