### PR TITLE
Fix exceptions to ESLint script not working on Windows

### DIFF
--- a/scripts/eslint/enforce-import-alias.js
+++ b/scripts/eslint/enforce-import-alias.js
@@ -18,7 +18,10 @@ const useImportAlias = {
   create: (context) => {
     return {
       ImportDeclaration: (node) => {
-        const repoRelativeFileName = context.filename.replace(context.cwd, "");
+        const repoRelativeFileName = context.filename
+          .replace(context.cwd, "")
+          .replace(/\\/g, "/");
+
         if (exceptions.some((e) => repoRelativeFileName.startsWith(e))) return;
 
         const value = node.source.value;


### PR DESCRIPTION
- Fixes bug where ESLint tries to enforce absolute imports on ESLint scripts too, which doesn't work.
- This occurs on Windows only (doesn't affect CI) as it uses backslashes for paths.
- Special thanks to GitHub Mobile and Platform 6, Richmond Railway Station for making this PR possible! 😅