### PR TITLE
Admin tab visibility

### DIFF
--- a/components/core/Button.tsx
+++ b/components/core/Button.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import React from "react";
 
 // TODO: Codify routes rather than allowing any string.
@@ -26,6 +27,7 @@ export function extractAction(props: Action): Action {
 export type ButtonProps = {
   children: React.ReactElement;
   alt?: string;
+  hidden?: boolean;
 } & Action;
 
 /**
@@ -43,7 +45,7 @@ export function Button(props: ButtonProps) {
     const type = props.submit === true ? "submit" : "button";
     return (
       <button
-        className="group grid"
+        className={clsx("group grid", { hidden: props.hidden })}
         onClick={props.onClick}
         type={type}
         title={props.alt}
@@ -54,7 +56,7 @@ export function Button(props: ButtonProps) {
   } else {
     return (
       <a
-        className="group grid"
+        className={clsx("group grid", { hidden: props.hidden })}
         href={props.href}
         title={props.alt}
         target={props.target}

--- a/components/navigation/DesktopTabButton.tsx
+++ b/components/navigation/DesktopTabButton.tsx
@@ -1,11 +1,12 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Button } from "@/components/core/Button";
 import { Row } from "@/components/core/Row";
 import { Text } from "@/components/core/Text";
 import { With } from "@/components/core/With";
 import clsx from "clsx";
-import { NavTab } from "@/components/navigation/utils";
+import { admin, NavTab, settings } from "@/components/navigation/utils";
 import { usePageContext } from "vike-react/usePageContext";
+import { useAdminVisibilityContext } from "@/context/AdminVisibility";
 
 export type DesktopTabButtonProps = {
   tab: NavTab;
@@ -13,10 +14,21 @@ export type DesktopTabButtonProps = {
 
 export function DesktopTabButton(props: DesktopTabButtonProps) {
   const { urlPathname } = usePageContext();
+  const { showAdminTab, incrementCount } = useAdminVisibilityContext();
+  const [hidden, setHidden] = useState<boolean>(true);
   const active = props.tab.active(urlPathname);
 
+  useEffect(() => {
+    setHidden(!showAdminTab && props.tab === admin && !active);
+  }, [active, props.tab, showAdminTab]);
+
+  const action =
+    active && props.tab === settings
+      ? { onClick: incrementCount }
+      : { href: props.tab.path };
+
   return (
-    <Button href={props.tab.path}>
+    <Button {...action} hidden={hidden}>
       <Row
         className={clsx(
           "group-hover:bg-action group-active:bg-action-secondary h-12 gap-2 border-y-2 border-transparent px-4",

--- a/components/navigation/DesktopTabButton.tsx
+++ b/components/navigation/DesktopTabButton.tsx
@@ -15,7 +15,7 @@ export type DesktopTabButtonProps = {
 export function DesktopTabButton(props: DesktopTabButtonProps) {
   const { urlPathname } = usePageContext();
   const { showAdminTab, incrementCount } = useAdminVisibilityContext();
-  const [hidden, setHidden] = useState<boolean>(true);
+  const [hidden, setHidden] = useState<boolean>(props.tab === admin);
   const active = props.tab.active(urlPathname);
 
   useEffect(() => {

--- a/components/navigation/MobileTabButton.tsx
+++ b/components/navigation/MobileTabButton.tsx
@@ -1,11 +1,12 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Button } from "@/components/core/Button";
 import { Text } from "@/components/core/Text";
 import { With } from "@/components/core/With";
 import clsx from "clsx";
-import { NavTab } from "@/components/navigation/utils";
+import { admin, NavTab, settings } from "@/components/navigation/utils";
 import { usePageContext } from "vike-react/usePageContext";
 import { Column } from "@/components/core/Column";
+import { useAdminVisibilityContext } from "@/context/AdminVisibility";
 
 export type MobileTabButtonProps = {
   tab: NavTab;
@@ -13,10 +14,21 @@ export type MobileTabButtonProps = {
 
 export function MobileTabButton(props: MobileTabButtonProps) {
   const { urlPathname } = usePageContext();
+  const { showAdminTab, incrementCount } = useAdminVisibilityContext();
+  const [hidden, setHidden] = useState<boolean>(true);
   const active = props.tab.active(urlPathname);
 
+  useEffect(() => {
+    setHidden(!showAdminTab && props.tab === admin && !active);
+  }, [active, props.tab, showAdminTab]);
+
+  const action =
+    active && props.tab === settings
+      ? { onClick: incrementCount }
+      : { href: props.tab.path };
+
   return (
-    <Button href={props.tab.path}>
+    <Button {...action} hidden={hidden}>
       <Column className={clsx("h-16 gap-1")} align="center" justify="center">
         <With
           className={clsx("-mt-1 rounded-full px-4 py-1 text-xl", {

--- a/components/navigation/MobileTabButton.tsx
+++ b/components/navigation/MobileTabButton.tsx
@@ -15,7 +15,7 @@ export type MobileTabButtonProps = {
 export function MobileTabButton(props: MobileTabButtonProps) {
   const { urlPathname } = usePageContext();
   const { showAdminTab, incrementCount } = useAdminVisibilityContext();
-  const [hidden, setHidden] = useState<boolean>(true);
+  const [hidden, setHidden] = useState<boolean>(props.tab === admin);
   const active = props.tab.active(urlPathname);
 
   useEffect(() => {

--- a/context/AdminVisibility.ts
+++ b/context/AdminVisibility.ts
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react";
+
+export type AdminVisibilityContent = {
+  incrementCount: () => void;
+  showToggle: boolean;
+  toggleAdminTab: () => void;
+  showAdminTab: boolean;
+};
+
+export const AdminVisibilityContext = createContext<AdminVisibilityContent>({
+  incrementCount() {},
+  showToggle: false,
+  toggleAdminTab() {},
+  showAdminTab: false,
+});
+
+export function useAdminVisibilityContext() {
+  return useContext<AdminVisibilityContent>(AdminVisibilityContext);
+}

--- a/pages/settings/+Page.tsx
+++ b/pages/settings/+Page.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 
 import { useData } from "vike-react/useData";
 import { Data } from "@/pages/settings/+data";
@@ -13,19 +13,25 @@ import { SettingsCommute } from "@/pages/settings/SettingsCommute";
 import { SettingsReset } from "@/pages/settings/SettingsReset";
 import { Settings } from "@/shared/settings";
 import { useSettings } from "@/hooks/useSettings";
+import { useAdminVisibilityContext } from "@/context/AdminVisibility";
+import { SettingsAdmin } from "@/pages/settings/SettingsAdmin";
 
 export default function Page() {
   const data = useData<Data>();
+  const { showToggle } = useAdminVisibilityContext();
 
-  const [settings, setSettings] = React.useState(
-    Settings.json.parse(data.settings),
-  );
+  const [showAdmin, setShowAdmin] = useState<boolean>(false);
+  const [settings, setSettings] = useState(Settings.json.parse(data.settings));
 
   const { setSettings: setCookie } = useSettings();
 
   useEffect(() => {
     setCookie(settings);
   }, [settings, setCookie]);
+
+  useEffect(() => {
+    setShowAdmin(showToggle);
+  }, [showToggle]);
 
   return (
     <PageCenterer>
@@ -40,6 +46,9 @@ export default function Page() {
             setSettings={setSettings}
             stations={data.stations}
           />
+          {showAdmin && (
+            <SettingsAdmin settings={settings} setSettings={setSettings} />
+          )}
           <SettingsReset settings={settings} setSettings={setSettings} />
         </Column>
       </PagePadding>

--- a/pages/settings/SettingsAdmin.tsx
+++ b/pages/settings/SettingsAdmin.tsx
@@ -1,0 +1,44 @@
+import React, { Dispatch, SetStateAction } from "react";
+
+import { Column } from "@/components/core/Column";
+import { Text } from "@/components/core/Text";
+import { Settings } from "@/shared/settings";
+import { useAdminVisibilityContext } from "@/context/AdminVisibility";
+
+type SettingsAdminProps = {
+  settings: Settings;
+  setSettings: Dispatch<SetStateAction<Settings>>;
+};
+
+export function SettingsAdmin({ settings, setSettings }: SettingsAdminProps) {
+  const { toggleAdminTab } = useAdminVisibilityContext();
+
+  function handleChange() {
+    setSettings(settings.with({ showAdminTab: !settings.showAdminTab }));
+    toggleAdminTab();
+  }
+  return (
+    <Column>
+      <Text style="custom" className="text-lg font-bold">
+        Admin
+      </Text>
+
+      <label className="flex h-9 cursor-pointer items-center justify-between hover:bg-gray-200 dark:hover:bg-gray-600">
+        <input
+          type="checkbox"
+          value={"showAdminTab"}
+          autoComplete="off"
+          className="peer sr-only"
+          checked={settings.showAdminTab}
+          onChange={handleChange}
+        />
+        <Column className="gap-1">
+          <Text>Show Admin Tab</Text>
+        </Column>
+        <div className="flex h-5 w-9 items-center rounded-full bg-gray-400 p-0.5 transition-all duration-500 ease-in-out peer-checked:bg-blue-600 peer-checked:*:translate-x-full peer-checked:*:border-white peer-disabled:opacity-50 hover:bg-blue-400 hover:peer-checked:bg-blue-500">
+          <div className="size-4 rounded-full border border-gray-300 bg-white transition-all" />
+        </div>
+      </label>
+    </Column>
+  );
+}

--- a/shared/settings.ts
+++ b/shared/settings.ts
@@ -36,9 +36,10 @@ export class Settings {
     readonly enabledCategories: readonly FilterableDisruptionCategory[],
     readonly theme: Theme,
     readonly startPage: Startpage,
+    readonly showAdminTab: boolean,
   ) {}
 
-  static readonly default = new Settings(null, [], "system", "overview");
+  static readonly default = new Settings(null, [], "system", "overview", false);
 
   // Consider that anything we add here is stored in a cookie, and we only have
   // 4KB (4096 characters!) to work with. We also might have to share that limit
@@ -54,6 +55,7 @@ export class Settings {
       enabledCategories: z.string().array().readonly(),
       theme: z.enum(["system", "light", "dark"]),
       startPage: z.enum(["overview", "commute"]),
+      showAdminTab: z.boolean(),
     })
     .transform(
       (obj) =>
@@ -68,6 +70,7 @@ export class Settings {
           ),
           obj.theme ?? "system",
           obj.startPage ?? "overview",
+          obj.showAdminTab ?? false,
         ),
     );
 
@@ -90,6 +93,7 @@ export class Settings {
       enabledCategories: this.enabledCategories,
       theme: this.theme,
       startPage: this.startPage,
+      showAdminTab: this.showAdminTab,
     };
   }
 
@@ -98,17 +102,20 @@ export class Settings {
     enabledCategories,
     theme,
     startPage,
+    showAdminTab,
   }: {
     commute?: { readonly a: number; readonly b: number } | null;
     enabledCategories?: readonly FilterableDisruptionCategory[];
     theme?: Theme;
     startPage?: Startpage;
+    showAdminTab?: boolean;
   }): Settings {
     return new Settings(
       commute !== undefined ? commute : this.commute,
       enabledCategories ?? this.enabledCategories,
       theme ?? this.theme,
       startPage ?? this.startPage,
+      showAdminTab ?? this.showAdminTab,
     );
   }
 


### PR DESCRIPTION
Adds a toggle in the settings page which controls the visibility of the `Admin` tab.

The toggle will appear if the user is on the `Settings` page and presses the `Settings` button on the nav bar at least 5 times or if the toggle was set to `true` in the cookie.

Also made sure that if the user for some reason accesses the page via the URL (`/admin`), that is still shows the tab on the navbar where it otherwise should have been hidden.

Next steps for this would be the protect the route by setting up [authentication](https://vike.dev/auth) and relevant aspects to secure the `admin` route.