### PR TITLE
Fix disruption fetching & make alert logger more resilient

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -70,8 +70,8 @@ export class App {
   }
 
   private _runHistoricalAlertLogger() {
-    setInterval(
-      async () => {
+    setInterval(async () => {
+      try {
         const disruptions = await this.disruptionSource.fetchDisruptions();
 
         disruptions.forEach(async (disruption) => {
@@ -90,8 +90,10 @@ export class App {
               );
           }
         });
-      },
-      1000 * 60 * 5,
-    );
+      } catch (error) {
+        console.warn("Failed to log historical alerts.");
+        console.warn(error);
+      }
+    }, 1000 * 5);
   }
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -70,30 +70,33 @@ export class App {
   }
 
   private _runHistoricalAlertLogger() {
-    setInterval(async () => {
-      try {
-        const disruptions = await this.disruptionSource.fetchDisruptions();
+    setInterval(
+      async () => {
+        try {
+          const disruptions = await this.disruptionSource.fetchDisruptions();
 
-        disruptions.forEach(async (disruption) => {
-          const x = await this.database
-            .of(HISTORICAL_ALERTS)
-            .get(disruption.disruption_id);
-          if (x == null) {
-            await this.database
+          disruptions.forEach(async (disruption) => {
+            const x = await this.database
               .of(HISTORICAL_ALERTS)
-              .create(
-                new HistoricalAlert(
-                  disruption.disruption_id,
-                  disruption.title,
-                  disruption.description,
-                ),
-              );
-          }
-        });
-      } catch (error) {
-        console.warn("Failed to log historical alerts.");
-        console.warn(error);
-      }
-    }, 1000 * 5);
+              .get(disruption.disruption_id);
+            if (x == null) {
+              await this.database
+                .of(HISTORICAL_ALERTS)
+                .create(
+                  new HistoricalAlert(
+                    disruption.disruption_id,
+                    disruption.title,
+                    disruption.description,
+                  ),
+                );
+            }
+          });
+        } catch (error) {
+          console.warn("Failed to log historical alerts.");
+          console.warn(error);
+        }
+      },
+      1000 * 60 * 5,
+    );
   }
 }

--- a/types/disruption.ts
+++ b/types/disruption.ts
@@ -34,7 +34,7 @@ export const disruptionSchema = z.object({
   to_date: z.string().datetime().nullable(),
   routes: routeSchema.array(),
   stops: stopSchema.array(),
-  colour: z.string(),
+  colour: z.string().nullable(),
   display_on_board: z.boolean(),
   display_status: z.boolean(),
 });


### PR DESCRIPTION
- PTV are currently publishing a disruption with `colour` as `null`! 😅
- The initial fetch of disruptions is fine, but the server crashes after 5 mins because the historical alert logger has no error handling.
- This PR addresses both issues :)