### PR TITLE
Switch from relative imports to absolute imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,9 @@
   // Stops VSCode complaining about custom Tailwind CSS at rules, e.g. @theme.
   "files.associations": {
     "*.css": "tailwindcss"
-  }
+  },
+
+  // Configures VSCode's auto import to use "@/..." paths.
+  "typescript.preferences.importModuleSpecifier": "non-relative",
+  "javascript.preferences.importModuleSpecifier": "non-relative"
 }

--- a/components/calendar/Calendar.tsx
+++ b/components/calendar/Calendar.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 
-import { Grid } from "../core/Grid";
-import { With } from "../core/With";
-import { Column } from "../core/Column";
+import { Grid } from "@/components/core/Grid";
+import { With } from "@/components/core/With";
+import { Column } from "@/components/core/Column";
 
-import { Legends } from "./Legends";
-import { MonthTitle } from "./Title";
-import { CalendarGrid } from "./Grid";
-import { DaysOfTheWeek } from "./Days";
-import { TodayIndicator } from "./Today";
-import { getMonthsToRender, isInitial } from "./utils";
+import { Legends } from "@/components/calendar/Legends";
+import { MonthTitle } from "@/components/calendar/Title";
+import { CalendarGrid } from "@/components/calendar/Grid";
+import { DaysOfTheWeek } from "@/components/calendar/Days";
+import { TodayIndicator } from "@/components/calendar/Today";
+import { getMonthsToRender, isInitial } from "@/components/calendar/utils";
 
 export type Disruption = {
   from: Date;

--- a/components/calendar/Days.tsx
+++ b/components/calendar/Days.tsx
@@ -3,7 +3,7 @@ import { range } from "@dan-schel/js-utils";
 import { daysInWeek } from "date-fns/constants";
 import { format, addDays, startOfISOWeek } from "date-fns";
 
-import { Grid } from "../core/Grid";
+import { Grid } from "@/components/core/Grid";
 
 export const DaysOfTheWeek = () => {
   return (

--- a/components/calendar/Grid.tsx
+++ b/components/calendar/Grid.tsx
@@ -3,11 +3,15 @@ import React from "react";
 import { addDays } from "date-fns";
 import { range } from "@dan-schel/js-utils";
 
-import { Grid } from "../core/Grid";
-import { Text } from "../core/Text";
-import { Disruption } from "./Calendar";
+import { Grid } from "@/components/core/Grid";
+import { Text } from "@/components/core/Text";
+import { Disruption } from "@/components/calendar/Calendar";
 
-import { isInitial, column, isThereDisruption } from "./utils";
+import {
+  isInitial,
+  column,
+  isThereDisruption,
+} from "@/components/calendar/utils";
 
 type Props = {
   start: Date;

--- a/components/calendar/Legends.tsx
+++ b/components/calendar/Legends.tsx
@@ -1,10 +1,10 @@
 import clsx from "clsx";
 import React from "react";
 
-import { Row } from "../core/Row";
-import { Text } from "../core/Text";
+import { Row } from "@/components/core/Row";
+import { Text } from "@/components/core/Text";
 
-import { disruption } from "./utils";
+import { disruption } from "@/components/calendar/utils";
 
 export const Legends = () => {
   return (

--- a/components/calendar/Title.tsx
+++ b/components/calendar/Title.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { format } from "date-fns";
 
-import { Text } from "../core/Text";
+import { Text } from "@/components/core/Text";
 
 type Props = {
   date: Date;

--- a/components/calendar/Today.tsx
+++ b/components/calendar/Today.tsx
@@ -3,10 +3,10 @@ import React from "react";
 import { toZonedTime } from "date-fns-tz";
 import { getISODay, isSameMonth, isThisISOWeek } from "date-fns";
 
-import { Grid } from "../core/Grid";
-import { Text } from "../core/Text";
+import { Grid } from "@/components/core/Grid";
+import { Text } from "@/components/core/Text";
 
-import { column, IANAMelbourneTimezone } from "./utils";
+import { column, IANAMelbourneTimezone } from "@/components/calendar/utils";
 
 type Props = {
   date: Date;

--- a/components/calendar/utils.ts
+++ b/components/calendar/utils.ts
@@ -1,4 +1,4 @@
-import { Disruption } from "./Calendar";
+import { Disruption } from "@/components/calendar/Calendar";
 import { toZonedTime } from "date-fns-tz";
 import { daysInWeek } from "date-fns/constants";
 import {

--- a/components/common/PageCenterer.tsx
+++ b/components/common/PageCenterer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { With } from "../core/With";
+import { With } from "@/components/core/With";
 
 export type PageCentererProps = {
   children: React.ReactElement;

--- a/components/common/PagePadding.tsx
+++ b/components/common/PagePadding.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { With } from "../core/With";
+import { With } from "@/components/core/With";
 
 export type PagePaddingProps = {
   children: React.ReactElement;

--- a/components/common/SimpleButton.tsx
+++ b/components/common/SimpleButton.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { Action, Button, extractAction } from "../core/Button";
-import { Row } from "../core/Row";
-import { Text } from "../core/Text";
-import { With } from "../core/With";
+import { Action, Button, extractAction } from "@/components/core/Button";
+import { Row } from "@/components/core/Row";
+import { Text } from "@/components/core/Text";
+import { With } from "@/components/core/With";
 import clsx from "clsx";
-import { Column } from "../core/Column";
+import { Column } from "@/components/core/Column";
 
 const themes = {
   default: "bg-slate-200 group-hover:bg-slate-300 group-active:bg-slate-400",

--- a/components/core/Link.tsx
+++ b/components/core/Link.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Action } from "./Button";
+import { Action } from "@/components/core/Button";
 
 export type LinkProps = {
   children: React.ReactNode;

--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef } from "react";
-import { Renderer } from "./renderer/renderer";
+import { Renderer } from "@/components/map/renderer/renderer";
 import { Geometry } from "./renderer/geometry";
 
 // To debug geometry without needing to re-run the generator:

--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useMemo, useRef } from "react";
 import { Renderer } from "@/components/map/renderer/renderer";
-import { Geometry } from "./renderer/geometry";
+import { Geometry } from "@/components/map/renderer/geometry";
 
 // To debug geometry without needing to re-run the generator:
 // import geometry from "../../scripts/generate-map-geometry/ptv";
-import geometryJson from "./geometry/ptv.json";
+import geometryJson from "@/components/map/geometry/ptv.json";
 
 export function Map() {
   const containerRef = useRef<HTMLDivElement>(null);

--- a/components/map/renderer/geometry.ts
+++ b/components/map/renderer/geometry.ts
@@ -1,9 +1,9 @@
-import { Line } from "./line";
-import { Interchange } from "./interchange";
-import { Terminus } from "./terminus";
+import { Line } from "@/components/map/renderer/line";
+import { Interchange } from "@/components/map/renderer/interchange";
+import { Terminus } from "@/components/map/renderer/terminus";
 import { z } from "zod";
-import { DualViewport } from "./dual-viewport";
-import { viewportPadding } from "./utils";
+import { DualViewport } from "@/components/map/renderer/dual-viewport";
+import { viewportPadding } from "@/components/map/renderer/utils";
 
 export class Geometry {
   constructor(

--- a/components/map/renderer/interchange.ts
+++ b/components/map/renderer/interchange.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { DualPoint } from "./dual-point";
+import { DualPoint } from "@/components/map/renderer/dual-point";
 
 export class Interchange {
   constructor(

--- a/components/map/renderer/line.ts
+++ b/components/map/renderer/line.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { DualPoint } from "./dual-point";
-import { LineColor, lineColors } from "./utils";
+import { DualPoint } from "@/components/map/renderer/dual-point";
+import { LineColor, lineColors } from "@/components/map/renderer/utils";
 
 export class Line {
   constructor(

--- a/components/map/renderer/renderer.ts
+++ b/components/map/renderer/renderer.ts
@@ -1,6 +1,6 @@
-import { Geometry } from "./geometry";
-import { Interchange } from "./interchange";
-import { DualPoint } from "./dual-point";
+import { Geometry } from "@/components/map/renderer/geometry";
+import { Interchange } from "@/components/map/renderer/interchange";
+import { DualPoint } from "@/components/map/renderer/dual-point";
 import {
   interchangeBorderWidth,
   interchangeFillColor,
@@ -11,7 +11,7 @@ import {
   lineWidth,
   terminusLineWidth,
   viewportPadding,
-} from "./utils";
+} from "@/components/map/renderer/utils";
 
 // Canvas has `backingStorePixelRatio`, but Typescript doesn't know about it for
 // some reason. (Probably the target "ES____" version we're using idk.)

--- a/components/map/renderer/terminus.ts
+++ b/components/map/renderer/terminus.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { DualPoint } from "./dual-point";
-import { LineColor, lineColors } from "./utils";
+import { DualPoint } from "@/components/map/renderer/dual-point";
+import { LineColor, lineColors } from "@/components/map/renderer/utils";
 
 export class Terminus {
   constructor(

--- a/components/navigation/BackNavigation.tsx
+++ b/components/navigation/BackNavigation.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { PageCenterer } from "../common/PageCenterer";
-import { SimpleButton } from "../common/SimpleButton";
-import { Row } from "../core/Row";
-import { With } from "../core/With";
-import { MingcuteLeftLine } from "../icons/MingcuteLeftLine";
+import { PageCenterer } from "@/components/common/PageCenterer";
+import { SimpleButton } from "@/components/common/SimpleButton";
+import { Row } from "@/components/core/Row";
+import { With } from "@/components/core/With";
+import { MingcuteLeftLine } from "@/components/icons/MingcuteLeftLine";
 
 export type BackNavigationProps = {
   name: string;

--- a/components/navigation/DesktopNavBar.tsx
+++ b/components/navigation/DesktopNavBar.tsx
@@ -1,12 +1,17 @@
 import React from "react";
-import { PageCenterer } from "../common/PageCenterer";
-import { Text } from "../core/Text";
-import { admin, myCommute, overview, settings } from "./utils";
-import { Grid } from "../core/Grid";
-import { Row } from "../core/Row";
-import { DesktopTabButton } from "./DesktopTabButton";
-import { Favicon } from "../icons/Favicon";
-import { Button } from "../core/Button";
+import { PageCenterer } from "@/components/common/PageCenterer";
+import { Text } from "@/components/core/Text";
+import {
+  admin,
+  myCommute,
+  overview,
+  settings,
+} from "@/components/navigation/utils";
+import { Grid } from "@/components/core/Grid";
+import { Row } from "@/components/core/Row";
+import { DesktopTabButton } from "@/components/navigation/DesktopTabButton";
+import { Favicon } from "@/components/icons/Favicon";
+import { Button } from "@/components/core/Button";
 
 export function DesktopNavBar() {
   return (

--- a/components/navigation/DesktopTabButton.tsx
+++ b/components/navigation/DesktopTabButton.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { Button } from "../core/Button";
-import { Row } from "../core/Row";
-import { Text } from "../core/Text";
-import { With } from "../core/With";
+import { Button } from "@/components/core/Button";
+import { Row } from "@/components/core/Row";
+import { Text } from "@/components/core/Text";
+import { With } from "@/components/core/With";
 import clsx from "clsx";
-import { NavTab } from "./utils";
+import { NavTab } from "@/components/navigation/utils";
 import { usePageContext } from "vike-react/usePageContext";
 
 export type DesktopTabButtonProps = {

--- a/components/navigation/MobileNavBar.tsx
+++ b/components/navigation/MobileNavBar.tsx
@@ -1,7 +1,12 @@
 import React from "react";
-import { admin, myCommute, overview, settings } from "./utils";
-import { MobileTabButton } from "./MobileTabButton";
-import { Grid } from "../core/Grid";
+import {
+  admin,
+  myCommute,
+  overview,
+  settings,
+} from "@/components/navigation/utils";
+import { MobileTabButton } from "@/components/navigation/MobileTabButton";
+import { Grid } from "@/components/core/Grid";
 
 export function MobileNavBar() {
   return (

--- a/components/navigation/MobileTabButton.tsx
+++ b/components/navigation/MobileTabButton.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import { Button } from "../core/Button";
-import { Text } from "../core/Text";
-import { With } from "../core/With";
+import { Button } from "@/components/core/Button";
+import { Text } from "@/components/core/Text";
+import { With } from "@/components/core/With";
 import clsx from "clsx";
-import { NavTab } from "./utils";
+import { NavTab } from "@/components/navigation/utils";
 import { usePageContext } from "vike-react/usePageContext";
-import { Column } from "../core/Column";
+import { Column } from "@/components/core/Column";
 
 export type MobileTabButtonProps = {
   tab: NavTab;

--- a/components/navigation/utils.tsx
+++ b/components/navigation/utils.tsx
@@ -1,12 +1,12 @@
 import React from "react";
-import { MingcuteArrowRightCircleLine } from "../icons/MingcuteArrowRightCircleLine";
-import { MingcuteMapLine } from "../icons/MingcuteMapLine";
-import { MingcuteToolLine } from "../icons/MingcuteToolLine";
-import { MingcuteSettings7Line } from "../icons/MingcuteSettings7Line";
-import { MingcuteMapFill } from "../icons/MingcuteMapFill";
-import { MingcuteArrowRightCircleFill } from "../icons/MingcuteArrowRightCircleFill";
-import { MingcuteToolFill } from "../icons/MingcuteToolFill";
-import { MingcuteSettings7Fill } from "../icons/MingcuteSettings7Fill";
+import { MingcuteArrowRightCircleLine } from "@/components/icons/MingcuteArrowRightCircleLine";
+import { MingcuteMapLine } from "@/components/icons/MingcuteMapLine";
+import { MingcuteToolLine } from "@/components/icons/MingcuteToolLine";
+import { MingcuteSettings7Line } from "@/components/icons/MingcuteSettings7Line";
+import { MingcuteMapFill } from "@/components/icons/MingcuteMapFill";
+import { MingcuteArrowRightCircleFill } from "@/components/icons/MingcuteArrowRightCircleFill";
+import { MingcuteToolFill } from "@/components/icons/MingcuteToolFill";
+import { MingcuteSettings7Fill } from "@/components/icons/MingcuteSettings7Fill";
 
 export type NavTab = {
   name: string;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,6 +34,9 @@ const customRules = {
     // Ensure return type of +data hooks checks against JsonSerializable.
     "custom/ensure-data-serializable": "warn",
 
+    // Ban relative imports, and require paths to start with "@/" instead.
+    "custom/enforce-import-alias": "warn",
+
     // TODO: Consider other lint rules from
     // https://github.com/jsx-eslint/eslint-plugin-react?tab=readme-ov-file#list-of-supported-rules
     // such as `react/button-has-type`.

--- a/hooks/useDisruptions.ts
+++ b/hooks/useDisruptions.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
-import { type Disruption } from "../types/disruption";
+import { type Disruption } from "@/types/disruption";
 
 /**
  * React hook used to retrieve disruptions from the API

--- a/hooks/useSettings.ts
+++ b/hooks/useSettings.ts
@@ -1,5 +1,5 @@
 import Cookies from "js-cookie";
-import { cookieSettings, Settings } from "../shared/settings";
+import { cookieSettings, Settings } from "@/shared/settings";
 
 const fetchSettingsSsrError =
   "fetchSettings (from useSettings) failed, as it was used during SSR! Pass " +

--- a/layouts/LayoutDefault.tsx
+++ b/layouts/LayoutDefault.tsx
@@ -1,11 +1,11 @@
-import "./tailwind.css";
+import "@/layouts/tailwind.css";
 
 import React from "react";
 
-import { DesktopNavBar } from "../components/navigation/DesktopNavBar";
-import { MobileNavBar } from "../components/navigation/MobileNavBar";
-import { Column } from "../components/core/Column";
-import { With } from "../components/core/With";
+import { DesktopNavBar } from "@/components/navigation/DesktopNavBar";
+import { MobileNavBar } from "@/components/navigation/MobileNavBar";
+import { Column } from "@/components/core/Column";
+import { With } from "@/components/core/With";
 
 export default function LayoutDefault({
   children,

--- a/main.ts
+++ b/main.ts
@@ -1,17 +1,17 @@
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { createVikeHandler } from "./server/vike-handler";
+import { createVikeHandler } from "@/server/vike-handler";
 import express from "express";
 import cookieParser from "cookie-parser";
-import { env } from "./server/env";
-import { createApiRouter } from "./server/routes/api";
+import { env } from "@/server/env";
+import { createApiRouter } from "@/server/routes/api";
 import { createDevMiddleware } from "vike/server";
-import { App } from "./server/app";
-import { lines } from "./server/data/static/lines";
-import { stations } from "./server/data/static/stations";
-import { initDatabase } from "./server/database/init-database";
-import { initDisruptionSource } from "./server/disruption-source/init-disruption-source";
+import { App } from "@/server/app";
+import { lines } from "@/server/data/static/lines";
+import { stations } from "@/server/data/static/stations";
+import { initDatabase } from "@/server/database/init-database";
+import { initDisruptionSource } from "@/server/disruption-source/init-disruption-source";
 
 await main();
 

--- a/pages/+config.ts
+++ b/pages/+config.ts
@@ -1,6 +1,6 @@
 import vikeReact from "vike-react/config";
 import type { Config } from "vike/types";
-import Layout from "../layouts/LayoutDefault.js";
+import Layout from "@/layouts/LayoutDefault.js";
 
 // Default config (can be overridden by pages)
 // https://vike.dev/config

--- a/pages/admin/+Page.tsx
+++ b/pages/admin/+Page.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 
-import { Text } from "../../components/core/Text";
-import { Column } from "../../components/core/Column";
-import { PageCenterer } from "../../components/common/PageCenterer";
-import { PagePadding } from "../../components/common/PagePadding";
+import { Text } from "@/components/core/Text";
+import { Column } from "@/components/core/Column";
+import { PageCenterer } from "@/components/common/PageCenterer";
+import { PagePadding } from "@/components/common/PagePadding";
 import { useData } from "vike-react/useData";
-import { Data } from "./+data";
+import { Data } from "@/pages/admin/+data";
 
 export default function Page() {
   // TODO: This is temporary. Saves me having to check the prod database all the

--- a/pages/admin/+data.ts
+++ b/pages/admin/+data.ts
@@ -1,6 +1,6 @@
 import { PageContext } from "vike/types";
-import { HISTORICAL_ALERTS } from "../../server/database/models/models";
-import { JsonSerializable } from "../../shared/json-serializable";
+import { HISTORICAL_ALERTS } from "@/server/database/models/models";
+import { JsonSerializable } from "@/shared/json-serializable";
 
 const historicalRecordsStartDate = Date.parse("2025-03-02");
 const millisInADay = 1000 * 60 * 60 * 24;

--- a/pages/commute/+Page.tsx
+++ b/pages/commute/+Page.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 
-import { Text } from "../../components/core/Text";
-import { Column } from "../../components/core/Column";
-import { PageCenterer } from "../../components/common/PageCenterer";
-import { SimpleButton } from "../../components/common/SimpleButton";
-import { PagePadding } from "../../components/common/PagePadding";
+import { Text } from "@/components/core/Text";
+import { Column } from "@/components/core/Column";
+import { PageCenterer } from "@/components/common/PageCenterer";
+import { SimpleButton } from "@/components/common/SimpleButton";
+import { PagePadding } from "@/components/common/PagePadding";
 import { useData } from "vike-react/useData";
-import { Data } from "./+data";
-import { Spacer } from "../../components/core/Spacer";
+import { Data } from "@/pages/commute/+data";
+import { Spacer } from "@/components/core/Spacer";
 
 export default function Page() {
   const { commute } = useData<Data>();

--- a/pages/commute/+data.ts
+++ b/pages/commute/+data.ts
@@ -1,5 +1,5 @@
 import { PageContext } from "vike/types";
-import { JsonSerializable } from "../../shared/json-serializable";
+import { JsonSerializable } from "@/shared/json-serializable";
 
 export type Data = {
   commute: {

--- a/pages/disruption/@id/+Page.tsx
+++ b/pages/disruption/@id/+Page.tsx
@@ -1,15 +1,15 @@
 import React from "react";
-import { Data } from "./+data";
+import { Data } from "@/pages/disruption/@id/+data";
 import { useData } from "vike-react/useData";
 
-import { Delay } from "./Delay";
-import { NotFound } from "./NotFound";
-import { Disruption } from "./Disruption";
-import { With } from "../../../components/core/With";
-import { Column } from "../../../components/core/Column";
-import { PagePadding } from "../../../components/common/PagePadding";
-import { PageCenterer } from "../../../components/common/PageCenterer";
-import { BackNavigation } from "../../../components/navigation/BackNavigation";
+import { Delay } from "@/pages/disruption/@id/Delay";
+import { NotFound } from "@/pages/disruption/@id/NotFound";
+import { Disruption } from "@/pages/disruption/@id/Disruption";
+import { With } from "@/components/core/With";
+import { Column } from "@/components/core/Column";
+import { PagePadding } from "@/components/common/PagePadding";
+import { PageCenterer } from "@/components/common/PageCenterer";
+import { BackNavigation } from "@/components/navigation/BackNavigation";
 
 export default function Page() {
   const { data, backHref } = useData<Data>();

--- a/pages/disruption/@id/+data.ts
+++ b/pages/disruption/@id/+data.ts
@@ -1,6 +1,6 @@
 import { PageContext } from "vike/types";
-import { Disruption } from "../../../components/calendar/Calendar";
-import { JsonSerializable } from "../../../shared/json-serializable";
+import { Disruption } from "@/components/calendar/Calendar";
+import { JsonSerializable } from "@/shared/json-serializable";
 
 export type Data = {
   backHref: string;

--- a/pages/disruption/@id/Delay.tsx
+++ b/pages/disruption/@id/Delay.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import { Delay as DelayProps } from "./+data";
+import { Delay as DelayProps } from "@/pages/disruption/@id/+data";
 
-import { Map } from "../../../components/map/Map";
-import { Text } from "../../../components/core/Text";
-import { Link } from "../../../components/core/Link";
-import { With } from "../../../components/core/With";
-import { Column } from "../../../components/core/Column";
+import { Map } from "@/components/map/Map";
+import { Text } from "@/components/core/Text";
+import { Link } from "@/components/core/Link";
+import { With } from "@/components/core/With";
+import { Column } from "@/components/core/Column";
 
 export function Delay(props: DelayProps) {
   const { title, description, link } = props;

--- a/pages/disruption/@id/Disruption.tsx
+++ b/pages/disruption/@id/Disruption.tsx
@@ -1,14 +1,14 @@
 import React from "react";
-import { AlteredRoute as AlteredRouteProps } from "./+data";
-import { BusReplacement as BusReplacementProps } from "./+data";
-import { StationClosure as StationClosureProps } from "./+data";
+import { AlteredRoute as AlteredRouteProps } from "@/pages/disruption/@id/+data";
+import { BusReplacement as BusReplacementProps } from "@/pages/disruption/@id/+data";
+import { StationClosure as StationClosureProps } from "@/pages/disruption/@id/+data";
 
-import { Map } from "../../../components/map/Map";
-import { Text } from "../../../components/core/Text";
-import { Link } from "../../../components/core/Link";
-import { With } from "../../../components/core/With";
-import { Column } from "../../../components/core/Column";
-import { Calendar } from "../../../components/calendar/Calendar";
+import { Map } from "@/components/map/Map";
+import { Text } from "@/components/core/Text";
+import { Link } from "@/components/core/Link";
+import { With } from "@/components/core/With";
+import { Column } from "@/components/core/Column";
+import { Calendar } from "@/components/calendar/Calendar";
 
 export function Disruption(
   props: StationClosureProps | AlteredRouteProps | BusReplacementProps,

--- a/pages/disruption/@id/NotFound.tsx
+++ b/pages/disruption/@id/NotFound.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
-import { Text } from "../../../components/core/Text";
-import { Column } from "../../../components/core/Column";
+import { Text } from "@/components/core/Text";
+import { Column } from "@/components/core/Column";
 
 export function NotFound() {
   return (

--- a/pages/index/+Page.tsx
+++ b/pages/index/+Page.tsx
@@ -1,18 +1,18 @@
 import React from "react";
 import { useData } from "vike-react/useData";
 
-import { Data } from "./+data";
+import { Data } from "@/pages/index/+data";
 
-import { Lines } from "./Lines";
-import { Disruptions } from "./Disruptions";
-import { Map } from "../../components/map/Map";
-import { Row } from "../../components/core/Row";
-import { With } from "../../components/core/With";
-import { Text } from "../../components/core/Text";
-import { Column } from "../../components/core/Column";
-import { Spacer } from "../../components/core/Spacer";
-import { PagePadding } from "../../components/common/PagePadding";
-import { PageCenterer } from "../../components/common/PageCenterer";
+import { Lines } from "@/pages/index/Lines";
+import { Disruptions } from "@/pages/index/Disruptions";
+import { Map } from "@/components/map/Map";
+import { Row } from "@/components/core/Row";
+import { With } from "@/components/core/With";
+import { Text } from "@/components/core/Text";
+import { Column } from "@/components/core/Column";
+import { Spacer } from "@/components/core/Spacer";
+import { PagePadding } from "@/components/common/PagePadding";
+import { PageCenterer } from "@/components/common/PageCenterer";
 
 export default function Page() {
   const { suburban, regional } = useData<Data>();

--- a/pages/index/+data.ts
+++ b/pages/index/+data.ts
@@ -1,5 +1,5 @@
 import { PageContext } from "vike/types";
-import { JsonSerializable } from "../../shared/json-serializable";
+import { JsonSerializable } from "@/shared/json-serializable";
 
 export type Line = {
   id: number;

--- a/pages/index/DisruptionButton.tsx
+++ b/pages/index/DisruptionButton.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import { Grid } from "../../components/core/Grid";
-import { Text } from "../../components/core/Text";
-import { Button } from "../../components/core/Button";
-import { Column } from "../../components/core/Column";
-import { MingcuteRightLine } from "../../components/icons/MingcuteRightLine";
-import { MingcuteRouteFill } from "../../components/icons/MingcuteRouteFill";
-import { MingcuteCloseCircleFill } from "../../components/icons/MingcuteCloseCircleFill";
+import { Grid } from "@/components/core/Grid";
+import { Text } from "@/components/core/Text";
+import { Button } from "@/components/core/Button";
+import { Column } from "@/components/core/Column";
+import { MingcuteRightLine } from "@/components/icons/MingcuteRightLine";
+import { MingcuteRouteFill } from "@/components/icons/MingcuteRouteFill";
+import { MingcuteCloseCircleFill } from "@/components/icons/MingcuteCloseCircleFill";
 
 type DisruptionType =
   | {

--- a/pages/index/Disruptions.tsx
+++ b/pages/index/Disruptions.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
-import { Column } from "../../components/core/Column";
-import { DisruptionButton } from "./DisruptionButton";
+import { Column } from "@/components/core/Column";
+import { DisruptionButton } from "@/pages/index/DisruptionButton";
 
 export function Disruptions() {
   return (

--- a/pages/index/LineButton.tsx
+++ b/pages/index/LineButton.tsx
@@ -1,12 +1,12 @@
 import clsx from "clsx";
 import React from "react";
-import { Line } from "./+data";
+import { Line } from "@/pages/index/+data";
 
-import { Row } from "../../components/core/Row";
-import { Grid } from "../../components/core/Grid";
-import { Text } from "../../components/core/Text";
-import { Button } from "../../components/core/Button";
-import { MingcuteRightLine } from "../../components/icons/MingcuteRightLine";
+import { Row } from "@/components/core/Row";
+import { Grid } from "@/components/core/Grid";
+import { Text } from "@/components/core/Text";
+import { Button } from "@/components/core/Button";
+import { MingcuteRightLine } from "@/components/icons/MingcuteRightLine";
 
 type LineButtonProps = {
   line: Line;

--- a/pages/index/Lines.tsx
+++ b/pages/index/Lines.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { Line } from "./+data";
+import { Line } from "@/pages/index/+data";
 
-import { LineButton } from "./LineButton";
-import { Text } from "../../components/core/Text";
-import { Column } from "../../components/core/Column";
+import { LineButton } from "@/pages/index/LineButton";
+import { Text } from "@/components/core/Text";
+import { Column } from "@/components/core/Column";
 
 type LinesProps = {
   title: string;

--- a/pages/line/@id/+Page.tsx
+++ b/pages/line/@id/+Page.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 
 import { useData } from "vike-react/useData";
-import { Data } from "./+data";
-import { Text } from "../../../components/core/Text";
-import { Column } from "../../../components/core/Column";
-import { PageCenterer } from "../../../components/common/PageCenterer";
-import { PagePadding } from "../../../components/common/PagePadding";
-import { BackNavigation } from "../../../components/navigation/BackNavigation";
-import { Calendar } from "../../../components/calendar/Calendar";
+import { Data } from "@/pages/line/@id/+data";
+import { Text } from "@/components/core/Text";
+import { Column } from "@/components/core/Column";
+import { PageCenterer } from "@/components/common/PageCenterer";
+import { PagePadding } from "@/components/common/PagePadding";
+import { BackNavigation } from "@/components/navigation/BackNavigation";
+import { Calendar } from "@/components/calendar/Calendar";
 
 export default function Page() {
   const { line } = useData<Data>();

--- a/pages/line/@id/+data.ts
+++ b/pages/line/@id/+data.ts
@@ -1,8 +1,8 @@
 import { PageContext } from "vike/types";
 import { parseIntNull } from "@dan-schel/js-utils";
-import { LineCollection } from "../../../server/data/static/line-collection";
-import { Line } from "../../../server/data/static/line";
-import { JsonSerializable } from "../../../shared/json-serializable";
+import { LineCollection } from "@/server/data/static/line-collection";
+import { Line } from "@/server/data/static/line";
+import { JsonSerializable } from "@/shared/json-serializable";
 
 export type Data = {
   line: {

--- a/pages/settings/+Page.tsx
+++ b/pages/settings/+Page.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 
-import { Text } from "../../components/core/Text";
-import { Column } from "../../components/core/Column";
-import { PageCenterer } from "../../components/common/PageCenterer";
-import { PagePadding } from "../../components/common/PagePadding";
+import { Text } from "@/components/core/Text";
+import { Column } from "@/components/core/Column";
+import { PageCenterer } from "@/components/common/PageCenterer";
+import { PagePadding } from "@/components/common/PagePadding";
 
 export default function Page() {
   return (

--- a/pages/trip/+Page.tsx
+++ b/pages/trip/+Page.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { useData } from "vike-react/useData";
-import { Data } from "./+data";
-import { DisplayTripPage } from "./DisplayTripPage";
-import { ChooseTripPage } from "./ChooseTripPage";
+import { Data } from "@/pages/trip/+data";
+import { DisplayTripPage } from "@/pages/trip/DisplayTripPage";
+import { ChooseTripPage } from "@/pages/trip/ChooseTripPage";
 
 export default function Page() {
   const data = useData<Data>();

--- a/pages/trip/+data.ts
+++ b/pages/trip/+data.ts
@@ -1,9 +1,9 @@
 import { parseIntNull } from "@dan-schel/js-utils";
 import { PageContext } from "vike/types";
-import { StationCollection } from "../../server/data/static/station-collection";
-import { Station } from "../../server/data/static/station";
-import { Settings } from "../../shared/settings";
-import { JsonSerializable } from "../../shared/json-serializable";
+import { StationCollection } from "@/server/data/static/station-collection";
+import { Station } from "@/server/data/static/station";
+import { Settings } from "@/shared/settings";
+import { JsonSerializable } from "@/shared/json-serializable";
 
 export type ChooseData = {
   type: "choose";

--- a/pages/trip/ChooseTripPage.tsx
+++ b/pages/trip/ChooseTripPage.tsx
@@ -1,14 +1,14 @@
 import React from "react";
-import { Row } from "../../components/core/Row";
-import { Text } from "../../components/core/Text";
-import { Column } from "../../components/core/Column";
-import { PageCenterer } from "../../components/common/PageCenterer";
-import { SimpleButton } from "../../components/common/SimpleButton";
-import { PagePadding } from "../../components/common/PagePadding";
-import { BackNavigation } from "../../components/navigation/BackNavigation";
-import { Spacer } from "../../components/core/Spacer";
-import { MingcuteSearch2Line } from "../../components/icons/MingcureSearch2Line";
-import { ChooseData } from "./+data";
+import { Row } from "@/components/core/Row";
+import { Text } from "@/components/core/Text";
+import { Column } from "@/components/core/Column";
+import { PageCenterer } from "@/components/common/PageCenterer";
+import { SimpleButton } from "@/components/common/SimpleButton";
+import { PagePadding } from "@/components/common/PagePadding";
+import { BackNavigation } from "@/components/navigation/BackNavigation";
+import { Spacer } from "@/components/core/Spacer";
+import { MingcuteSearch2Line } from "@/components/icons/MingcureSearch2Line";
+import { ChooseData } from "@/pages/trip/+data";
 
 export type ChooseTripPageProps = {
   data: ChooseData;

--- a/pages/trip/DisplayTripPage.tsx
+++ b/pages/trip/DisplayTripPage.tsx
@@ -1,15 +1,15 @@
 import React from "react";
-import { Text } from "../../components/core/Text";
-import { Column } from "../../components/core/Column";
-import { PageCenterer } from "../../components/common/PageCenterer";
-import { PagePadding } from "../../components/common/PagePadding";
-import { BackNavigation } from "../../components/navigation/BackNavigation";
-import { DisplayData } from "./+data";
-import { SimpleButton } from "../../components/common/SimpleButton";
-import { Spacer } from "../../components/core/Spacer";
-import { useSettings } from "../../hooks/useSettings";
-import { Row } from "../../components/core/Row";
-import { MingcuteCheckLine } from "../../components/icons/MingcuteCheckLine";
+import { Text } from "@/components/core/Text";
+import { Column } from "@/components/core/Column";
+import { PageCenterer } from "@/components/common/PageCenterer";
+import { PagePadding } from "@/components/common/PagePadding";
+import { BackNavigation } from "@/components/navigation/BackNavigation";
+import { DisplayData } from "@/pages/trip/+data";
+import { SimpleButton } from "@/components/common/SimpleButton";
+import { Spacer } from "@/components/core/Spacer";
+import { useSettings } from "@/hooks/useSettings";
+import { Row } from "@/components/core/Row";
+import { MingcuteCheckLine } from "@/components/icons/MingcuteCheckLine";
 
 export type DisplayTripPageProps = {
   data: DisplayData;

--- a/scripts/eslint/enforce-import-alias.js
+++ b/scripts/eslint/enforce-import-alias.js
@@ -19,13 +19,7 @@ const useImportAlias = {
     return {
       ImportDeclaration: (node) => {
         const repoRelativeFileName = context.filename.replace(context.cwd, "");
-        if (
-          exceptions.some((exception) =>
-            repoRelativeFileName.startsWith(exception),
-          )
-        ) {
-          return;
-        }
+        if (exceptions.some((e) => repoRelativeFileName.startsWith(e))) return;
 
         const value = node.source.value;
         if (!value.startsWith(".")) return;
@@ -34,7 +28,11 @@ const useImportAlias = {
           path.dirname(context.filename),
           value,
         );
-        const aliasedPath = absolutePath.replace(context.cwd, "@");
+
+        const aliasedPath = absolutePath
+          .replace(context.cwd, "@")
+          .replace("\\", "/");
+
         const replacement = `"${aliasedPath}"`;
 
         context.report({

--- a/scripts/eslint/enforce-import-alias.js
+++ b/scripts/eslint/enforce-import-alias.js
@@ -31,7 +31,7 @@ const useImportAlias = {
 
         const aliasedPath = absolutePath
           .replace(context.cwd, "@")
-          .replace("\\", "/");
+          .replace(/\\/g, "/");
 
         const replacement = `"${aliasedPath}"`;
 

--- a/scripts/eslint/enforce-import-alias.js
+++ b/scripts/eslint/enforce-import-alias.js
@@ -1,0 +1,41 @@
+import path from "path";
+
+const useImportAlias = {
+  meta: {
+    type: "problem",
+    messages: {
+      violation: "Replace relative import with {{ replacement }}.",
+    },
+    schema: [],
+    fixable: "code",
+  },
+  create: (context) => {
+    return {
+      ImportDeclaration: (node) => {
+        const value = node.source.value;
+        if (!value.startsWith(".")) return;
+
+        const absolutePath = path.resolve(
+          path.dirname(context.filename),
+          value,
+        );
+        const aliasedPath = absolutePath.replace(context.cwd, "@");
+        const replacement = `"${aliasedPath}"`;
+
+        context.report({
+          loc: node.source.loc,
+          messageId: "violation",
+          data: {
+            replacement,
+          },
+          fix: (fixer) => {
+            return fixer.replaceText(node.source, replacement);
+          },
+        });
+      },
+    };
+  },
+  defaultOptions: [],
+};
+
+export default useImportAlias;

--- a/scripts/eslint/enforce-import-alias.js
+++ b/scripts/eslint/enforce-import-alias.js
@@ -1,5 +1,11 @@
 import path from "path";
 
+const exceptions = [
+  // ESLint config doesn't use import aliases.
+  "/scripts/eslint/",
+  "/eslint.config.js",
+];
+
 const useImportAlias = {
   meta: {
     type: "problem",
@@ -12,6 +18,15 @@ const useImportAlias = {
   create: (context) => {
     return {
       ImportDeclaration: (node) => {
+        const repoRelativeFileName = context.filename.replace(context.cwd, "");
+        if (
+          exceptions.some((exception) =>
+            repoRelativeFileName.startsWith(exception),
+          )
+        ) {
+          return;
+        }
+
         const value = node.source.value;
         if (!value.startsWith(".")) return;
 

--- a/scripts/eslint/index.js
+++ b/scripts/eslint/index.js
@@ -1,4 +1,5 @@
 import ensureDataSerializable from "./ensure-data-serializable.js";
+import enforceImportAlias from "./enforce-import-alias.js";
 
 const plugin = {
   meta: {
@@ -7,6 +8,7 @@ const plugin = {
   },
   rules: {
     "ensure-data-serializable": ensureDataSerializable,
+    "enforce-import-alias": enforceImportAlias,
   },
 };
 

--- a/scripts/generate-map-geometry/example/index.ts
+++ b/scripts/generate-map-geometry/example/index.ts
@@ -1,9 +1,9 @@
-import { flexi } from "../lib/dimensions/flexi-length";
-import { fp } from "../lib/dimensions/flexi-point";
-import { InterchangeBlueprint } from "../lib/blueprint/interchange-blueprint";
-import { LineBlueprint } from "../lib/blueprint/line-blueprint";
-import { PathBlueprint } from "../lib/blueprint/path-blueprint";
-import { GeometryBuilder } from "../lib/builder/geometry-builder";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { fp } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-point";
+import { InterchangeBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/interchange-blueprint";
+import { LineBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/line-blueprint";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
+import { GeometryBuilder } from "@/scripts/generate-map-geometry/lib/builder/geometry-builder";
 
 const interchange = InterchangeBlueprint.simple(
   1,

--- a/scripts/generate-map-geometry/index.ts
+++ b/scripts/generate-map-geometry/index.ts
@@ -7,8 +7,8 @@
 /* eslint-disable no-console */
 import fsp, { rm } from "fs/promises";
 import path from "path";
-import example from "./example";
-import ptv from "./ptv";
+import example from "@/scripts/generate-map-geometry/example";
+import ptv from "@/scripts/generate-map-geometry/ptv";
 
 const outDir = "./components/map/geometry";
 

--- a/scripts/generate-map-geometry/lib/blueprint/interchange-blueprint.ts
+++ b/scripts/generate-map-geometry/lib/blueprint/interchange-blueprint.ts
@@ -1,4 +1,4 @@
-import { InterchangePoint } from "./path-blueprint-piece/station-location";
+import { InterchangePoint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/station-location";
 
 export type RelativePosition =
   | "left-edge"

--- a/scripts/generate-map-geometry/lib/blueprint/line-blueprint.ts
+++ b/scripts/generate-map-geometry/lib/blueprint/line-blueprint.ts
@@ -1,8 +1,8 @@
-import { PathBuilder } from "../builder/path-builder";
-import { FlexiPoint } from "../dimensions/flexi-point";
-import { PathBlueprint } from "./path-blueprint";
-import { ColoredPathCollection } from "../builder/path";
-import { LineColor } from "../../../../components/map/renderer/utils";
+import { PathBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-builder";
+import { FlexiPoint } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-point";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
+import { ColoredPathCollection } from "@/scripts/generate-map-geometry/lib/builder/path";
+import { LineColor } from "@/components/map/renderer/utils";
 
 export class LineBlueprint {
   readonly origin: FlexiPoint;

--- a/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/curve.ts
+++ b/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/curve.ts
@@ -1,7 +1,7 @@
-import { CurveBuilder } from "../../builder/path-piece-builder/curve-builder";
-import { PathPieceBuilder } from "../../builder/path-piece-builder/path-piece-builder";
-import { FlexiLength } from "../../dimensions/flexi-length";
-import { PathBlueprintPiece } from "./path-blueprint-piece";
+import { CurveBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-piece-builder/curve-builder";
+import { PathPieceBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-piece-builder/path-piece-builder";
+import { FlexiLength } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { PathBlueprintPiece } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/path-blueprint-piece";
 
 export class Curve extends PathBlueprintPiece {
   constructor(

--- a/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/path-blueprint-piece.ts
+++ b/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/path-blueprint-piece.ts
@@ -1,4 +1,4 @@
-import { PathPieceBuilder } from "../../builder/path-piece-builder/path-piece-builder";
+import { PathPieceBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-piece-builder/path-piece-builder";
 
 export abstract class PathBlueprintPiece {
   abstract reverse(): PathBlueprintPiece;

--- a/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/split.ts
+++ b/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/split.ts
@@ -1,7 +1,7 @@
-import { PathPieceBuilder } from "../../builder/path-piece-builder/path-piece-builder";
-import { SplitBuilder } from "../../builder/path-piece-builder/split-builder";
-import { PathBlueprint } from "../path-blueprint";
-import { PathBlueprintPiece } from "./path-blueprint-piece";
+import { PathPieceBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-piece-builder/path-piece-builder";
+import { SplitBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-piece-builder/split-builder";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
+import { PathBlueprintPiece } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/path-blueprint-piece";
 
 export class Split extends PathBlueprintPiece {
   constructor(

--- a/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/station-location.ts
+++ b/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/station-location.ts
@@ -1,7 +1,7 @@
-import { PathPieceBuilder } from "../../builder/path-piece-builder/path-piece-builder";
-import { StationLocationBuilder } from "../../builder/path-piece-builder/station-location-builder";
-import { InterchangeBlueprint } from "../interchange-blueprint";
-import { PathBlueprintPiece } from "./path-blueprint-piece";
+import { PathPieceBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-piece-builder/path-piece-builder";
+import { StationLocationBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-piece-builder/station-location-builder";
+import { InterchangeBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/interchange-blueprint";
+import { PathBlueprintPiece } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/path-blueprint-piece";
 
 export class StationLocation extends PathBlueprintPiece {
   constructor(

--- a/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/straight.ts
+++ b/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/straight.ts
@@ -1,7 +1,7 @@
-import { PathPieceBuilder } from "../../builder/path-piece-builder/path-piece-builder";
-import { StraightBuilder } from "../../builder/path-piece-builder/straight-builder";
-import { FlexiLength } from "../../dimensions/flexi-length";
-import { PathBlueprintPiece } from "./path-blueprint-piece";
+import { PathPieceBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-piece-builder/path-piece-builder";
+import { StraightBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-piece-builder/straight-builder";
+import { FlexiLength } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { PathBlueprintPiece } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/path-blueprint-piece";
 
 export class Straight extends PathBlueprintPiece {
   constructor(readonly length: FlexiLength) {

--- a/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/terminus.ts
+++ b/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/terminus.ts
@@ -1,6 +1,6 @@
-import { PathPieceBuilder } from "../../builder/path-piece-builder/path-piece-builder";
-import { TerminusBuilder } from "../../builder/path-piece-builder/terminus-builder";
-import { PathBlueprintPiece } from "./path-blueprint-piece";
+import { PathPieceBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-piece-builder/path-piece-builder";
+import { TerminusBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-piece-builder/terminus-builder";
+import { PathBlueprintPiece } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/path-blueprint-piece";
 
 export class Terminus extends PathBlueprintPiece {
   constructor() {

--- a/scripts/generate-map-geometry/lib/blueprint/path-blueprint.ts
+++ b/scripts/generate-map-geometry/lib/blueprint/path-blueprint.ts
@@ -1,14 +1,14 @@
-import { PathBuilder } from "../builder/path-builder";
-import { FlexiLength } from "./../dimensions/flexi-length";
-import { Curve } from "./path-blueprint-piece/curve";
-import { PathBlueprintPiece } from "./path-blueprint-piece/path-blueprint-piece";
-import { Split } from "./path-blueprint-piece/split";
+import { PathBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-builder";
+import { FlexiLength } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { Curve } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/curve";
+import { PathBlueprintPiece } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/path-blueprint-piece";
+import { Split } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/split";
 import {
   InterchangePoint,
   StationLocation,
-} from "./path-blueprint-piece/station-location";
-import { Straight } from "./path-blueprint-piece/straight";
-import { Terminus } from "./path-blueprint-piece/terminus";
+} from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/station-location";
+import { Straight } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/straight";
+import { Terminus } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/terminus";
 
 export class PathBlueprint {
   readonly pieces: readonly PathBlueprintPiece[];

--- a/scripts/generate-map-geometry/lib/builder/geometry-builder.ts
+++ b/scripts/generate-map-geometry/lib/builder/geometry-builder.ts
@@ -1,16 +1,16 @@
 import { groupBy } from "@dan-schel/js-utils";
-import { LineBlueprint } from "../blueprint/line-blueprint";
-import { Geometry } from "../../../../components/map/renderer/geometry";
-import { InterchangeBuilder } from "./interchange-builder";
-import { Line } from "../../../../components/map/renderer/line";
-import { Terminus } from "../../../../components/map/renderer/terminus";
+import { LineBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/line-blueprint";
+import { Geometry } from "@/components/map/renderer/geometry";
+import { InterchangeBuilder } from "@/scripts/generate-map-geometry/lib/builder/interchange-builder";
+import { Line } from "@/components/map/renderer/line";
+import { Terminus } from "@/components/map/renderer/terminus";
 import {
   DualViewport,
   Viewport,
-} from "../../../../components/map/renderer/dual-viewport";
-import { ColoredPathCollection } from "./path";
-import { Point } from "../dimensions/point";
-import { terminusExtents } from "../utils";
+} from "@/components/map/renderer/dual-viewport";
+import { ColoredPathCollection } from "@/scripts/generate-map-geometry/lib/builder/path";
+import { Point } from "@/scripts/generate-map-geometry/lib/dimensions/point";
+import { terminusExtents } from "@/scripts/generate-map-geometry/lib/utils";
 
 export class GeometryBuilder {
   constructor() {}

--- a/scripts/generate-map-geometry/lib/builder/interchange-builder.ts
+++ b/scripts/generate-map-geometry/lib/builder/interchange-builder.ts
@@ -1,11 +1,14 @@
-import { Interchange } from "../../../../components/map/renderer/interchange";
-import { DualPoint } from "../../../../components/map/renderer/dual-point";
+import { Interchange } from "@/components/map/renderer/interchange";
+import { DualPoint } from "@/components/map/renderer/dual-point";
 import {
   InterchangeBlueprint,
   PointPosition,
-} from "../blueprint/interchange-blueprint";
-import { LocatedInterchange } from "./path";
-import { interchangeEdgeOffset, interchangeInnerOffset } from "../utils";
+} from "@/scripts/generate-map-geometry/lib/blueprint/interchange-blueprint";
+import { LocatedInterchange } from "@/scripts/generate-map-geometry/lib/builder/path";
+import {
+  interchangeEdgeOffset,
+  interchangeInnerOffset,
+} from "@/scripts/generate-map-geometry/lib/utils";
 
 export class InterchangeBuilder {
   constructor(

--- a/scripts/generate-map-geometry/lib/builder/path-builder.ts
+++ b/scripts/generate-map-geometry/lib/builder/path-builder.ts
@@ -1,5 +1,9 @@
-import { FlexiPoint } from "../dimensions/flexi-point";
-import { Path, LocatedInterchange, LocatedTerminus } from "./path";
+import { FlexiPoint } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-point";
+import {
+  Path,
+  LocatedInterchange,
+  LocatedTerminus,
+} from "@/scripts/generate-map-geometry/lib/builder/path";
 
 export class PathBuilder {
   private _currentPoint: FlexiPoint;

--- a/scripts/generate-map-geometry/lib/builder/path-piece-builder/curve-builder.ts
+++ b/scripts/generate-map-geometry/lib/builder/path-piece-builder/curve-builder.ts
@@ -1,6 +1,6 @@
-import { Curve } from "../../blueprint/path-blueprint-piece/curve";
-import { PathBuilder } from "../path-builder";
-import { PathPieceBuilder } from "./path-piece-builder";
+import { Curve } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/curve";
+import { PathBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-builder";
+import { PathPieceBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-piece-builder/path-piece-builder";
 
 export class CurveBuilder extends PathPieceBuilder {
   constructor(private readonly _blueprint: Curve) {

--- a/scripts/generate-map-geometry/lib/builder/path-piece-builder/path-piece-builder.ts
+++ b/scripts/generate-map-geometry/lib/builder/path-piece-builder/path-piece-builder.ts
@@ -1,4 +1,4 @@
-import { PathBuilder } from "../path-builder";
+import { PathBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-builder";
 
 export abstract class PathPieceBuilder {
   abstract build(builder: PathBuilder): void;

--- a/scripts/generate-map-geometry/lib/builder/path-piece-builder/split-builder.ts
+++ b/scripts/generate-map-geometry/lib/builder/path-piece-builder/split-builder.ts
@@ -1,6 +1,6 @@
-import { Split } from "../../blueprint/path-blueprint-piece/split";
-import { PathBuilder } from "../path-builder";
-import { PathPieceBuilder } from "./path-piece-builder";
+import { Split } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/split";
+import { PathBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-builder";
+import { PathPieceBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-piece-builder/path-piece-builder";
 
 export class SplitBuilder extends PathPieceBuilder {
   constructor(private readonly _blueprint: Split) {

--- a/scripts/generate-map-geometry/lib/builder/path-piece-builder/station-location-builder.ts
+++ b/scripts/generate-map-geometry/lib/builder/path-piece-builder/station-location-builder.ts
@@ -1,7 +1,7 @@
-import { StationLocation } from "../../blueprint/path-blueprint-piece/station-location";
-import { LocatedInterchange } from "../path";
-import { PathBuilder } from "../path-builder";
-import { PathPieceBuilder } from "./path-piece-builder";
+import { StationLocation } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/station-location";
+import { LocatedInterchange } from "@/scripts/generate-map-geometry/lib/builder/path";
+import { PathBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-builder";
+import { PathPieceBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-piece-builder/path-piece-builder";
 
 export class StationLocationBuilder extends PathPieceBuilder {
   constructor(private readonly _blueprint: StationLocation) {

--- a/scripts/generate-map-geometry/lib/builder/path-piece-builder/straight-builder.ts
+++ b/scripts/generate-map-geometry/lib/builder/path-piece-builder/straight-builder.ts
@@ -1,6 +1,6 @@
-import { Straight } from "../../blueprint/path-blueprint-piece/straight";
-import { PathBuilder } from "../path-builder";
-import { PathPieceBuilder } from "./path-piece-builder";
+import { Straight } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/straight";
+import { PathBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-builder";
+import { PathPieceBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-piece-builder/path-piece-builder";
 
 export class StraightBuilder extends PathPieceBuilder {
   constructor(private readonly _blueprint: Straight) {

--- a/scripts/generate-map-geometry/lib/builder/path-piece-builder/terminus-builder.ts
+++ b/scripts/generate-map-geometry/lib/builder/path-piece-builder/terminus-builder.ts
@@ -1,7 +1,7 @@
-import { Terminus } from "../../blueprint/path-blueprint-piece/terminus";
-import { LocatedTerminus } from "../path";
-import { PathBuilder } from "../path-builder";
-import { PathPieceBuilder } from "./path-piece-builder";
+import { Terminus } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/terminus";
+import { LocatedTerminus } from "@/scripts/generate-map-geometry/lib/builder/path";
+import { PathBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-builder";
+import { PathPieceBuilder } from "@/scripts/generate-map-geometry/lib/builder/path-piece-builder/path-piece-builder";
 
 export class TerminusBuilder extends PathPieceBuilder {
   constructor(private readonly _blueprint: Terminus) {

--- a/scripts/generate-map-geometry/lib/builder/path.ts
+++ b/scripts/generate-map-geometry/lib/builder/path.ts
@@ -1,6 +1,6 @@
-import { FlexiPoint } from "../dimensions/flexi-point";
-import { InterchangePoint } from "../blueprint/path-blueprint-piece/station-location";
-import { LineColor } from "../../../../components/map/renderer/utils";
+import { FlexiPoint } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-point";
+import { InterchangePoint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint-piece/station-location";
+import { LineColor } from "@/components/map/renderer/utils";
 
 export class ColoredPathCollection {
   constructor(

--- a/scripts/generate-map-geometry/lib/dimensions/flexi-point.ts
+++ b/scripts/generate-map-geometry/lib/dimensions/flexi-point.ts
@@ -1,6 +1,6 @@
-import { DualPoint } from "../../../../components/map/renderer/dual-point";
-import { FlexiLength } from "./flexi-length";
-import { Point } from "./point";
+import { DualPoint } from "@/components/map/renderer/dual-point";
+import { FlexiLength } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { Point } from "@/scripts/generate-map-geometry/lib/dimensions/point";
 
 // TODO: I kinda hate that this is just a clone of DualPoint, with some extra
 // methods. But the reason it's this way is:

--- a/scripts/generate-map-geometry/lib/utils.ts
+++ b/scripts/generate-map-geometry/lib/utils.ts
@@ -1,5 +1,5 @@
-import { lineWidth } from "../../../components/map/renderer/utils";
-import { flexi } from "./dimensions/flexi-length";
+import { lineWidth } from "@/components/map/renderer/utils";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
 
 export const interchangeEdgeOffset = flexi(lineWidth / 2);
 export const interchangeInnerOffset = flexi(1);

--- a/scripts/generate-map-geometry/ptv/index.ts
+++ b/scripts/generate-map-geometry/ptv/index.ts
@@ -1,13 +1,16 @@
-import { burnley } from "./lines/burnley";
-import { cliftonHill } from "./lines/clifton-hill";
-import { frankston, stonyPoint } from "./lines/frankston-and-stony-point";
-import { dandenong } from "./lines/dandenong";
-import { northern } from "./lines/northern";
-import { regionalWestern } from "./lines/regional-western";
-import { sandringham } from "./lines/sandringham";
-import { newport } from "./lines/newport";
-import { gippsland } from "./lines/gippsland";
-import { GeometryBuilder } from "../lib/builder/geometry-builder";
+import { burnley } from "@/scripts/generate-map-geometry/ptv/lines/burnley";
+import { cliftonHill } from "@/scripts/generate-map-geometry/ptv/lines/clifton-hill";
+import {
+  frankston,
+  stonyPoint,
+} from "@/scripts/generate-map-geometry/ptv/lines/frankston-and-stony-point";
+import { dandenong } from "@/scripts/generate-map-geometry/ptv/lines/dandenong";
+import { northern } from "@/scripts/generate-map-geometry/ptv/lines/northern";
+import { regionalWestern } from "@/scripts/generate-map-geometry/ptv/lines/regional-western";
+import { sandringham } from "@/scripts/generate-map-geometry/ptv/lines/sandringham";
+import { newport } from "@/scripts/generate-map-geometry/ptv/lines/newport";
+import { gippsland } from "@/scripts/generate-map-geometry/ptv/lines/gippsland";
+import { GeometryBuilder } from "@/scripts/generate-map-geometry/lib/builder/geometry-builder";
 
 const geometry = new GeometryBuilder().build([
   gippsland,

--- a/scripts/generate-map-geometry/ptv/interchanges.ts
+++ b/scripts/generate-map-geometry/ptv/interchanges.ts
@@ -33,9 +33,9 @@ import {
   SUNBURY,
   SUNSHINE,
   WATERGARDENS,
-} from "../../../shared/station-ids";
+} from "@/shared/station-ids";
 
-import { InterchangeBlueprint } from "../lib/blueprint/interchange-blueprint";
+import { InterchangeBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/interchange-blueprint";
 
 export const flindersStreet = InterchangeBlueprint.simple(
   FLINDERS_STREET,

--- a/scripts/generate-map-geometry/ptv/lines/burnley.ts
+++ b/scripts/generate-map-geometry/ptv/lines/burnley.ts
@@ -1,6 +1,6 @@
-import { flexi } from "../../lib/dimensions/flexi-length";
-import { LineBlueprint } from "../../lib/blueprint/line-blueprint";
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { LineBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/line-blueprint";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
 import {
   flagstaff,
   flindersStreet,
@@ -10,13 +10,13 @@ import {
   burnley as burnleyInterchange,
   camberwell,
   ringwood,
-} from "../interchanges";
-import { flagstaffToParliament } from "../segments/flagstaff-to-parliament";
-import { flindersStreetToSouthernCross } from "../segments/flinders-street-to-southern-cross";
-import { richmondLoopPortal } from "../segments/richmond-loop-portal";
-import { southernCrossToFlagstaff } from "../segments/southern-cross-to-flagstaff";
-import { defaultRadius } from "../utils";
-import * as loop from "../utils-city-loop";
+} from "@/scripts/generate-map-geometry/ptv/interchanges";
+import { flagstaffToParliament } from "@/scripts/generate-map-geometry/ptv/segments/flagstaff-to-parliament";
+import { flindersStreetToSouthernCross } from "@/scripts/generate-map-geometry/ptv/segments/flinders-street-to-southern-cross";
+import { richmondLoopPortal } from "@/scripts/generate-map-geometry/ptv/segments/richmond-loop-portal";
+import { southernCrossToFlagstaff } from "@/scripts/generate-map-geometry/ptv/segments/southern-cross-to-flagstaff";
+import { defaultRadius } from "@/scripts/generate-map-geometry/ptv/utils";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
 
 const loopPortalStraight = flexi(25);
 const burnleyStraight = flexi(20, 40);

--- a/scripts/generate-map-geometry/ptv/lines/clifton-hill.ts
+++ b/scripts/generate-map-geometry/ptv/lines/clifton-hill.ts
@@ -1,20 +1,23 @@
-import { JOLIMONT } from "../../../../shared/station-ids";
-import { flexi } from "../../lib/dimensions/flexi-length";
-import { LineBlueprint } from "../../lib/blueprint/line-blueprint";
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
+import { JOLIMONT } from "@/shared/station-ids";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { LineBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/line-blueprint";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
 import {
   flagstaff,
   flindersStreet,
   parliament,
   southernCross,
   cliftonHill as cliftonHillInterchange,
-} from "../interchanges";
-import { flagstaffToParliament } from "../segments/flagstaff-to-parliament";
-import { flindersStreetToSouthernCross } from "../segments/flinders-street-to-southern-cross";
-import { jolimontLoopPortal } from "../segments/jolimont-loop-portal";
-import { southernCrossToFlagstaff } from "../segments/southern-cross-to-flagstaff";
-import { defaultRadius, standardDiagonal } from "../utils";
-import * as loop from "../utils-city-loop";
+} from "@/scripts/generate-map-geometry/ptv/interchanges";
+import { flagstaffToParliament } from "@/scripts/generate-map-geometry/ptv/segments/flagstaff-to-parliament";
+import { flindersStreetToSouthernCross } from "@/scripts/generate-map-geometry/ptv/segments/flinders-street-to-southern-cross";
+import { jolimontLoopPortal } from "@/scripts/generate-map-geometry/ptv/segments/jolimont-loop-portal";
+import { southernCrossToFlagstaff } from "@/scripts/generate-map-geometry/ptv/segments/southern-cross-to-flagstaff";
+import {
+  defaultRadius,
+  standardDiagonal,
+} from "@/scripts/generate-map-geometry/ptv/utils";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
 
 const cliftonHillStraight = flexi(40, 80);
 const heidelbergStraight = flexi(40, 80);

--- a/scripts/generate-map-geometry/ptv/lines/dandenong.ts
+++ b/scripts/generate-map-geometry/ptv/lines/dandenong.ts
@@ -1,6 +1,6 @@
-import { flexi } from "../../lib/dimensions/flexi-length";
-import { LineBlueprint } from "../../lib/blueprint/line-blueprint";
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { LineBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/line-blueprint";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
 import {
   caulfield,
   clayton,
@@ -12,13 +12,13 @@ import {
   southYarra,
   dandenong as dandenongInterchange,
   pakenham,
-} from "../interchanges";
-import { flagstaffToParliament } from "../segments/flagstaff-to-parliament";
-import { flindersStreetToSouthernCross } from "../segments/flinders-street-to-southern-cross";
-import { richmondLoopPortal } from "../segments/richmond-loop-portal";
-import { southernCrossToFlagstaff } from "../segments/southern-cross-to-flagstaff";
-import { defaultRadius } from "../utils";
-import * as loop from "../utils-city-loop";
+} from "@/scripts/generate-map-geometry/ptv/interchanges";
+import { flagstaffToParliament } from "@/scripts/generate-map-geometry/ptv/segments/flagstaff-to-parliament";
+import { flindersStreetToSouthernCross } from "@/scripts/generate-map-geometry/ptv/segments/flinders-street-to-southern-cross";
+import { richmondLoopPortal } from "@/scripts/generate-map-geometry/ptv/segments/richmond-loop-portal";
+import { southernCrossToFlagstaff } from "@/scripts/generate-map-geometry/ptv/segments/southern-cross-to-flagstaff";
+import { defaultRadius } from "@/scripts/generate-map-geometry/ptv/utils";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
 import {
   caulfieldToClayton,
   claytonToDandenong,
@@ -28,7 +28,7 @@ import {
   pakenhamToEastPakenham,
   richmondToSouthYarra,
   southYarraToCaulfield,
-} from "../utils-shared-corridors";
+} from "@/scripts/generate-map-geometry/ptv/utils-shared-corridors";
 
 const loopPortalStraight = flexi(20);
 const cranbourneStraight = flexi(30, 45);

--- a/scripts/generate-map-geometry/ptv/lines/frankston-and-stony-point.ts
+++ b/scripts/generate-map-geometry/ptv/lines/frankston-and-stony-point.ts
@@ -1,17 +1,17 @@
-import { flexi } from "../../lib/dimensions/flexi-length";
-import { LineBlueprint } from "../../lib/blueprint/line-blueprint";
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { LineBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/line-blueprint";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
 import {
   caulfield,
   flindersStreet,
   frankston as frankstonInterchange,
   richmond,
   southYarra,
-} from "../interchanges";
+} from "@/scripts/generate-map-geometry/ptv/interchanges";
 import {
   flindersStreetToRichmond,
   richmondPos,
-} from "../segments/flinders-street-to-richmond";
+} from "@/scripts/generate-map-geometry/ptv/segments/flinders-street-to-richmond";
 import {
   defaultRadius,
   diagonal,
@@ -19,12 +19,12 @@ import {
   long45,
   short45,
   standardDiagonal,
-} from "../utils";
-import * as loop from "../utils-city-loop";
+} from "@/scripts/generate-map-geometry/ptv/utils";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
 import {
   richmondToSouthYarra,
   southYarraToCaulfield,
-} from "../utils-shared-corridors";
+} from "@/scripts/generate-map-geometry/ptv/utils-shared-corridors";
 
 const aspendaleStraight = flexi(60, 120);
 const frankstonStraight = flexi(30, 60);

--- a/scripts/generate-map-geometry/ptv/lines/gippsland.ts
+++ b/scripts/generate-map-geometry/ptv/lines/gippsland.ts
@@ -1,7 +1,7 @@
-import { EAST_PAKENHAM } from "../../../../shared/station-ids";
-import { flexi } from "../../lib/dimensions/flexi-length";
-import { LineBlueprint } from "../../lib/blueprint/line-blueprint";
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
+import { EAST_PAKENHAM } from "@/shared/station-ids";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { LineBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/line-blueprint";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
 import {
   caulfield,
   clayton,
@@ -11,11 +11,14 @@ import {
   richmond,
   southernCross,
   southYarra,
-} from "../interchanges";
-import { flindersStreetToRichmond } from "../segments/flinders-street-to-richmond";
-import { flindersStreetToSouthernCross } from "../segments/flinders-street-to-southern-cross";
-import { defaultRadius, standardDiagonal } from "../utils";
-import * as loop from "../utils-city-loop";
+} from "@/scripts/generate-map-geometry/ptv/interchanges";
+import { flindersStreetToRichmond } from "@/scripts/generate-map-geometry/ptv/segments/flinders-street-to-richmond";
+import { flindersStreetToSouthernCross } from "@/scripts/generate-map-geometry/ptv/segments/flinders-street-to-southern-cross";
+import {
+  defaultRadius,
+  standardDiagonal,
+} from "@/scripts/generate-map-geometry/ptv/utils";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
 import {
   caulfieldToClayton,
   claytonToDandenong,
@@ -25,7 +28,7 @@ import {
   pakenhamToEastPakenham,
   richmondToSouthYarra,
   southYarraToCaulfield,
-} from "../utils-shared-corridors";
+} from "@/scripts/generate-map-geometry/ptv/utils-shared-corridors";
 
 const eastPakenhamToCurve = flexi(10, 25);
 const bairnsdaleStraight = flexi(60, 120);

--- a/scripts/generate-map-geometry/ptv/lines/newport.ts
+++ b/scripts/generate-map-geometry/ptv/lines/newport.ts
@@ -1,6 +1,6 @@
-import { LineBlueprint } from "../../lib/blueprint/line-blueprint";
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
-import { flexi } from "../../lib/dimensions/flexi-length";
+import { LineBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/line-blueprint";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
 import {
   flindersStreet,
   southernCross,
@@ -8,12 +8,15 @@ import {
   footscray,
   newport as newportInterchange,
   laverton,
-} from "../interchanges";
-import { flindersStreetToSouthernCross } from "../segments/flinders-street-to-southern-cross";
-import { northMelbourneToFootscray } from "../segments/north-melbourne-to-footscray";
-import { southernCrossToNorthMelbourne } from "../segments/southern-cross-to-north-melbourne";
-import { defaultRadius, diagonal } from "../utils";
-import * as loop from "../utils-city-loop";
+} from "@/scripts/generate-map-geometry/ptv/interchanges";
+import { flindersStreetToSouthernCross } from "@/scripts/generate-map-geometry/ptv/segments/flinders-street-to-southern-cross";
+import { northMelbourneToFootscray } from "@/scripts/generate-map-geometry/ptv/segments/north-melbourne-to-footscray";
+import { southernCrossToNorthMelbourne } from "@/scripts/generate-map-geometry/ptv/segments/southern-cross-to-north-melbourne";
+import {
+  defaultRadius,
+  diagonal,
+} from "@/scripts/generate-map-geometry/ptv/utils";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
 
 const newportStraight = flexi(40, 80);
 const williamstownStraight = flexi(30, 40);

--- a/scripts/generate-map-geometry/ptv/lines/northern.ts
+++ b/scripts/generate-map-geometry/ptv/lines/northern.ts
@@ -1,6 +1,6 @@
-import { flexi } from "../../lib/dimensions/flexi-length";
-import { LineBlueprint } from "../../lib/blueprint/line-blueprint";
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { LineBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/line-blueprint";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
 import {
   broadmeadows,
   craigieburn,
@@ -13,14 +13,14 @@ import {
   sunbury,
   sunshine,
   watergardens,
-} from "../interchanges";
-import { flagstaffToParliament } from "../segments/flagstaff-to-parliament";
-import { flindersStreetToSouthernCross } from "../segments/flinders-street-to-southern-cross";
-import { northMelbourneLoopPortal } from "../segments/north-melbourne-loop-portal";
-import { northMelbourneToFootscray } from "../segments/north-melbourne-to-footscray";
-import { parliamentToFlindersStreet } from "../segments/parliament-to-flinders-street";
-import { defaultRadius } from "../utils";
-import * as loop from "../utils-city-loop";
+} from "@/scripts/generate-map-geometry/ptv/interchanges";
+import { flagstaffToParliament } from "@/scripts/generate-map-geometry/ptv/segments/flagstaff-to-parliament";
+import { flindersStreetToSouthernCross } from "@/scripts/generate-map-geometry/ptv/segments/flinders-street-to-southern-cross";
+import { northMelbourneLoopPortal } from "@/scripts/generate-map-geometry/ptv/segments/north-melbourne-loop-portal";
+import { northMelbourneToFootscray } from "@/scripts/generate-map-geometry/ptv/segments/north-melbourne-to-footscray";
+import { parliamentToFlindersStreet } from "@/scripts/generate-map-geometry/ptv/segments/parliament-to-flinders-street";
+import { defaultRadius } from "@/scripts/generate-map-geometry/ptv/utils";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
 import {
   broadmeadowsStraight,
   craigieburnStraight,
@@ -32,7 +32,7 @@ import {
   sunshineJunctionDiagonal,
   tottenhamStraight,
   watergardensStraight,
-} from "../utils-shared-corridors";
+} from "@/scripts/generate-map-geometry/ptv/utils-shared-corridors";
 
 const upfieldJunctionStraight = flexi(5);
 const macaulayStraight = flexi(10);

--- a/scripts/generate-map-geometry/ptv/lines/regional-western.ts
+++ b/scripts/generate-map-geometry/ptv/lines/regional-western.ts
@@ -1,6 +1,6 @@
-import { flexi } from "../../lib/dimensions/flexi-length";
-import { LineBlueprint } from "../../lib/blueprint/line-blueprint";
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { LineBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/line-blueprint";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
 import {
   ballarat,
   bendigo,
@@ -14,11 +14,14 @@ import {
   sunbury,
   sunshine,
   watergardens,
-} from "../interchanges";
-import { northMelbourneToFootscray } from "../segments/north-melbourne-to-footscray";
-import { southernCrossToNorthMelbourneRegional } from "../segments/southern-cross-to-north-melbourne";
-import { defaultRadius, standardDiagonal } from "../utils";
-import * as loop from "../utils-city-loop";
+} from "@/scripts/generate-map-geometry/ptv/interchanges";
+import { northMelbourneToFootscray } from "@/scripts/generate-map-geometry/ptv/segments/north-melbourne-to-footscray";
+import { southernCrossToNorthMelbourneRegional } from "@/scripts/generate-map-geometry/ptv/segments/southern-cross-to-north-melbourne";
+import {
+  defaultRadius,
+  standardDiagonal,
+} from "@/scripts/generate-map-geometry/ptv/utils";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
 import {
   broadmeadowsStraight,
   craigieburnStraight,
@@ -32,7 +35,7 @@ import {
   sunshineJunctionStraight,
   tottenhamStraight,
   watergardensStraight,
-} from "../utils-shared-corridors";
+} from "@/scripts/generate-map-geometry/ptv/utils-shared-corridors";
 
 const seymourStraight = flexi(50, 100);
 const sheppartonStraight = flexi(75, 150);

--- a/scripts/generate-map-geometry/ptv/lines/sandringham.ts
+++ b/scripts/generate-map-geometry/ptv/lines/sandringham.ts
@@ -1,11 +1,15 @@
-import { flexi } from "../../lib/dimensions/flexi-length";
-import { LineBlueprint } from "../../lib/blueprint/line-blueprint";
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
-import { flindersStreet, richmond, southYarra } from "../interchanges";
-import { flindersStreetToRichmond } from "../segments/flinders-street-to-richmond";
-import { defaultRadius } from "../utils";
-import * as loop from "../utils-city-loop";
-import { richmondToSouthYarra } from "../utils-shared-corridors";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { LineBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/line-blueprint";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
+import {
+  flindersStreet,
+  richmond,
+  southYarra,
+} from "@/scripts/generate-map-geometry/ptv/interchanges";
+import { flindersStreetToRichmond } from "@/scripts/generate-map-geometry/ptv/segments/flinders-street-to-richmond";
+import { defaultRadius } from "@/scripts/generate-map-geometry/ptv/utils";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
+import { richmondToSouthYarra } from "@/scripts/generate-map-geometry/ptv/utils-shared-corridors";
 
 const divergeStraight = flexi(10);
 const diagonalStraight = flexi(10, 20);

--- a/scripts/generate-map-geometry/ptv/segments/flagstaff-to-parliament.ts
+++ b/scripts/generate-map-geometry/ptv/segments/flagstaff-to-parliament.ts
@@ -1,6 +1,6 @@
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
-import { melbourneCentral } from "../interchanges";
-import * as loop from "../utils-city-loop";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
+import { melbourneCentral } from "@/scripts/generate-map-geometry/ptv/interchanges";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
 
 /** Underground city loop section from Flagstaff to Parliament. */
 export function flagstaffToParliament(

--- a/scripts/generate-map-geometry/ptv/segments/flinders-street-to-richmond.ts
+++ b/scripts/generate-map-geometry/ptv/segments/flinders-street-to-richmond.ts
@@ -1,8 +1,13 @@
-import { flexi } from "../../lib/dimensions/flexi-length";
-import { FlexiPoint } from "../../lib/dimensions/flexi-point";
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
-import { diagonal, lineGap, long45, short45 } from "../utils";
-import * as loop from "../utils-city-loop";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { FlexiPoint } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-point";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
+import {
+  diagonal,
+  lineGap,
+  long45,
+  short45,
+} from "@/scripts/generate-map-geometry/ptv/utils";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
 
 const innerRadius = flexi(15);
 const flindersStreetStraight = flexi(40);

--- a/scripts/generate-map-geometry/ptv/segments/flinders-street-to-southern-cross.ts
+++ b/scripts/generate-map-geometry/ptv/segments/flinders-street-to-southern-cross.ts
@@ -1,6 +1,10 @@
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
-import { lineGap, long45, short45 } from "../utils";
-import * as loop from "../utils-city-loop";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
+import {
+  lineGap,
+  long45,
+  short45,
+} from "@/scripts/generate-map-geometry/ptv/utils";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
 
 /** South-west corner of the city loop from Flinders Street to Southern Cross. */
 export function flindersStreetToSouthernCross(

--- a/scripts/generate-map-geometry/ptv/segments/jolimont-loop-portal.ts
+++ b/scripts/generate-map-geometry/ptv/segments/jolimont-loop-portal.ts
@@ -1,7 +1,7 @@
-import { flexi } from "../../lib/dimensions/flexi-length";
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
-import { flindersStreet } from "../interchanges";
-import * as loop from "../utils-city-loop";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
+import { flindersStreet } from "@/scripts/generate-map-geometry/ptv/interchanges";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
 
 const radiusReduction = flexi(5);
 

--- a/scripts/generate-map-geometry/ptv/segments/north-melbourne-loop-portal.ts
+++ b/scripts/generate-map-geometry/ptv/segments/north-melbourne-loop-portal.ts
@@ -1,11 +1,11 @@
-import { flexi } from "../../lib/dimensions/flexi-length";
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
 import {
   measure45CurveLockedRadius,
   measure45CurveLockedStraight,
-} from "../utils";
-import * as loop from "../utils-city-loop";
-import * as direct from "./southern-cross-to-north-melbourne";
+} from "@/scripts/generate-map-geometry/ptv/utils";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
+import * as direct from "@/scripts/generate-map-geometry/ptv/segments/southern-cross-to-north-melbourne";
 
 const directRadius = flexi(20);
 

--- a/scripts/generate-map-geometry/ptv/segments/north-melbourne-to-footscray.ts
+++ b/scripts/generate-map-geometry/ptv/segments/north-melbourne-to-footscray.ts
@@ -1,6 +1,6 @@
-import { flexi } from "../../lib/dimensions/flexi-length";
-import { FlexiPoint } from "../../lib/dimensions/flexi-point";
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { FlexiPoint } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-point";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
 import {
   defaultRadius,
   diagonal,
@@ -8,8 +8,8 @@ import {
   long45,
   measure45CurveLockedDiagonal,
   short45,
-} from "../utils";
-import { northMelbournePos as northMelbournePosFunc } from "./southern-cross-to-north-melbourne";
+} from "@/scripts/generate-map-geometry/ptv/utils";
+import { northMelbournePos as northMelbournePosFunc } from "@/scripts/generate-map-geometry/ptv/segments/southern-cross-to-north-melbourne";
 
 const northMelbourneStraight = flexi(10);
 const northMelbourneStraightSunbury = flexi(5);

--- a/scripts/generate-map-geometry/ptv/segments/parliament-to-flinders-street.ts
+++ b/scripts/generate-map-geometry/ptv/segments/parliament-to-flinders-street.ts
@@ -1,6 +1,6 @@
-import { flexi } from "../../lib/dimensions/flexi-length";
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
-import * as loop from "../utils-city-loop";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
 
 const radiusReduction = flexi(5);
 

--- a/scripts/generate-map-geometry/ptv/segments/richmond-loop-portal.ts
+++ b/scripts/generate-map-geometry/ptv/segments/richmond-loop-portal.ts
@@ -1,9 +1,9 @@
-import { FlexiLength } from "../../lib/dimensions/flexi-length";
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
-import { flindersStreet } from "../interchanges";
-import { measure45CurveLockedDiagonal } from "../utils";
-import * as loop from "../utils-city-loop";
-import * as direct from "./flinders-street-to-richmond";
+import { FlexiLength } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
+import { flindersStreet } from "@/scripts/generate-map-geometry/ptv/interchanges";
+import { measure45CurveLockedDiagonal } from "@/scripts/generate-map-geometry/ptv/utils";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
+import * as direct from "@/scripts/generate-map-geometry/ptv/segments/flinders-street-to-richmond";
 
 /** The curve from Parliament to Richmond, and the split back to Flinders Street. */
 export function richmondLoopPortal(

--- a/scripts/generate-map-geometry/ptv/segments/southern-cross-to-flagstaff.ts
+++ b/scripts/generate-map-geometry/ptv/segments/southern-cross-to-flagstaff.ts
@@ -1,5 +1,5 @@
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
-import * as loop from "../utils-city-loop";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
 
 /** North-west corner of the city loop from Southern Cross to Flagstaff. */
 export function southernCrossToFlagstaff(

--- a/scripts/generate-map-geometry/ptv/segments/southern-cross-to-north-melbourne.ts
+++ b/scripts/generate-map-geometry/ptv/segments/southern-cross-to-north-melbourne.ts
@@ -1,8 +1,13 @@
-import { flexi } from "../../lib/dimensions/flexi-length";
-import { FlexiPoint } from "../../lib/dimensions/flexi-point";
-import { PathBlueprint } from "../../lib/blueprint/path-blueprint";
-import { diagonal, lineGap, long45, short45 } from "../utils";
-import * as loop from "../utils-city-loop";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { FlexiPoint } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-point";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
+import {
+  diagonal,
+  lineGap,
+  long45,
+  short45,
+} from "@/scripts/generate-map-geometry/ptv/utils";
+import * as loop from "@/scripts/generate-map-geometry/ptv/utils-city-loop";
 
 const innerRadius = flexi(15);
 const southernCrossStraight = flexi(30);

--- a/scripts/generate-map-geometry/ptv/utils-city-loop.ts
+++ b/scripts/generate-map-geometry/ptv/utils-city-loop.ts
@@ -1,6 +1,6 @@
-import { flexi } from "../lib/dimensions/flexi-length";
-import { fp } from "../lib/dimensions/flexi-point";
-import { lineGap } from "./utils";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { fp } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-point";
+import { lineGap } from "@/scripts/generate-map-geometry/ptv/utils";
 
 const innerRadius = flexi(15);
 

--- a/scripts/generate-map-geometry/ptv/utils-shared-corridors.ts
+++ b/scripts/generate-map-geometry/ptv/utils-shared-corridors.ts
@@ -1,6 +1,12 @@
-import { flexi } from "../lib/dimensions/flexi-length";
-import { interchangeEdgeOffset } from "../lib/utils";
-import { defaultRadius, diagonal, lineGap, long45, short45 } from "./utils";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { interchangeEdgeOffset } from "@/scripts/generate-map-geometry/lib/utils";
+import {
+  defaultRadius,
+  diagonal,
+  lineGap,
+  long45,
+  short45,
+} from "@/scripts/generate-map-geometry/ptv/utils";
 
 export const richmondToSouthYarra = flexi(20, 20);
 export const southYarraToCaulfield = flexi(30, 60);

--- a/scripts/generate-map-geometry/ptv/utils.ts
+++ b/scripts/generate-map-geometry/ptv/utils.ts
@@ -1,4 +1,7 @@
-import { flexi, FlexiLength } from "../lib/dimensions/flexi-length";
+import {
+  flexi,
+  FlexiLength,
+} from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
 
 export const lineGap = flexi(5);
 export const long45 = Math.cos(Math.PI / 4);

--- a/server/app.ts
+++ b/server/app.ts
@@ -3,7 +3,7 @@ import { LineCollection } from "./data/static/line-collection";
 import { StationCollection } from "./data/static/station-collection";
 import { Database } from "./database/lib/general/database";
 import { Crayon } from "./database/models/crayons";
-import { CRAYONS, HISTORICAL_ALERTS } from "./database/models/models";
+import { CRAYONS, HISTORICAL_ALERTS } from "@/server/database/models/models";
 import { DisruptionSource } from "./disruption-source/disruption-source";
 import { InMemoryDatabase } from "./database/lib/in-memory/in-memory-database";
 import { FakeDisruptionSource } from "./disruption-source/fake-disruption-source";

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,14 +1,14 @@
 import { uuid } from "@dan-schel/js-utils";
-import { LineCollection } from "./data/static/line-collection";
-import { StationCollection } from "./data/static/station-collection";
-import { Database } from "./database/lib/general/database";
-import { Crayon } from "./database/models/crayons";
+import { LineCollection } from "@/server/data/static/line-collection";
+import { StationCollection } from "@/server/data/static/station-collection";
+import { Database } from "@/server/database/lib/general/database";
+import { Crayon } from "@/server/database/models/crayons";
 import { CRAYONS, HISTORICAL_ALERTS } from "@/server/database/models/models";
-import { DisruptionSource } from "./disruption-source/disruption-source";
-import { InMemoryDatabase } from "./database/lib/in-memory/in-memory-database";
-import { FakeDisruptionSource } from "./disruption-source/fake-disruption-source";
-import { HistoricalAlert } from "./data/historical-alert";
-import { migrations } from "./database/migrations/migrations";
+import { DisruptionSource } from "@/server/disruption-source/disruption-source";
+import { InMemoryDatabase } from "@/server/database/lib/in-memory/in-memory-database";
+import { FakeDisruptionSource } from "@/server/disruption-source/fake-disruption-source";
+import { HistoricalAlert } from "@/server/data/historical-alert";
+import { migrations } from "@/server/database/migrations/migrations";
 
 export class App {
   constructor(

--- a/server/data/disruption/data/custom-disruption-data.ts
+++ b/server/data/disruption/data/custom-disruption-data.ts
@@ -1,15 +1,15 @@
 import { z } from "zod";
-import { DisruptionDataBase } from "./disruption-data-base";
-import { DisruptionWriteup } from "../writeup/disruption-writeup";
-import { DisruptionWriteupAuthor } from "../writeup/disruption-writeup-author";
-import { CustomDisruptionWriteupAuthor } from "../writeup/custom-disruption-writeup-author";
-import { RouteGraphTrainEdge } from "../../route-graph/edge/route-graph-train-edge";
+import { DisruptionDataBase } from "@/server/data/disruption/data/disruption-data-base";
+import { DisruptionWriteup } from "@/server/data/disruption/writeup/disruption-writeup";
+import { DisruptionWriteupAuthor } from "@/server/data/disruption/writeup/disruption-writeup-author";
+import { CustomDisruptionWriteupAuthor } from "@/server/data/disruption/writeup/custom-disruption-writeup-author";
+import { RouteGraphTrainEdge } from "@/server/data/route-graph/edge/route-graph-train-edge";
 import {
   RouteGraphEdge,
   routeGraphEdgeBson,
-} from "../../route-graph/edge/route-graph-edge";
-import { RouteGraphModifier } from "../route-graph-modifier/route-graph-modifier";
-import { SimpleRouteGraphModifier } from "../route-graph-modifier/simple-route-graph-modifier";
+} from "@/server/data/route-graph/edge/route-graph-edge";
+import { RouteGraphModifier } from "@/server/data/disruption/route-graph-modifier/route-graph-modifier";
+import { SimpleRouteGraphModifier } from "@/server/data/disruption/route-graph-modifier/simple-route-graph-modifier";
 
 /**
  * Used in edge cases where the normal disruption types we have don't cut it.

--- a/server/data/disruption/data/disruption-data-base.ts
+++ b/server/data/disruption/data/disruption-data-base.ts
@@ -1,5 +1,5 @@
-import { RouteGraphModifier } from "../route-graph-modifier/route-graph-modifier";
-import { DisruptionWriteupAuthor } from "../writeup/disruption-writeup-author";
+import { RouteGraphModifier } from "@/server/data/disruption/route-graph-modifier/route-graph-modifier";
+import { DisruptionWriteupAuthor } from "@/server/data/disruption/writeup/disruption-writeup-author";
 
 /** Stores the data inherent to this particular type of disruption. */
 export abstract class DisruptionDataBase {

--- a/server/data/disruption/data/disruption-data.ts
+++ b/server/data/disruption/data/disruption-data.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { StationClosureDisruptionData } from "./station-closure-disruption-data";
-import { CustomDisruptionData } from "./custom-disruption-data";
+import { StationClosureDisruptionData } from "@/server/data/disruption/data/station-closure-disruption-data";
+import { CustomDisruptionData } from "@/server/data/disruption/data/custom-disruption-data";
 
 /**
  * Stores the data inherent to this particular type of disruption.

--- a/server/data/disruption/data/station-closure-disruption-data.ts
+++ b/server/data/disruption/data/station-closure-disruption-data.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
-import { DisruptionDataBase } from "./disruption-data-base";
-import { DisruptionWriteupAuthor } from "../writeup/disruption-writeup-author";
-import { StationClosureDisruptionWriteupAuthor } from "../writeup/station-closure-disruption-writeup-author";
-import { RouteGraphModifier } from "../route-graph-modifier/route-graph-modifier";
-import { StationClosureRouteGraphModifier } from "../route-graph-modifier/station-closure-route-graph-modifier";
+import { DisruptionDataBase } from "@/server/data/disruption/data/disruption-data-base";
+import { DisruptionWriteupAuthor } from "@/server/data/disruption/writeup/disruption-writeup-author";
+import { StationClosureDisruptionWriteupAuthor } from "@/server/data/disruption/writeup/station-closure-disruption-writeup-author";
+import { RouteGraphModifier } from "@/server/data/disruption/route-graph-modifier/route-graph-modifier";
+import { StationClosureRouteGraphModifier } from "@/server/data/disruption/route-graph-modifier/station-closure-route-graph-modifier";
 
 /**
  * A single station is closed. (Trains may be continuing to run express through

--- a/server/data/disruption/disruption.ts
+++ b/server/data/disruption/disruption.ts
@@ -1,5 +1,5 @@
-import { DisruptionPeriod } from "./period/disruption-period";
-import { DisruptionData } from "./data/disruption-data";
+import { DisruptionPeriod } from "@/server/data/disruption/period/disruption-period";
+import { DisruptionData } from "@/server/data/disruption/data/disruption-data";
 
 /**
  * Represents a curated disruption, ready for display on the site. Not to be

--- a/server/data/disruption/period/custom-disruption-period.ts
+++ b/server/data/disruption/period/custom-disruption-period.ts
@@ -3,10 +3,10 @@ import {
   CalendarMark,
   DisplayStringOptions,
   DisruptionPeriodBase,
-} from "./disruption-period-base";
-import { TimeRange } from "./utils/time-range";
-import { DisruptedCalendarDay } from "./utils/disrupted-calendar-day";
-import { JustDate } from "./utils/just-date";
+} from "@/server/data/disruption/period/disruption-period-base";
+import { TimeRange } from "@/server/data/disruption/period/utils/time-range";
+import { DisruptedCalendarDay } from "@/server/data/disruption/period/utils/disrupted-calendar-day";
+import { JustDate } from "@/server/data/disruption/period/utils/just-date";
 
 /**
  * Allows complete customisation of active time ranges, calendar marks, and the

--- a/server/data/disruption/period/disruption-period-base.ts
+++ b/server/data/disruption/period/disruption-period-base.ts
@@ -1,5 +1,5 @@
-import { JustDate } from "./utils/just-date";
-import { TimeRange } from "./utils/time-range";
+import { JustDate } from "@/server/data/disruption/period/utils/just-date";
+import { TimeRange } from "@/server/data/disruption/period/utils/time-range";
 
 export type DisplayStringOptions = {
   now: Date;

--- a/server/data/disruption/period/disruption-period.ts
+++ b/server/data/disruption/period/disruption-period.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { EveningsOnlyDisruptionPeriod } from "./evenings-only-disruption-period";
-import { StandardDisruptionPeriod } from "./standard-disruption-period";
-import { CustomDisruptionPeriod } from "./custom-disruption-period";
+import { EveningsOnlyDisruptionPeriod } from "@/server/data/disruption/period/evenings-only-disruption-period";
+import { StandardDisruptionPeriod } from "@/server/data/disruption/period/standard-disruption-period";
+import { CustomDisruptionPeriod } from "@/server/data/disruption/period/custom-disruption-period";
 
 /**
  * Defines the period(s) of time a disruption is active.

--- a/server/data/disruption/period/ends/ends-after-last-service.ts
+++ b/server/data/disruption/period/ends/ends-after-last-service.ts
@@ -1,8 +1,15 @@
 import { z } from "zod";
-import { DisplayStringOptions, EndsBase } from "./ends-base";
+import {
+  DisplayStringOptions,
+  EndsBase,
+} from "@/server/data/disruption/period/ends/ends-base";
 import { addHours } from "date-fns";
-import { dayStarts, formatDate, localToUtcTime } from "../utils/utils";
-import { JustDate } from "../utils/just-date";
+import {
+  dayStarts,
+  formatDate,
+  localToUtcTime,
+} from "@/server/data/disruption/period/utils/utils";
+import { JustDate } from "@/server/data/disruption/period/utils/just-date";
 
 /** The disruption ends after the last service on a given date. */
 export class EndsAfterLastService extends EndsBase {

--- a/server/data/disruption/period/ends/ends-approximately.ts
+++ b/server/data/disruption/period/ends/ends-approximately.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { DisplayStringOptions, EndsBase } from "./ends-base";
+import {
+  DisplayStringOptions,
+  EndsBase,
+} from "@/server/data/disruption/period/ends/ends-base";
 
 /** The disruption ends sometime between two implied dates, e.g. "late March". */
 export class EndsApproximately extends EndsBase {

--- a/server/data/disruption/period/ends/ends-exactly.ts
+++ b/server/data/disruption/period/ends/ends-exactly.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
-import { DisplayStringOptions, EndsBase } from "./ends-base";
-import { formatDate } from "../utils/utils";
+import {
+  DisplayStringOptions,
+  EndsBase,
+} from "@/server/data/disruption/period/ends/ends-base";
+import { formatDate } from "@/server/data/disruption/period/utils/utils";
 
 /** The disruption ends after an exact timestamp. */
 export class EndsExactly extends EndsBase {

--- a/server/data/disruption/period/ends/ends-never.ts
+++ b/server/data/disruption/period/ends/ends-never.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { DisplayStringOptions, EndsBase } from "./ends-base";
+import {
+  DisplayStringOptions,
+  EndsBase,
+} from "@/server/data/disruption/period/ends/ends-base";
 
 /** The disruption has no known end date. */
 export class EndsNever extends EndsBase {

--- a/server/data/disruption/period/ends/ends-when-alert-ends.ts
+++ b/server/data/disruption/period/ends/ends-when-alert-ends.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
-import { DisplayStringOptions, EndsBase } from "./ends-base";
-import { formatDate } from "../utils/utils";
+import {
+  DisplayStringOptions,
+  EndsBase,
+} from "@/server/data/disruption/period/ends/ends-base";
+import { formatDate } from "@/server/data/disruption/period/utils/utils";
 
 /** The disruption ends when the source alert ends. */
 export class EndsWhenAlertEnds extends EndsBase {

--- a/server/data/disruption/period/ends/ends.ts
+++ b/server/data/disruption/period/ends/ends.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
-import { EndsAfterLastService } from "./ends-after-last-service";
-import { EndsApproximately } from "./ends-approximately";
-import { EndsExactly } from "./ends-exactly";
-import { EndsNever } from "./ends-never";
-import { EndsWhenAlertEnds } from "./ends-when-alert-ends";
+import { EndsAfterLastService } from "@/server/data/disruption/period/ends/ends-after-last-service";
+import { EndsApproximately } from "@/server/data/disruption/period/ends/ends-approximately";
+import { EndsExactly } from "@/server/data/disruption/period/ends/ends-exactly";
+import { EndsNever } from "@/server/data/disruption/period/ends/ends-never";
+import { EndsWhenAlertEnds } from "@/server/data/disruption/period/ends/ends-when-alert-ends";
 
 /**
  * Defines how/when the disruption ends.

--- a/server/data/disruption/period/evenings-only-disruption-period.ts
+++ b/server/data/disruption/period/evenings-only-disruption-period.ts
@@ -3,17 +3,17 @@ import {
   CalendarMark,
   DisplayStringOptions,
   DisruptionPeriodBase,
-} from "./disruption-period-base";
-import { Ends, endsBson } from "./ends/ends";
+} from "@/server/data/disruption/period/disruption-period-base";
+import { Ends, endsBson } from "@/server/data/disruption/period/ends/ends";
 import {
   dayStarts,
   eveningStarts,
   formatDate,
   localToUtcTime,
   utcToLocalTime,
-} from "./utils/utils";
-import { TimeRange } from "./utils/time-range";
-import { JustDate } from "./utils/just-date";
+} from "@/server/data/disruption/period/utils/utils";
+import { TimeRange } from "@/server/data/disruption/period/utils/time-range";
+import { JustDate } from "@/server/data/disruption/period/utils/just-date";
 import { addHours, isSameDay, setHours, startOfHour } from "date-fns";
 import { hour24To12 } from "@dan-schel/js-utils";
 

--- a/server/data/disruption/period/standard-disruption-period.ts
+++ b/server/data/disruption/period/standard-disruption-period.ts
@@ -1,18 +1,18 @@
 import { z } from "zod";
-import { Ends, endsBson } from "./ends/ends";
-import { TimeRange } from "./utils/time-range";
+import { Ends, endsBson } from "@/server/data/disruption/period/ends/ends";
+import { TimeRange } from "@/server/data/disruption/period/utils/time-range";
 import {
   CalendarMark,
   DisplayStringOptions,
   DisruptionPeriodBase,
-} from "./disruption-period-base";
+} from "@/server/data/disruption/period/disruption-period-base";
 import {
   dayStarts,
   eveningStarts,
   formatDate,
   localToUtcTime,
-} from "./utils/utils";
-import { JustDate } from "./utils/just-date";
+} from "@/server/data/disruption/period/utils/utils";
+import { JustDate } from "@/server/data/disruption/period/utils/just-date";
 import { addHours } from "date-fns";
 
 /** Disruption is active continuously from the start date to the end date. */

--- a/server/data/disruption/period/utils/disrupted-calendar-day.ts
+++ b/server/data/disruption/period/utils/disrupted-calendar-day.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { JustDate } from "./just-date";
+import { JustDate } from "@/server/data/disruption/period/utils/just-date";
 
 export class DisruptedCalendarDay {
   constructor(

--- a/server/data/disruption/route-graph-modifier/route-graph-modifier.ts
+++ b/server/data/disruption/route-graph-modifier/route-graph-modifier.ts
@@ -1,4 +1,4 @@
-import { RouteGraph } from "../../route-graph/route-graph";
+import { RouteGraph } from "@/server/data/route-graph/route-graph";
 
 /** Knows how to modify the route graph on behalf of a certain disruption. */
 export abstract class RouteGraphModifier {

--- a/server/data/disruption/route-graph-modifier/simple-route-graph-modifier.ts
+++ b/server/data/disruption/route-graph-modifier/simple-route-graph-modifier.ts
@@ -1,7 +1,7 @@
-import { RouteGraphEdge } from "../../route-graph/edge/route-graph-edge";
-import { RouteGraphTrainEdge } from "../../route-graph/edge/route-graph-train-edge";
-import { RouteGraph } from "../../route-graph/route-graph";
-import { RouteGraphModifier } from "./route-graph-modifier";
+import { RouteGraphEdge } from "@/server/data/route-graph/edge/route-graph-edge";
+import { RouteGraphTrainEdge } from "@/server/data/route-graph/edge/route-graph-train-edge";
+import { RouteGraph } from "@/server/data/route-graph/route-graph";
+import { RouteGraphModifier } from "@/server/data/disruption/route-graph-modifier/route-graph-modifier";
 
 /** Accepts a list of edges to remove and a list of edges to add. */
 export class SimpleRouteGraphModifier extends RouteGraphModifier {

--- a/server/data/disruption/route-graph-modifier/station-closure-route-graph-modifier.ts
+++ b/server/data/disruption/route-graph-modifier/station-closure-route-graph-modifier.ts
@@ -1,5 +1,5 @@
-import { RouteGraph } from "../../route-graph/route-graph";
-import { RouteGraphModifier } from "./route-graph-modifier";
+import { RouteGraph } from "@/server/data/route-graph/route-graph";
+import { RouteGraphModifier } from "@/server/data/disruption/route-graph-modifier/route-graph-modifier";
 
 /**
  * Modifies the route graph for a station closure (disconnects train edges from

--- a/server/data/disruption/writeup/custom-disruption-writeup-author.ts
+++ b/server/data/disruption/writeup/custom-disruption-writeup-author.ts
@@ -1,7 +1,7 @@
-import { CustomDisruptionData } from "../data/custom-disruption-data";
-import { Disruption } from "../disruption";
-import { DisruptionWriteup } from "./disruption-writeup";
-import { DisruptionWriteupAuthor } from "./disruption-writeup-author";
+import { CustomDisruptionData } from "@/server/data/disruption/data/custom-disruption-data";
+import { Disruption } from "@/server/data/disruption/disruption";
+import { DisruptionWriteup } from "@/server/data/disruption/writeup/disruption-writeup";
+import { DisruptionWriteupAuthor } from "@/server/data/disruption/writeup/disruption-writeup-author";
 
 /** DisruptionWriteupAuther for CustomDisruptionData. */
 export class CustomDisruptionWriteupAuthor extends DisruptionWriteupAuthor {

--- a/server/data/disruption/writeup/disruption-writeup-author.ts
+++ b/server/data/disruption/writeup/disruption-writeup-author.ts
@@ -1,5 +1,5 @@
-import { Disruption } from "../disruption";
-import { DisruptionWriteup } from "./disruption-writeup";
+import { Disruption } from "@/server/data/disruption/disruption";
+import { DisruptionWriteup } from "@/server/data/disruption/writeup/disruption-writeup";
 
 /**
  * Knows how to create a writeup for a particular disruption data type, despite

--- a/server/data/disruption/writeup/station-closure-disruption-writeup-author.ts
+++ b/server/data/disruption/writeup/station-closure-disruption-writeup-author.ts
@@ -1,8 +1,8 @@
-import { stations } from "../../static/stations";
-import { StationClosureDisruptionData } from "../data/station-closure-disruption-data";
-import { Disruption } from "../disruption";
-import { DisruptionWriteup } from "./disruption-writeup";
-import { DisruptionWriteupAuthor } from "./disruption-writeup-author";
+import { stations } from "@/server/data/static/stations";
+import { StationClosureDisruptionData } from "@/server/data/disruption/data/station-closure-disruption-data";
+import { Disruption } from "@/server/data/disruption/disruption";
+import { DisruptionWriteup } from "@/server/data/disruption/writeup/disruption-writeup";
+import { DisruptionWriteupAuthor } from "@/server/data/disruption/writeup/disruption-writeup-author";
 
 /** DisruptionWriteupAuther for StationClosureDisruptionData. */
 export class StationClosureDisruptionWriteupAuthor extends DisruptionWriteupAuthor {

--- a/server/data/line-section.ts
+++ b/server/data/line-section.ts
@@ -1,4 +1,4 @@
-import { LineShapeNode } from "./static/line-routes/line-shape";
+import { LineShapeNode } from "@/server/data/static/line-routes/line-shape";
 
 /**
  * Represents a series of stations on a particular line, e.g. "East Pakenham to

--- a/server/data/route-graph/edge/route-graph-alternative-edge.ts
+++ b/server/data/route-graph/edge/route-graph-alternative-edge.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { RouteGraphEdgeBase } from "./route-graph-edge-base";
+import { RouteGraphEdgeBase } from "@/server/data/route-graph/edge/route-graph-edge-base";
 
 export type RouteGraphAlternativeEdgeMode = "bus" | "tram" | "walk";
 

--- a/server/data/route-graph/edge/route-graph-edge.ts
+++ b/server/data/route-graph/edge/route-graph-edge.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { RouteGraphAlternativeEdge } from "./route-graph-alternative-edge";
-import { RouteGraphTrainEdge } from "./route-graph-train-edge";
+import { RouteGraphAlternativeEdge } from "@/server/data/route-graph/edge/route-graph-alternative-edge";
+import { RouteGraphTrainEdge } from "@/server/data/route-graph/edge/route-graph-train-edge";
 
 /**
  * Defines an edge connecting to stations in the route graph.

--- a/server/data/route-graph/edge/route-graph-train-edge.ts
+++ b/server/data/route-graph/edge/route-graph-train-edge.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { RouteGraphEdgeBase } from "./route-graph-edge-base";
+import { RouteGraphEdgeBase } from "@/server/data/route-graph/edge/route-graph-edge-base";
 
 /** A path between two stations achievable by train. */
 export class RouteGraphTrainEdge extends RouteGraphEdgeBase {

--- a/server/data/static/line-collection.ts
+++ b/server/data/static/line-collection.ts
@@ -1,5 +1,5 @@
-import { Collection } from "../utils/collection";
-import { Line } from "./line";
+import { Collection } from "@/server/data/utils/collection";
+import { Line } from "@/server/data/static/line";
 
 export class LineCollection extends Collection<number, Line> {
   private _ptvMap: Map<number, Line>;

--- a/server/data/static/line-routes/line-route.ts
+++ b/server/data/static/line-routes/line-route.ts
@@ -1,6 +1,6 @@
-import { LineSection } from "../../line-section";
-import { StationPair } from "./station-pair";
-import { LineShape } from "./line-shape";
+import { LineSection } from "@/server/data/line-section";
+import { StationPair } from "@/server/data/static/line-routes/station-pair";
+import { LineShape } from "@/server/data/static/line-routes/line-shape";
 
 /**
  * Knows deeply about the stations this line serves, and in which manner. It's

--- a/server/data/static/line-routes/line-routes-utils.ts
+++ b/server/data/static/line-routes/line-routes-utils.ts
@@ -1,7 +1,10 @@
-import { LineRoute } from "./line-route";
-import * as station from "../../../../shared/station-ids";
-import { LineShape, LineShapeEdge } from "./line-shape";
-import { StationPair } from "./station-pair";
+import { LineRoute } from "@/server/data/static/line-routes/line-route";
+import * as station from "@/shared/station-ids";
+import {
+  LineShape,
+  LineShapeEdge,
+} from "@/server/data/static/line-routes/line-shape";
+import { StationPair } from "@/server/data/static/line-routes/station-pair";
 import { itsOk } from "@dan-schel/js-utils";
 
 const directWestern = [station.FLINDERS_STREET, station.SOUTHERN_CROSS];

--- a/server/data/static/line-routes/line-routes.ts
+++ b/server/data/static/line-routes/line-routes.ts
@@ -1,11 +1,11 @@
-import * as station from "../../../../shared/station-ids";
+import * as station from "@/shared/station-ids";
 import {
   loop,
   simple,
   dualPath,
   regionalSimple,
   regionalBranch,
-} from "./line-routes-utils";
+} from "@/server/data/static/line-routes/line-routes-utils";
 
 export const SANDRINGHAM = simple([
   station.FLINDERS_STREET,

--- a/server/data/static/line-routes/line-shape.ts
+++ b/server/data/static/line-routes/line-shape.ts
@@ -1,6 +1,6 @@
 import { unique } from "@dan-schel/js-utils";
-import { StationPair } from "./station-pair";
-import { Edge, Tree } from "./tree";
+import { StationPair } from "@/server/data/static/line-routes/station-pair";
+import { Edge, Tree } from "@/server/data/static/line-routes/tree";
 
 export type LineShapeNode = number | "the-city";
 

--- a/server/data/static/line.ts
+++ b/server/data/static/line.ts
@@ -1,4 +1,4 @@
-import { LineRoute } from "./line-routes/line-route";
+import { LineRoute } from "@/server/data/static/line-routes/line-route";
 
 type LineGroup = "suburban" | "regional";
 

--- a/server/data/static/lines.ts
+++ b/server/data/static/lines.ts
@@ -1,7 +1,7 @@
-import { Line } from "./line";
-import { LineCollection } from "./line-collection";
-import * as line from "../../../shared/line-ids";
-import * as route from "./line-routes/line-routes";
+import { Line } from "@/server/data/static/line";
+import { LineCollection } from "@/server/data/static/line-collection";
+import * as line from "@/shared/line-ids";
+import * as route from "@/server/data/static/line-routes/line-routes";
 
 const data = [
   new Line({

--- a/server/data/static/station-collection.ts
+++ b/server/data/static/station-collection.ts
@@ -1,5 +1,5 @@
-import { Collection } from "../utils/collection";
-import { Station } from "./station";
+import { Collection } from "@/server/data/utils/collection";
+import { Station } from "@/server/data/static/station";
 
 export class StationCollection extends Collection<number, Station> {
   private _ptvMap: Map<number, Station>;

--- a/server/data/static/stations.ts
+++ b/server/data/static/stations.ts
@@ -1,6 +1,6 @@
-import { Station } from "./station";
-import { StationCollection } from "./station-collection";
-import * as station from "../../../shared/station-ids";
+import { Station } from "@/server/data/static/station";
+import { StationCollection } from "@/server/data/static/station-collection";
+import * as station from "@/shared/station-ids";
 
 const data = [
   new Station({ id: station.AIRCRAFT, name: "Aircraft", ptvIds: [1220] }),

--- a/server/database/init-database.ts
+++ b/server/database/init-database.ts
@@ -1,7 +1,7 @@
-import { env } from "../env";
-import { Database } from "./lib/general/database";
-import { InMemoryDatabase } from "./lib/in-memory/in-memory-database";
-import { MongoDatabase } from "./lib/mongo/mongo-database";
+import { env } from "@/server/env";
+import { Database } from "@/server/database/lib/general/database";
+import { InMemoryDatabase } from "@/server/database/lib/in-memory/in-memory-database";
+import { MongoDatabase } from "@/server/database/lib/mongo/mongo-database";
 
 /**
  * Ideally returns a MongoDatabase, but falls back to an InMemoryDatabase if

--- a/server/database/lib/general/database-model.ts
+++ b/server/database/lib/general/database-model.ts
@@ -1,4 +1,4 @@
-import { SerializedObject } from "./serialized-types";
+import { SerializedObject } from "@/server/database/lib/general/serialized-types";
 
 /** Typescript magic to extract the Id type used by a DatabaseModel. */
 export type IdOf<T extends DatabaseModel> =

--- a/server/database/lib/general/database.ts
+++ b/server/database/lib/general/database.ts
@@ -1,6 +1,14 @@
-import { DatabaseModel, DataOf, IdOf } from "./database-model";
-import { Migration, Migrator } from "./migration";
-import { CountQuery, FindQuery, FirstQuery } from "./query-types";
+import {
+  DatabaseModel,
+  DataOf,
+  IdOf,
+} from "@/server/database/lib/general/database-model";
+import { Migration, Migrator } from "@/server/database/lib/general/migration";
+import {
+  CountQuery,
+  FindQuery,
+  FirstQuery,
+} from "@/server/database/lib/general/query-types";
 
 export abstract class Database {
   abstract of<Model extends DatabaseModel>(model: Model): Repository<Model>;

--- a/server/database/lib/general/migration-command-types.ts
+++ b/server/database/lib/general/migration-command-types.ts
@@ -1,6 +1,9 @@
-import { DatabaseModel, IdOf } from "./database-model";
-import { SerializedObject } from "./serialized-types";
-import { WhereClause } from "./where-clause";
+import {
+  DatabaseModel,
+  IdOf,
+} from "@/server/database/lib/general/database-model";
+import { SerializedObject } from "@/server/database/lib/general/serialized-types";
+import { WhereClause } from "@/server/database/lib/general/where-clause";
 
 /** Arguments to the Migrator's map command. */
 export type MigratorMapCommand = {

--- a/server/database/lib/general/migration.ts
+++ b/server/database/lib/general/migration.ts
@@ -1,11 +1,11 @@
-import { Repository } from "./database";
-import { DatabaseModel } from "./database-model";
+import { Repository } from "@/server/database/lib/general/database";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
 import {
   MigratorDeleteCommand,
   MigratorDropCommand,
   MigratorMapCommand,
   MigratorRenameCommand,
-} from "./migration-command-types";
+} from "@/server/database/lib/general/migration-command-types";
 
 /**
  * Represents a one-off job to run on the database before the server starts.

--- a/server/database/lib/general/query-types.ts
+++ b/server/database/lib/general/query-types.ts
@@ -1,5 +1,8 @@
-import { DatabaseModel, SerializedDataOf } from "./database-model";
-import { WhereClause } from "./where-clause";
+import {
+  DatabaseModel,
+  SerializedDataOf,
+} from "@/server/database/lib/general/database-model";
+import { WhereClause } from "@/server/database/lib/general/where-clause";
 
 /** Arguments to a find (select) query. */
 export type FindQuery<Model extends DatabaseModel> = {

--- a/server/database/lib/general/where-clause.ts
+++ b/server/database/lib/general/where-clause.ts
@@ -1,4 +1,7 @@
-import { DatabaseModel, SerializedDataOf } from "./database-model";
+import {
+  DatabaseModel,
+  SerializedDataOf,
+} from "@/server/database/lib/general/database-model";
 
 /** Can match any field (but not nested structures). */
 export type WhereClause<Model extends DatabaseModel> = {

--- a/server/database/lib/in-memory/in-memory-database.ts
+++ b/server/database/lib/in-memory/in-memory-database.ts
@@ -1,8 +1,12 @@
-import { Database, MigrationHandler, Repository } from "../general/database";
-import { DatabaseModel } from "../general/database-model";
-import { InMemoryDatabaseData } from "./in-memory-database-collection";
-import { InMemoryMigrationHandler } from "./in-memory-migration-handler";
-import { InMemoryRepository } from "./in-memory-repository";
+import {
+  Database,
+  MigrationHandler,
+  Repository,
+} from "@/server/database/lib/general/database";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
+import { InMemoryDatabaseData } from "@/server/database/lib/in-memory/in-memory-database-collection";
+import { InMemoryMigrationHandler } from "@/server/database/lib/in-memory/in-memory-migration-handler";
+import { InMemoryRepository } from "@/server/database/lib/in-memory/in-memory-repository";
 
 export class InMemoryDatabase extends Database {
   private readonly _data: InMemoryDatabaseData;

--- a/server/database/lib/in-memory/in-memory-migration-handler.ts
+++ b/server/database/lib/in-memory/in-memory-migration-handler.ts
@@ -1,18 +1,21 @@
-import { MigrationHandler, Repository } from "../general/database";
-import { DatabaseModel } from "../general/database-model";
-import { Migrator } from "../general/migration";
+import {
+  MigrationHandler,
+  Repository,
+} from "@/server/database/lib/general/database";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
+import { Migrator } from "@/server/database/lib/general/migration";
 import {
   MigratorMapCommand,
   MigratorDeleteCommand,
   MigratorRenameCommand,
   MigratorDropCommand,
-} from "../general/migration-command-types";
+} from "@/server/database/lib/general/migration-command-types";
 import {
   InMemoryDatabaseData,
   InMemoryDatabaseItem,
-} from "./in-memory-database-collection";
-import { InMemoryRepository } from "./in-memory-repository";
-import { InMemoryWhereClauseInterpreter } from "./in-memory-where-clause-interpreter";
+} from "@/server/database/lib/in-memory/in-memory-database-collection";
+import { InMemoryRepository } from "@/server/database/lib/in-memory/in-memory-repository";
+import { InMemoryWhereClauseInterpreter } from "@/server/database/lib/in-memory/in-memory-where-clause-interpreter";
 
 export class InMemoryMigrationHandler extends MigrationHandler {
   constructor(private readonly _data: InMemoryDatabaseData) {

--- a/server/database/lib/in-memory/in-memory-repository.ts
+++ b/server/database/lib/in-memory/in-memory-repository.ts
@@ -1,12 +1,20 @@
-import { Repository } from "../general/database";
-import { DatabaseModel, DataOf, IdOf } from "../general/database-model";
-import { FindQuery, FirstQuery, CountQuery } from "../general/query-types";
+import { Repository } from "@/server/database/lib/general/database";
+import {
+  DatabaseModel,
+  DataOf,
+  IdOf,
+} from "@/server/database/lib/general/database-model";
+import {
+  FindQuery,
+  FirstQuery,
+  CountQuery,
+} from "@/server/database/lib/general/query-types";
 import {
   InMemoryDatabaseCollection,
   InMemoryDatabaseItem,
-} from "./in-memory-database-collection";
-import { InMemorySortClauseInterpreter } from "./in-memory-sort-clause-interpreter";
-import { InMemoryWhereClauseInterpreter } from "./in-memory-where-clause-interpreter";
+} from "@/server/database/lib/in-memory/in-memory-database-collection";
+import { InMemorySortClauseInterpreter } from "@/server/database/lib/in-memory/in-memory-sort-clause-interpreter";
+import { InMemoryWhereClauseInterpreter } from "@/server/database/lib/in-memory/in-memory-where-clause-interpreter";
 
 export class InMemoryRepository<
   Model extends DatabaseModel,

--- a/server/database/lib/in-memory/in-memory-sort-clause-interpreter.ts
+++ b/server/database/lib/in-memory/in-memory-sort-clause-interpreter.ts
@@ -1,6 +1,6 @@
-import { DatabaseModel } from "../general/database-model";
-import { SortClause } from "../general/query-types";
-import { InMemoryDatabaseItem } from "./in-memory-database-collection";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
+import { SortClause } from "@/server/database/lib/general/query-types";
+import { InMemoryDatabaseItem } from "@/server/database/lib/in-memory/in-memory-database-collection";
 
 /** Provides a sorting function based on the given SortClause. */
 export class InMemorySortClauseInterpreter<Model extends DatabaseModel> {

--- a/server/database/lib/in-memory/in-memory-where-clause-interpreter.ts
+++ b/server/database/lib/in-memory/in-memory-where-clause-interpreter.ts
@@ -1,6 +1,9 @@
-import { DatabaseModel } from "../general/database-model";
-import { WhereClause, FieldConstraint } from "../general/where-clause";
-import { InMemoryDatabaseItem } from "./in-memory-database-collection";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
+import {
+  WhereClause,
+  FieldConstraint,
+} from "@/server/database/lib/general/where-clause";
+import { InMemoryDatabaseItem } from "@/server/database/lib/in-memory/in-memory-database-collection";
 
 /** Determines whether items match the provided WhereClause. */
 export class InMemoryWhereClauseInterpreter<Model extends DatabaseModel> {

--- a/server/database/lib/mongo/mongo-database.ts
+++ b/server/database/lib/mongo/mongo-database.ts
@@ -1,9 +1,13 @@
 import { Db, MongoClient } from "mongodb";
-import { config } from "../../../config";
-import { DatabaseModel } from "../general/database-model";
-import { Database, MigrationHandler, Repository } from "../general/database";
-import { MongoRepository } from "./mongo-repository";
-import { MongoMigrationHandler } from "./mongo-migration-handler";
+import { config } from "@/server/config";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
+import {
+  Database,
+  MigrationHandler,
+  Repository,
+} from "@/server/database/lib/general/database";
+import { MongoRepository } from "@/server/database/lib/mongo/mongo-repository";
+import { MongoMigrationHandler } from "@/server/database/lib/mongo/mongo-migration-handler";
 
 export class MongoDatabase extends Database {
   private readonly _db: Db;

--- a/server/database/lib/mongo/mongo-migration-handler.ts
+++ b/server/database/lib/mongo/mongo-migration-handler.ts
@@ -1,15 +1,21 @@
 import { Db } from "mongodb";
-import { MigrationHandler, Repository } from "../general/database";
-import { Migrator } from "../general/migration";
-import { DatabaseModel } from "../general/database-model";
-import { ModelDocument, MongoRepository } from "./mongo-repository";
+import {
+  MigrationHandler,
+  Repository,
+} from "@/server/database/lib/general/database";
+import { Migrator } from "@/server/database/lib/general/migration";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
+import {
+  ModelDocument,
+  MongoRepository,
+} from "@/server/database/lib/mongo/mongo-repository";
 import {
   MigratorMapCommand,
   MigratorDeleteCommand,
   MigratorRenameCommand,
   MigratorDropCommand,
-} from "../general/migration-command-types";
-import { MongoWhereClauseInterpreter } from "./mongo-where-clause-interpreter";
+} from "@/server/database/lib/general/migration-command-types";
+import { MongoWhereClauseInterpreter } from "@/server/database/lib/mongo/mongo-where-clause-interpreter";
 import { z } from "zod";
 
 export class MongoMigrationHandler extends MigrationHandler {

--- a/server/database/lib/mongo/mongo-repository.ts
+++ b/server/database/lib/mongo/mongo-repository.ts
@@ -1,9 +1,17 @@
 import { Collection, WithId } from "mongodb";
-import { Repository } from "../general/database";
-import { DatabaseModel, DataOf, IdOf } from "../general/database-model";
-import { FindQuery, FirstQuery, CountQuery } from "../general/query-types";
-import { MongoWhereClauseInterpreter } from "./mongo-where-clause-interpreter";
-import { MongoSortClauseInterpreter } from "./mongo-sort-clause-interpreter";
+import { Repository } from "@/server/database/lib/general/database";
+import {
+  DatabaseModel,
+  DataOf,
+  IdOf,
+} from "@/server/database/lib/general/database-model";
+import {
+  FindQuery,
+  FirstQuery,
+  CountQuery,
+} from "@/server/database/lib/general/query-types";
+import { MongoWhereClauseInterpreter } from "@/server/database/lib/mongo/mongo-where-clause-interpreter";
+import { MongoSortClauseInterpreter } from "@/server/database/lib/mongo/mongo-sort-clause-interpreter";
 
 export type ModelDocument = {
   // The mongodb driver hates it when I try to use IdOf<Model> here, otherwise I

--- a/server/database/lib/mongo/mongo-sort-clause-interpreter.ts
+++ b/server/database/lib/mongo/mongo-sort-clause-interpreter.ts
@@ -1,6 +1,6 @@
 import { Sort } from "mongodb";
-import { SortClause } from "../general/query-types";
-import { DatabaseModel } from "../general/database-model";
+import { SortClause } from "@/server/database/lib/general/query-types";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
 
 /** Takes a SortClause and converts it to MongoDB's sort syntax. */
 export class MongoSortClauseInterpreter<Model extends DatabaseModel> {

--- a/server/database/lib/mongo/mongo-where-clause-interpreter.ts
+++ b/server/database/lib/mongo/mongo-where-clause-interpreter.ts
@@ -1,7 +1,10 @@
 import { Filter } from "mongodb";
-import { ModelDocument } from "./mongo-repository";
-import { DatabaseModel } from "../general/database-model";
-import { WhereClause, FieldConstraint } from "../general/where-clause";
+import { ModelDocument } from "@/server/database/lib/mongo/mongo-repository";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
+import {
+  WhereClause,
+  FieldConstraint,
+} from "@/server/database/lib/general/where-clause";
 
 /** Takes a WhereClause and builds the equivalent filter in MongoDB syntax. */
 export class MongoWhereClauseInterpreter<Model extends DatabaseModel> {

--- a/server/database/migrations/migrations.ts
+++ b/server/database/migrations/migrations.ts
@@ -1,4 +1,4 @@
-import { Migration } from "../lib/general/migration";
+import { Migration } from "@/server/database/lib/general/migration";
 
 /**
  * See docs/database/writing-database-migrations.md for help writing a database

--- a/server/database/models/alert.ts
+++ b/server/database/models/alert.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { Alert, AlertData } from "../../data/alert";
-import { DatabaseModel } from "../lib/general/database-model";
+import { Alert, AlertData } from "@/server/data/alert";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
 
 export class AlertModel extends DatabaseModel<
   Alert,

--- a/server/database/models/crayons.ts
+++ b/server/database/models/crayons.ts
@@ -1,7 +1,7 @@
 // For demonstration purposes. Delete this once we've got the first real model.
 
 import { z } from "zod";
-import { DatabaseModel } from "../lib/general/database-model";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
 
 /**
  * The class returned by the database.

--- a/server/database/models/disruption.ts
+++ b/server/database/models/disruption.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { DatabaseModel } from "../lib/general/database-model";
-import { Disruption } from "../../data/disruption/disruption";
-import { disruptionPeriodBson } from "../../data/disruption/period/disruption-period";
-import { disruptionDataBson } from "../../data/disruption/data/disruption-data";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
+import { Disruption } from "@/server/data/disruption/disruption";
+import { disruptionPeriodBson } from "@/server/data/disruption/period/disruption-period";
+import { disruptionDataBson } from "@/server/data/disruption/data/disruption-data";
 
 const beginningOfTime = new Date("2000-01-01T00:00:00Z");
 const endOfTime = new Date("2100-01-01T00:00:00Z");

--- a/server/database/models/historical-alert.ts
+++ b/server/database/models/historical-alert.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { DatabaseModel } from "../lib/general/database-model";
-import { HistoricalAlert } from "../../data/historical-alert";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
+import { HistoricalAlert } from "@/server/data/historical-alert";
 
 export class HistoricalAlertModel extends DatabaseModel<
   HistoricalAlert,

--- a/server/database/models/models.ts
+++ b/server/database/models/models.ts
@@ -1,5 +1,5 @@
-import { CrayonModel } from "./crayons";
-import { HistoricalAlertModel } from "./historical-alert";
+import { CrayonModel } from "@/server/database/models/crayons";
+import { HistoricalAlertModel } from "@/server/database/models/historical-alert";
 
 export const CRAYONS = CrayonModel.instance;
 export const HISTORICAL_ALERTS = HistoricalAlertModel.instance;

--- a/server/disruption-source/disruption-source.ts
+++ b/server/disruption-source/disruption-source.ts
@@ -1,4 +1,4 @@
-import { Disruption } from "../../types/disruption";
+import { Disruption } from "@/types/disruption";
 
 export abstract class DisruptionSource {
   abstract fetchDisruptions(): Promise<Disruption[]>;

--- a/server/disruption-source/fake-disruption-source.ts
+++ b/server/disruption-source/fake-disruption-source.ts
@@ -1,5 +1,5 @@
-import { Disruption } from "../../types/disruption";
-import { DisruptionSource } from "./disruption-source";
+import { Disruption } from "@/types/disruption";
+import { DisruptionSource } from "@/server/disruption-source/disruption-source";
 
 // For testing purposes.
 export class FakeDisruptionSource extends DisruptionSource {

--- a/server/disruption-source/init-disruption-source.ts
+++ b/server/disruption-source/init-disruption-source.ts
@@ -1,7 +1,7 @@
-import { config } from "../config";
-import { env } from "../env";
-import { FakeDisruptionSource } from "./fake-disruption-source";
-import { VtarDisruptionSource } from "./vtar-disruption-source";
+import { config } from "@/server/config";
+import { env } from "@/server/env";
+import { FakeDisruptionSource } from "@/server/disruption-source/fake-disruption-source";
+import { VtarDisruptionSource } from "@/server/disruption-source/vtar-disruption-source";
 
 /**
  * Ideally returns a VtarDisruptionSource, but falls back to a

--- a/server/disruption-source/vtar-disruption-source.ts
+++ b/server/disruption-source/vtar-disruption-source.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { Disruption, disruptionSchema } from "../../types/disruption";
-import { DisruptionSource } from "./disruption-source";
+import { Disruption, disruptionSchema } from "@/types/disruption";
+import { DisruptionSource } from "@/server/disruption-source/disruption-source";
 
 export class VtarDisruptionSource extends DisruptionSource {
   constructor(

--- a/server/env.ts
+++ b/server/env.ts
@@ -1,6 +1,6 @@
 import { configDotenv } from "dotenv";
 import { z } from "zod";
-import { stringNumberSchema } from "./utils";
+import { stringNumberSchema } from "@/server/utils";
 
 const schema = z.object({
   RELAY_KEY: z.string().optional(),

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -1,8 +1,8 @@
 import { Router } from "express";
 import cors, { type CorsOptions } from "cors";
-import { errorHandler } from "./middleware/error";
-import { App } from "../app";
-import { createDisruptionRouter } from "./disruptions";
+import { errorHandler } from "@/server/routes/middleware/error";
+import { App } from "@/server/app";
+import { createDisruptionRouter } from "@/server/routes/disruptions";
 
 // CORS enabled to prevent API abuse from origins outside our domain(s)
 const corsOptions: CorsOptions = {

--- a/server/routes/disruptions.ts
+++ b/server/routes/disruptions.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
-import { validateMiddleware } from "./middleware/validate";
-import { disruptionSchema } from "../../types/disruption";
-import { App } from "../app";
+import { validateMiddleware } from "@/server/routes/middleware/validate";
+import { disruptionSchema } from "@/types/disruption";
+import { App } from "@/server/app";
 
 export function createDisruptionRouter(app: App) {
   const disruptionRouter = Router();

--- a/server/routes/middleware/error.ts
+++ b/server/routes/middleware/error.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from "express";
-import { ValidationError } from "../../../types/errors/validation";
+import { ValidationError } from "@/types/errors/validation";
 
 /**
  * Handles any errors recovered via `next()`

--- a/server/routes/middleware/validate.ts
+++ b/server/routes/middleware/validate.ts
@@ -1,10 +1,7 @@
 import { ZodIssue, ZodObjectDef, ZodSchema } from "zod";
 import { NextFunction, Request, Response } from "express";
 import { ParamsDictionary } from "express-serve-static-core";
-import {
-  IValidationError,
-  ValidationError,
-} from "../../../types/errors/validation";
+import { IValidationError, ValidationError } from "@/types/errors/validation";
 
 type ValidationRequest<TParams, TQuery, TBody, TResBody> = {
   params?: ZodSchema<TParams, ZodObjectDef>;

--- a/server/settings.ts
+++ b/server/settings.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
-import { cookieSettings, Settings } from "../shared/settings";
-import { StationCollection } from "./data/static/station-collection";
+import { cookieSettings, Settings } from "@/shared/settings";
+import { StationCollection } from "@/server/data/static/station-collection";
 
 /** Extracts the user settings from an Express request's cookies. */
 export function getSettings(req: Request): Settings {

--- a/server/vike-handler.ts
+++ b/server/vike-handler.ts
@@ -1,8 +1,8 @@
 import { renderPage } from "vike/server";
 import express from "express";
-import { getSettings, validateSettings } from "./settings";
-import { App } from "./app";
-import { Settings } from "../shared/settings";
+import { getSettings, validateSettings } from "@/server/settings";
+import { App } from "@/server/app";
+import { Settings } from "@/shared/settings";
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/tests/scripts/generate-map-geometry/builder/geometry-builder.test.ts
+++ b/tests/scripts/generate-map-geometry/builder/geometry-builder.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { InterchangeBlueprint } from "../../../../scripts/generate-map-geometry/lib/blueprint/interchange-blueprint";
-import { LineBlueprint } from "../../../../scripts/generate-map-geometry/lib/blueprint/line-blueprint";
-import { fp } from "../../../../scripts/generate-map-geometry/lib/dimensions/flexi-point";
-import { PathBlueprint } from "../../../../scripts/generate-map-geometry/lib/blueprint/path-blueprint";
-import { flexi } from "../../../../scripts/generate-map-geometry/lib/dimensions/flexi-length";
-import { GeometryBuilder } from "../../../../scripts/generate-map-geometry/lib/builder/geometry-builder";
+import { InterchangeBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/interchange-blueprint";
+import { LineBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/line-blueprint";
+import { fp } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-point";
+import { PathBlueprint } from "@/scripts/generate-map-geometry/lib/blueprint/path-blueprint";
+import { flexi } from "@/scripts/generate-map-geometry/lib/dimensions/flexi-length";
+import { GeometryBuilder } from "@/scripts/generate-map-geometry/lib/builder/geometry-builder";
 
 describe("GeometryBuilder", () => {
   it("builds the geometry as expected", () => {

--- a/tests/server/data/disruption/period/ends/ends-after-last-service.test.ts
+++ b/tests/server/data/disruption/period/ends/ends-after-last-service.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { EndsAfterLastService } from "../../../../../../server/data/disruption/period/ends/ends-after-last-service";
-import { JustDate } from "../../../../../../server/data/disruption/period/utils/just-date";
+import { EndsAfterLastService } from "@/server/data/disruption/period/ends/ends-after-last-service";
+import { JustDate } from "@/server/data/disruption/period/utils/just-date";
 
 describe("EndsAfterLastService", () => {
   describe("getDisplayString", () => {

--- a/tests/server/data/disruption/period/ends/ends-approximately.test.ts
+++ b/tests/server/data/disruption/period/ends/ends-approximately.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { EndsApproximately } from "../../../../../../server/data/disruption/period/ends/ends-approximately";
+import { EndsApproximately } from "@/server/data/disruption/period/ends/ends-approximately";
 
 describe("EndsApproximately", () => {
   const end1 = new EndsApproximately(

--- a/tests/server/data/disruption/period/ends/ends-exactly.test.ts
+++ b/tests/server/data/disruption/period/ends/ends-exactly.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { EndsExactly } from "../../../../../../server/data/disruption/period/ends/ends-exactly";
+import { EndsExactly } from "@/server/data/disruption/period/ends/ends-exactly";
 
 describe("EndsExactly", () => {
   const end1 = new EndsExactly(new Date("2025-03-20T15:00:00+11:00"));

--- a/tests/server/data/disruption/period/ends/ends-never.test.ts
+++ b/tests/server/data/disruption/period/ends/ends-never.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { EndsNever } from "../../../../../../server/data/disruption/period/ends/ends-never";
+import { EndsNever } from "@/server/data/disruption/period/ends/ends-never";
 
 describe("EndsNever", () => {
   const end = new EndsNever();

--- a/tests/server/data/disruption/period/ends/ends-when-alert-ends.test.ts
+++ b/tests/server/data/disruption/period/ends/ends-when-alert-ends.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { EndsWhenAlertEnds } from "../../../../../../server/data/disruption/period/ends/ends-when-alert-ends";
+import { EndsWhenAlertEnds } from "@/server/data/disruption/period/ends/ends-when-alert-ends";
 
 describe("EndsWhenAlertEnds", () => {
   const end = new EndsWhenAlertEnds("1", new Date("2025-03-20T15:00:00+11:00"));

--- a/tests/server/data/disruption/period/evenings-only-disruption-period.test.ts
+++ b/tests/server/data/disruption/period/evenings-only-disruption-period.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { EveningsOnlyDisruptionPeriod } from "../../../../../server/data/disruption/period/evenings-only-disruption-period";
-import { EndsNever } from "../../../../../server/data/disruption/period/ends/ends-never";
-import { EndsExactly } from "../../../../../server/data/disruption/period/ends/ends-exactly";
-import { expectCalendarMarks } from "./utils";
-import { TimeRange } from "../../../../../server/data/disruption/period/utils/time-range";
+import { EveningsOnlyDisruptionPeriod } from "@/server/data/disruption/period/evenings-only-disruption-period";
+import { EndsNever } from "@/server/data/disruption/period/ends/ends-never";
+import { EndsExactly } from "@/server/data/disruption/period/ends/ends-exactly";
+import { expectCalendarMarks } from "@/tests/server/data/disruption/period/utils";
+import { TimeRange } from "@/server/data/disruption/period/utils/time-range";
 
 describe("EveningsOnlyDisruptionPeriod", () => {
   it("doesn't allow startHourEachDay to be invalid", () => {

--- a/tests/server/data/disruption/period/standard-disruption-period.test.ts
+++ b/tests/server/data/disruption/period/standard-disruption-period.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { StandardDisruptionPeriod } from "@/server/data/disruption/period/standard-disruption-period";
-import { EndsExactly } from "../../../../../server/data/disruption/period/ends/ends-exactly";
-import { EndsNever } from "../../../../../server/data/disruption/period/ends/ends-never";
-import { expectCalendarMarks } from "./utils";
+import { EndsExactly } from "@/server/data/disruption/period/ends/ends-exactly";
+import { EndsNever } from "@/server/data/disruption/period/ends/ends-never";
+import { expectCalendarMarks } from "@/tests/server/data/disruption/period/utils";
 
 describe("StandardDisruptionPeriod", () => {
   describe("#getDisplayString", () => {

--- a/tests/server/data/disruption/period/standard-disruption-period.test.ts
+++ b/tests/server/data/disruption/period/standard-disruption-period.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { StandardDisruptionPeriod } from "../../../../../server/data/disruption/period/standard-disruption-period";
+import { StandardDisruptionPeriod } from "@/server/data/disruption/period/standard-disruption-period";
 import { EndsExactly } from "../../../../../server/data/disruption/period/ends/ends-exactly";
 import { EndsNever } from "../../../../../server/data/disruption/period/ends/ends-never";
 import { expectCalendarMarks } from "./utils";

--- a/tests/server/data/disruption/period/utils.ts
+++ b/tests/server/data/disruption/period/utils.ts
@@ -1,7 +1,7 @@
 import { expect } from "vitest";
-import { DisruptionPeriod } from "../../../../../server/data/disruption/period/disruption-period";
-import { JustDate } from "../../../../../server/data/disruption/period/utils/just-date";
-import { CalendarMark } from "../../../../../server/data/disruption/period/disruption-period-base";
+import { DisruptionPeriod } from "@/server/data/disruption/period/disruption-period";
+import { JustDate } from "@/server/data/disruption/period/utils/just-date";
+import { CalendarMark } from "@/server/data/disruption/period/disruption-period-base";
 
 export function expectCalendarMarks(
   period: DisruptionPeriod,

--- a/tests/server/data/disruption/period/utils/time-range.test.ts
+++ b/tests/server/data/disruption/period/utils/time-range.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { TimeRange } from "../../../../../../server/data/disruption/period/utils/time-range";
+import { TimeRange } from "@/server/data/disruption/period/utils/time-range";
 
 describe("TimeRange", () => {
   describe("#includes", () => {

--- a/tests/server/data/static/line-routes/line-routes.test.ts
+++ b/tests/server/data/static/line-routes/line-routes.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { lines } from "../../../../../server/data/static/lines";
-import { stations } from "../../../../../server/data/static/stations";
+import { lines } from "@/server/data/static/lines";
+import { stations } from "@/server/data/static/stations";
 import {
   LineShape,
   LineShapeNode,
-} from "../../../../../server/data/static/line-routes/line-shape";
+} from "@/server/data/static/line-routes/line-shape";
 
 describe("Melbourne default line route edges", () => {
   it("should match the snapshot", () => {

--- a/tests/server/data/static/line-routes/line-shape.test.ts
+++ b/tests/server/data/static/line-routes/line-shape.test.ts
@@ -2,8 +2,8 @@ import { assert, describe, expect, it } from "vitest";
 import {
   LineShape,
   LineShapeEdge,
-} from "../../../../../server/data/static/line-routes/line-shape";
-import { StationPair } from "../../../../../server/data/static/line-routes/station-pair";
+} from "@/server/data/static/line-routes/line-shape";
+import { StationPair } from "@/server/data/static/line-routes/station-pair";
 
 describe("LineShape", () => {
   const lineShape = new LineShape("the-city", [

--- a/tests/server/data/static/line-routes/tree.test.ts
+++ b/tests/server/data/static/line-routes/tree.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { Edge, Tree } from "../../../../../server/data/static/line-routes/tree";
+import { Edge, Tree } from "@/server/data/static/line-routes/tree";
 
 describe("Tree", () => {
   describe("#throwUnlessValid", () => {

--- a/tests/server/database/lib/in-memory/in-memory-database.test.ts
+++ b/tests/server/database/lib/in-memory/in-memory-database.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { getDatabase } from "./test-database";
+import { getDatabase } from "@/tests/server/database/lib/in-memory/test-database";
 import {
   MUSICAL_INSTRUMENTS,
   MusicalInstrument,
   PIANO_1,
   PIANO_4,
   SYNTH_2,
-} from "../test-model";
+} from "@/tests/server/database/lib/test-model";
 
 describe("InMemoryDatabase", () => {
   it("should get items by ID", async () => {

--- a/tests/server/database/lib/in-memory/in-memory-migration-handler.test.ts
+++ b/tests/server/database/lib/in-memory/in-memory-migration-handler.test.ts
@@ -3,8 +3,8 @@ import { it, expect, vi } from "vitest";
 import {
   InMemoryMigrationHandler,
   InMemoryMigrator,
-} from "../../../../../server/database/lib/in-memory/in-memory-migration-handler";
-import { InMemoryDatabaseData } from "../../../../../server/database/lib/in-memory/in-memory-database-collection";
+} from "@/server/database/lib/in-memory/in-memory-migration-handler";
+import { InMemoryDatabaseData } from "@/server/database/lib/in-memory/in-memory-database-collection";
 import { z } from "zod";
 
 describe("InMemoryMigrationHandler", () => {

--- a/tests/server/database/lib/in-memory/in-memory-sort-clause-interpreter.test.ts
+++ b/tests/server/database/lib/in-memory/in-memory-sort-clause-interpreter.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { DatabaseModel } from "../../../../../server/database/lib/general/database-model";
-import { InMemorySortClauseInterpreter } from "../../../../../server/database/lib/in-memory/in-memory-sort-clause-interpreter";
-import { InMemoryDatabaseItem } from "../../../../../server/database/lib/in-memory/in-memory-database-collection";
-import { SortClause } from "../../../../../server/database/lib/general/query-types";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
+import { InMemorySortClauseInterpreter } from "@/server/database/lib/in-memory/in-memory-sort-clause-interpreter";
+import { InMemoryDatabaseItem } from "@/server/database/lib/in-memory/in-memory-database-collection";
+import { SortClause } from "@/server/database/lib/general/query-types";
 
 describe("InMemorySortClauseInterpreter", () => {
   describe("matches", () => {

--- a/tests/server/database/lib/in-memory/in-memory-where-clause-interpreter.test.ts
+++ b/tests/server/database/lib/in-memory/in-memory-where-clause-interpreter.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { WhereClause } from "../../../../../server/database/lib/general/where-clause";
-import { DatabaseModel } from "../../../../../server/database/lib/general/database-model";
-import { InMemoryWhereClauseInterpreter } from "../../../../../server/database/lib/in-memory/in-memory-where-clause-interpreter";
-import { InMemoryDatabaseItem } from "../../../../../server/database/lib/in-memory/in-memory-database-collection";
+import { WhereClause } from "@/server/database/lib/general/where-clause";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
+import { InMemoryWhereClauseInterpreter } from "@/server/database/lib/in-memory/in-memory-where-clause-interpreter";
+import { InMemoryDatabaseItem } from "@/server/database/lib/in-memory/in-memory-database-collection";
 
 const obj = {
   id: 1,

--- a/tests/server/database/lib/in-memory/test-database.ts
+++ b/tests/server/database/lib/in-memory/test-database.ts
@@ -1,11 +1,11 @@
-import { InMemoryDatabase } from "../../../../../server/database/lib/in-memory/in-memory-database";
+import { InMemoryDatabase } from "@/server/database/lib/in-memory/in-memory-database";
 import {
   BASS_3,
   MUSICAL_INSTRUMENTS,
   PIANO_1,
   PIANO_4,
   SYNTH_2,
-} from "../test-model";
+} from "@/tests/server/database/lib/test-model";
 
 export function getDatabase(): InMemoryDatabase {
   const db = new InMemoryDatabase();

--- a/tests/server/database/lib/mongo/mongo-migration-handler.test.ts
+++ b/tests/server/database/lib/mongo/mongo-migration-handler.test.ts
@@ -3,7 +3,7 @@ import { it, expect, vi } from "vitest";
 import {
   MongoMigrationHandler,
   MongoMigrator,
-} from "../../../../../server/database/lib/mongo/mongo-migration-handler";
+} from "@/server/database/lib/mongo/mongo-migration-handler";
 import { Collection, Db, FindCursor } from "mongodb";
 import { mock } from "vitest-mock-extended";
 import { z } from "zod";

--- a/tests/server/database/lib/mongo/mongo-repository.test.ts
+++ b/tests/server/database/lib/mongo/mongo-repository.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   ModelDocument,
   MongoRepository,
-} from "../../../../../server/database/lib/mongo/mongo-repository";
-import { MUSICAL_INSTRUMENTS, MusicalInstrument } from "../test-model";
+} from "@/server/database/lib/mongo/mongo-repository";
+import {
+  MUSICAL_INSTRUMENTS,
+  MusicalInstrument,
+} from "@/tests/server/database/lib/test-model";
 import { mock } from "vitest-mock-extended";
 import { Collection, FindCursor } from "mongodb";
 

--- a/tests/server/database/lib/mongo/mongo-sort-clause-interpreter.test.ts
+++ b/tests/server/database/lib/mongo/mongo-sort-clause-interpreter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { MongoSortClauseInterpreter } from "../../../../../server/database/lib/mongo/mongo-sort-clause-interpreter";
-import { SortClause } from "../../../../../server/database/lib/general/query-types";
-import { DatabaseModel } from "../../../../../server/database/lib/general/database-model";
+import { MongoSortClauseInterpreter } from "@/server/database/lib/mongo/mongo-sort-clause-interpreter";
+import { SortClause } from "@/server/database/lib/general/query-types";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
 
 describe("MongoSortClauseInterpreter", () => {
   describe("toMongoSort", () => {

--- a/tests/server/database/lib/mongo/mongo-where-clause-interpreter.test.ts
+++ b/tests/server/database/lib/mongo/mongo-where-clause-interpreter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { MongoWhereClauseInterpreter } from "../../../../../server/database/lib/mongo/mongo-where-clause-interpreter";
-import { DatabaseModel } from "../../../../../server/database/lib/general/database-model";
-import { WhereClause } from "../../../../../server/database/lib/general/where-clause";
+import { MongoWhereClauseInterpreter } from "@/server/database/lib/mongo/mongo-where-clause-interpreter";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
+import { WhereClause } from "@/server/database/lib/general/where-clause";
 
 const date1 = Date.parse("2024-12-28T12:00:00Z");
 const date2 = Date.parse("2024-12-28T13:00:00Z");

--- a/tests/server/database/lib/test-model.ts
+++ b/tests/server/database/lib/test-model.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { DatabaseModel } from "../../../../server/database/lib/general/database-model";
+import { DatabaseModel } from "@/server/database/lib/general/database-model";
 
 export class MusicalInstrument {
   constructor(

--- a/tests/server/generic/abstract-class-bson.test.ts
+++ b/tests/server/generic/abstract-class-bson.test.ts
@@ -1,8 +1,8 @@
 import { assert, describe, expect, it } from "vitest";
-import { disruptionDataBson } from "../../../server/data/disruption/data/disruption-data";
-import { disruptionPeriodBson } from "../../../server/data/disruption/period/disruption-period";
-import { endsBson } from "../../../server/data/disruption/period/ends/ends";
-import { routeGraphEdgeBson } from "../../../server/data/route-graph/edge/route-graph-edge";
+import { disruptionDataBson } from "@/server/data/disruption/data/disruption-data";
+import { disruptionPeriodBson } from "@/server/data/disruption/period/disruption-period";
+import { endsBson } from "@/server/data/disruption/period/ends/ends";
+import { routeGraphEdgeBson } from "@/server/data/route-graph/edge/route-graph-edge";
 
 // NOTE: If this test is breaking, it's probably because you've edited a Zod
 // schema which has a "type" field on it which is used to distinguish between

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
     "types": ["vite/client", "vike-react"],
     "jsx": "preserve",
     "jsxImportSource": "react",
-    "baseUrl": "./",
     "paths": {
       "@/*": ["./*"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,11 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "types": ["vite/client", "vike-react"],
     "jsx": "preserve",
-    "jsxImportSource": "react"
+    "jsxImportSource": "react",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "exclude": ["dist"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vite";
 import vike from "vike/plugin";
 import { VitePWA, VitePWAOptions } from "vite-plugin-pwa";
 import tailwindcss from "@tailwindcss/vite";
+import path from "path";
 
 const pwaConfig: Partial<VitePWAOptions> = {
   // TODO: It looks like there's no way to create a custom "You're offline" page
@@ -76,4 +77,9 @@ const pwaConfig: Partial<VitePWAOptions> = {
 
 export default defineConfig({
   plugins: [vike({}), react({}), VitePWA(pwaConfig), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./"),
+    },
+  },
 });


### PR DESCRIPTION
### Changes

- Add `@` as an alias for the root directory.
- Switch all imports to use `import ... from "@/..."` (a.k.a. the "absolute" style).
- Add custom ESLint rule to enforce new imports going forward use the absolute style.
- Configure `.vscode/settings.json` to automatically import using the absolute style.

### Why? 

- This opens the door to adding a further ESLint rule to prevent us accidentally importing `@/server` code on the frontend. 
- It also can look a little nicer than having `import ... from "../../../../whatever/thing"`, which tends to happen a lot in the tests.

### Reviewing this PR

- Please switch to this branch, restart your VSCode (to reload the lint rules), and check:
  - That you get no lint errors, either in your editor, or by running `npm run lint`.
  - Change something back to using a relative import. Does the "quick fix" option fix it correctly?
  - Remove an import and use "quick fix" to import it again. Does VSCode automatically use the `@/...` style?
- If you want to see the changes prior to changing all the existing imports, look through the first 3 commits.