### PR TITLE
Standardize colors

### DIFF
--- a/components/calendar/TodayIndicator.tsx
+++ b/components/calendar/TodayIndicator.tsx
@@ -12,15 +12,15 @@ export function TodayIndicator({ column }: TodayIndicatorProps) {
   return (
     <With gridColumn={column}>
       <div className="relative h-4">
-        <div className="bg-calendar-today absolute top-3 left-[50%] size-2 -translate-x-[50%] rotate-45" />
+        <div className="bg-foreground absolute top-3 left-[50%] size-2 -translate-x-[50%] rotate-45" />
         <Column
-          className="bg-calendar-today absolute left-[50%] h-4 -translate-x-[50%] px-2"
+          className="bg-foreground absolute left-[50%] h-4 -translate-x-[50%] px-2"
           align="center"
           justify="center"
         >
           <Text
             style="custom"
-            className="text-calendar-on-today text-xs"
+            className="text-background text-xs"
             align="center"
           >
             TODAY

--- a/components/calendar/utils.ts
+++ b/components/calendar/utils.ts
@@ -2,11 +2,9 @@ import { getDay } from "date-fns";
 import { CalendarMark } from "@/shared/types/calendar-data";
 
 export const dateBoxStyles: Record<CalendarMark, string> = {
-  "no-disruption": "bg-calendar-cell text-calendar-on-cell",
-  "evening-only":
-    "bg-calendar-cell text-calendar-on-cell " +
-    "border-3 border-calendar-accent",
-  "all-day": "bg-calendar-accent text-calendar-on-accent",
+  "no-disruption": "bg-soft",
+  "evening-only": "bg-soft border-3 border-accent",
+  "all-day": "bg-accent text-on-accent",
 };
 
 export function getColumn(date: { year: number; month: number; day: number }) {

--- a/components/common/LoadingSpinner.tsx
+++ b/components/common/LoadingSpinner.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import clsx from "clsx";
 
 const styles = {
-  default: "text-2xl text-slate-500",
+  default: "text-2xl text-foreground",
 };
 
 export type LoadingSpinnerProps = {

--- a/components/common/SimpleButton.tsx
+++ b/components/common/SimpleButton.tsx
@@ -10,7 +10,7 @@ const themes = {
   default: "bg-soft group-hover:bg-soft-hover group-active:bg-soft-active",
   primary:
     "bg-accent group-hover:bg-accent-hover group-active:bg-accent-active text-on-accent",
-  hover: "group-hover:bg-button-bg-hover group-active:bg-button-bg-active",
+  hover: "group-hover:bg-soft-hover group-active:bg-soft-active",
 };
 
 type Content =

--- a/components/common/SimpleButton.tsx
+++ b/components/common/SimpleButton.tsx
@@ -7,10 +7,9 @@ import clsx from "clsx";
 import { Column } from "@/components/core/Column";
 
 const themes = {
-  default:
-    "bg-button-bg group-hover:bg-button-bg-hover group-active:bg-button-bg-active",
+  default: "bg-soft group-hover:bg-soft-hover group-active:bg-soft-active",
   primary:
-    "bg-blue-600 group-hover:bg-blue-700 group-active:bg-blue-900 text-white",
+    "bg-accent group-hover:bg-accent-hover group-active:bg-accent-active text-on-accent",
   hover: "group-hover:bg-button-bg-hover group-active:bg-button-bg-active",
 };
 

--- a/components/core/Link.tsx
+++ b/components/core/Link.tsx
@@ -19,7 +19,7 @@ export function Link(props: LinkProps) {
   if (props.href != null) {
     return (
       <a
-        className="text-link inline underline"
+        className="text-accent inline underline"
         href={props.href}
         target={props.target}
       >
@@ -31,7 +31,7 @@ export function Link(props: LinkProps) {
     // (doesn't do text wrapping or highlighting).
     return (
       <a
-        className="text-link inline underline"
+        className="text-accent inline underline"
         href="#"
         onClick={props.onClick}
       >

--- a/components/core/Text.tsx
+++ b/components/core/Text.tsx
@@ -19,8 +19,8 @@ const sizeScale = [
 
 const styles = {
   regular: "",
-  title: "text-2xl",
-  subtitle: "text-lg",
+  title: "text-2xl text-typography-strong",
+  subtitle: "text-lg text-typography-strong",
   small: "text-sm",
   "mobile-nav-bar": "text-xs",
   "mobile-nav-bar-active": "text-xs text-accent",

--- a/components/core/Text.tsx
+++ b/components/core/Text.tsx
@@ -19,8 +19,8 @@ const sizeScale = [
 
 const styles = {
   regular: "",
-  title: "text-2xl text-typography-strong",
-  subtitle: "text-lg text-typography-strong",
+  title: "text-2xl text-foreground-strong",
+  subtitle: "text-lg text-foreground-strong",
   small: "text-sm",
   "mobile-nav-bar": "text-xs",
   "mobile-nav-bar-active": "text-xs text-accent",

--- a/components/core/Text.tsx
+++ b/components/core/Text.tsx
@@ -23,7 +23,7 @@ const styles = {
   subtitle: "text-lg",
   small: "text-sm",
   "mobile-nav-bar": "text-xs",
-  "mobile-nav-bar-active": "text-xs text-active",
+  "mobile-nav-bar-active": "text-xs text-accent",
 };
 
 type Style =

--- a/components/navigation/BackNavigation.tsx
+++ b/components/navigation/BackNavigation.tsx
@@ -12,7 +12,7 @@ export type BackNavigationProps = {
 
 export function BackNavigation(props: BackNavigationProps) {
   return (
-    <With className="bg-surface border-b-soft-border border-b md:border-b-0">
+    <With className="bg-background border-b-soft-border border-b md:border-b-0">
       <PageCenterer>
         <Row className="px-4 py-3 md:px-6 md:pt-4 md:pb-0">
           <SimpleButton

--- a/components/navigation/BackNavigation.tsx
+++ b/components/navigation/BackNavigation.tsx
@@ -12,7 +12,7 @@ export type BackNavigationProps = {
 
 export function BackNavigation(props: BackNavigationProps) {
   return (
-    <With className="bg-surface border-b-action-secondary border-b md:border-b-0">
+    <With className="bg-surface border-b-soft-border border-b md:border-b-0">
       <PageCenterer>
         <Row className="px-4 py-3 md:px-6 md:pt-4 md:pb-0">
           <SimpleButton

--- a/components/navigation/DesktopNavBar.tsx
+++ b/components/navigation/DesktopNavBar.tsx
@@ -15,13 +15,17 @@ import { Button } from "@/components/core/Button";
 
 export function DesktopNavBar() {
   return (
-    <nav className="bg-surface border-b-soft-border fixed top-0 right-0 left-0 z-50 hidden border-b md:block">
+    <nav className="bg-background border-b-soft-border fixed top-0 right-0 left-0 z-50 hidden border-b md:block">
       <PageCenterer>
         <Grid columns="auto 1fr auto" className="gap-4 px-4">
           <Button href="/">
             <Row align="center" className="gap-2 px-2">
               <Favicon />
-              <Text style="custom" className="text-xl" oneLine>
+              <Text
+                style="custom"
+                className="text-foreground-strong text-xl"
+                oneLine
+              >
                 Is it buses?
               </Text>
             </Row>

--- a/components/navigation/DesktopNavBar.tsx
+++ b/components/navigation/DesktopNavBar.tsx
@@ -15,7 +15,7 @@ import { Button } from "@/components/core/Button";
 
 export function DesktopNavBar() {
   return (
-    <nav className="bg-surface border-b-action-secondary fixed top-0 right-0 left-0 z-50 hidden border-b md:block">
+    <nav className="bg-surface border-b-soft-border fixed top-0 right-0 left-0 z-50 hidden border-b transition-colors md:block">
       <PageCenterer>
         <Grid columns="auto 1fr auto" className="gap-4 px-4">
           <Button href="/">

--- a/components/navigation/DesktopNavBar.tsx
+++ b/components/navigation/DesktopNavBar.tsx
@@ -15,7 +15,7 @@ import { Button } from "@/components/core/Button";
 
 export function DesktopNavBar() {
   return (
-    <nav className="bg-surface border-b-soft-border fixed top-0 right-0 left-0 z-50 hidden border-b transition-colors md:block">
+    <nav className="bg-surface border-b-soft-border fixed top-0 right-0 left-0 z-50 hidden border-b md:block">
       <PageCenterer>
         <Grid columns="auto 1fr auto" className="gap-4 px-4">
           <Button href="/">

--- a/components/navigation/DesktopTabButton.tsx
+++ b/components/navigation/DesktopTabButton.tsx
@@ -31,7 +31,7 @@ export function DesktopTabButton(props: DesktopTabButtonProps) {
     <Button {...action} hidden={hidden}>
       <Row
         className={clsx(
-          "group-hover:bg-action group-active:bg-action-secondary h-12 gap-2 border-y-2 border-transparent px-4",
+          "group-hover:bg-soft-hover group-active:bg-soft-active h-12 gap-2 border-y-2 border-transparent px-4",
           { "border-b-accent": active },
         )}
         align="center"

--- a/components/navigation/DesktopTabButton.tsx
+++ b/components/navigation/DesktopTabButton.tsx
@@ -32,7 +32,7 @@ export function DesktopTabButton(props: DesktopTabButtonProps) {
       <Row
         className={clsx(
           "group-hover:bg-action group-active:bg-action-secondary h-12 gap-2 border-y-2 border-transparent px-4",
-          { "border-b-active": active },
+          { "border-b-accent": active },
         )}
         align="center"
       >

--- a/components/navigation/MobileNavBar.tsx
+++ b/components/navigation/MobileNavBar.tsx
@@ -10,7 +10,7 @@ import { Grid } from "@/components/core/Grid";
 
 export function MobileNavBar() {
   return (
-    <nav className="bg-surface border-t-action-secondary fixed right-0 bottom-0 left-0 z-50 min-w-(--page-min-width) border-t md:hidden">
+    <nav className="bg-surface border-t-soft-border fixed right-0 bottom-0 left-0 z-50 min-w-(--page-min-width) border-t transition-colors md:hidden">
       <Grid className="auto-cols-[1fr] grid-flow-col px-4">
         {[overview, myCommute, admin, settings].map((route) => (
           <MobileTabButton key={route.name} tab={route} />

--- a/components/navigation/MobileNavBar.tsx
+++ b/components/navigation/MobileNavBar.tsx
@@ -10,7 +10,7 @@ import { Grid } from "@/components/core/Grid";
 
 export function MobileNavBar() {
   return (
-    <nav className="bg-surface border-t-soft-border fixed right-0 bottom-0 left-0 z-50 min-w-(--page-min-width) border-t md:hidden">
+    <nav className="bg-background border-t-soft-border fixed right-0 bottom-0 left-0 z-50 min-w-(--page-min-width) border-t md:hidden">
       <Grid className="auto-cols-[1fr] grid-flow-col px-4">
         {[overview, myCommute, admin, settings].map((route) => (
           <MobileTabButton key={route.name} tab={route} />

--- a/components/navigation/MobileNavBar.tsx
+++ b/components/navigation/MobileNavBar.tsx
@@ -10,7 +10,7 @@ import { Grid } from "@/components/core/Grid";
 
 export function MobileNavBar() {
   return (
-    <nav className="bg-surface border-t-soft-border fixed right-0 bottom-0 left-0 z-50 min-w-(--page-min-width) border-t transition-colors md:hidden">
+    <nav className="bg-surface border-t-soft-border fixed right-0 bottom-0 left-0 z-50 min-w-(--page-min-width) border-t md:hidden">
       <Grid className="auto-cols-[1fr] grid-flow-col px-4">
         {[overview, myCommute, admin, settings].map((route) => (
           <MobileTabButton key={route.name} tab={route} />

--- a/components/navigation/MobileTabButton.tsx
+++ b/components/navigation/MobileTabButton.tsx
@@ -32,7 +32,7 @@ export function MobileTabButton(props: MobileTabButtonProps) {
       <Column className={clsx("h-16 gap-1")} align="center" justify="center">
         <With
           className={clsx("-mt-1 rounded-full px-4 py-1 text-xl", {
-            "bg-action text-active": active,
+            "bg-accent-soft text-accent": active,
           })}
         >
           {active ? props.tab.iconFill : props.tab.icon}

--- a/docs/ui-conventions.md
+++ b/docs/ui-conventions.md
@@ -74,7 +74,7 @@ Renders text.
 ```
 
 ```tsx
-<Text style="custom" className="text-sm text-green-800">
+<Text style="custom" className="text-status-green text-sm">
   Some text, where <b>this bit</b> is bold.
 </Text>
 ```
@@ -266,7 +266,7 @@ All icons can be found under `/components/icons`, and the code for an icon compo
 
 Since they're just `<svg>` elements set to a size of `1em` and using `currentColor`, you can style them as you would with text, i.e.:
 
-- To set the color, use `text-[color]`, e.g. `text-white`.
+- To set the color, use `text-[color]`, e.g. `text-accent`.
 
 - To set the size, use `text-[size]`, e.g. `text-2xl`.
 

--- a/docs/ui-conventions.md
+++ b/docs/ui-conventions.md
@@ -222,7 +222,7 @@ A clickable element (supports `onClick` or `href`).
 
 ```tsx
 <Button onClick={() => console.log("Hello.")}>
-  <Column className="bg-slate-200 group-hover:bg-slate-300 group-active:bg-slate-400">
+  <Column className="bg-soft group-hover:bg-soft-hover group-active:bg-soft-active">
     <Text>Hello.</Text>
   </Column>
 </Button>

--- a/layouts/LayoutDefault.tsx
+++ b/layouts/LayoutDefault.tsx
@@ -45,7 +45,7 @@ export default function LayoutDefault({
   );
 
   return (
-    <Column className="bg-surface text-typography min-h-screen transition-colors">
+    <Column className="min-h-screen">
       <AdminVisibilityContext.Provider value={contextValue}>
         <DesktopNavBar />
         <MobileNavBar />

--- a/layouts/LayoutDefault.tsx
+++ b/layouts/LayoutDefault.tsx
@@ -45,7 +45,7 @@ export default function LayoutDefault({
   );
 
   return (
-    <Column className="bg-surface text-typography min-h-screen transition-colors duration-250">
+    <Column className="bg-surface text-typography min-h-screen transition-colors">
       <AdminVisibilityContext.Provider value={contextValue}>
         <DesktopNavBar />
         <MobileNavBar />

--- a/layouts/tailwind.css
+++ b/layouts/tailwind.css
@@ -18,7 +18,14 @@
 @theme {
   --font-sans: "Outfit", sans-serif;
 
-  --color-surface: var(--color-white);
+  --color-*: initial;
+  --color-surface: white;
+  --color-typography: black;
+  --color-soft-border: hsl(220deg 5% 85%);
+  --color-accent: hsl(220deg 100% 40%);
+  --color-accent-soft: hsl(220deg 100% 93%);
+
+  /* --color-surface: var(--color-white);
   --color-surface-secondary: var(--color-white);
   --color-typography: var(--color-black);
   --color-action: var(--color-slate-100);
@@ -30,15 +37,15 @@
   --color-button-bg-active: var(--color-slate-400);
 
   --color-calendar-cell: var(--color-slate-200);
-  --color-calendar-accent: oklch(65% 0.23 35); /* #FC4000 */
+  --color-calendar-accent: oklch(65% 0.23 35);
   --color-calendar-today: var(--color-black);
   --color-calendar-on-cell: var(--color-black);
   --color-calendar-on-accent: var(--color-white);
   --color-calendar-on-today: var(--color-white);
 
-  --color-status-clear: oklch(76.47% 0.2289 146.12); /* #14D64B */
-  --color-status-delays: oklch(77.48% 0.1544 78.87); /* #EAA81F */
-  --color-status-buses: oklch(61.76% 0.2511 28.06); /* #F90514 */
+  --color-status-clear: oklch(76.47% 0.2289 146.12);
+  --color-status-delays: oklch(77.48% 0.1544 78.87);
+  --color-status-buses: oklch(61.76% 0.2511 28.06); */
 
   --leading-*: initial;
   --leading-none: 0em;
@@ -51,22 +58,28 @@
 
 /* Dark mode colours */
 @variant dark {
-  --color-surface: oklch(18.23% 0 0); /* #121212 */
-  --color-surface-secondary: oklch(25% 0 0); /* #222222 */
+  --color-surface: black;
+  --color-typography: white;
+  --color-soft-border: hsl(220deg 5% 20%);
+  --color-accent: hsl(220deg 100% 80%);
+  --color-accent-soft: hsl(220deg 30% 20%);
+
+  /* --color-surface: oklch(18.23% 0 0);
+  --color-surface-secondary: oklch(25% 0 0);
   --color-typography: var(--color-white);
-  --color-action: oklch(27.68% 0 0); /* #282828 */
-  --color-action-secondary: oklch(33.78% 0.0223 256.39); /* #303843 */
-  --color-active: oklch(60.81% 0.2097 267.74); /* #4D74FE */
-  --color-link: oklch(66.18% 0.1648 267.74); /* #678BF7 */
+  --color-action: oklch(27.68% 0 0);
+  --color-action-secondary: oklch(33.78% 0.0223 256.39);
+  --color-active: oklch(60.81% 0.2097 267.74);
+  --color-link: oklch(66.18% 0.1648 267.74);
   --color-button-bg: var(--color-action-secondary);
-  --color-button-bg-hover: oklch(41.02% 0.0223 256.39); /* #434B57 */
-  --color-button-bg-active: oklch(29.02% 0.0223 256.39); /* #242C37 */
+  --color-button-bg-hover: oklch(41.02% 0.0223 256.39);
+  --color-button-bg-active: oklch(29.02% 0.0223 256.39);
   --color-calendar-cell: oklch(28% 0.0223 256.39);
-  --color-calendar-accent: oklch(65% 0.23 35); /* #FC4000 */
+  --color-calendar-accent: oklch(65% 0.23 35);
   --color-calendar-today: var(--color-white);
   --color-calendar-on-cell: var(--color-white);
   --color-calendar-on-accent: var(--color-white);
-  --color-calendar-on-today: var(--color-black);
+  --color-calendar-on-today: var(--color-black); */
 }
 
 /* Override leading to set --line-spacing instead (see ./css/text.css). */

--- a/layouts/tailwind.css
+++ b/layouts/tailwind.css
@@ -21,9 +21,18 @@
   --color-*: initial;
   --color-surface: white;
   --color-typography: black;
-  --color-soft-border: hsl(220deg 5% 85%);
+  --color-soft: hsl(220deg 30% 90%);
+  --color-soft-hover: hsl(220deg 30% 85%);
+  --color-soft-active: hsl(220deg 30% 80%);
+  --color-soft-border: hsl(220deg 30% 85%);
   --color-accent: hsl(220deg 100% 40%);
+  --color-accent-hover: hsl(220deg 100% 50%);
+  --color-accent-active: hsl(220deg 100% 60%);
   --color-accent-soft: hsl(220deg 100% 93%);
+  --color-on-accent: white;
+  --color-status-green: hsl(130, 60%, 40%);
+  --color-status-yellow: hsl(40, 100%, 40%);
+  --color-status-red: hsl(0, 100%, 45%);
 
   /* --color-surface: var(--color-white);
   --color-surface-secondary: var(--color-white);
@@ -60,9 +69,18 @@
 @variant dark {
   --color-surface: black;
   --color-typography: white;
-  --color-soft-border: hsl(220deg 5% 20%);
-  --color-accent: hsl(220deg 100% 80%);
+  --color-soft: hsl(220deg 30% 15%);
+  --color-soft-hover: hsl(220deg 30% 20%);
+  --color-soft-active: hsl(220deg 30% 25%);
+  --color-soft-border: hsl(220deg 30% 20%);
+  --color-accent: hsl(220deg 100% 70%);
+  --color-accent-hover: hsl(220deg 100% 65%);
+  --color-accent-active: hsl(220deg 100% 60%);
   --color-accent-soft: hsl(220deg 30% 20%);
+  --color-on-accent: black;
+  --color-status-green: hsl(130, 60%, 60%);
+  --color-status-yellow: hsl(40, 100%, 60%);
+  --color-status-red: hsl(0, 100%, 70%);
 
   /* --color-surface: oklch(18.23% 0 0);
   --color-surface-secondary: oklch(25% 0 0);

--- a/layouts/tailwind.css
+++ b/layouts/tailwind.css
@@ -19,7 +19,7 @@
   --font-sans: "Outfit", sans-serif;
 
   --color-*: initial;
-  --color-background: hsl(220deg 20% 100%);
+  --color-background: hsl(220deg 20% 100%); /* Update pages/utils.ts too! */
   --color-foreground: hsl(220deg 20% 20%);
   --color-foreground-strong: hsl(220deg 20% 0%);
   --color-soft: hsl(220deg 20% 93%);
@@ -29,7 +29,7 @@
   --color-accent: hsl(220deg 100% 40%);
   --color-accent-hover: hsl(220deg 100% 50%);
   --color-accent-active: hsl(220deg 100% 60%);
-  --color-accent-soft: hsl(220deg 100% 90%);
+  --color-accent-soft: hsl(220deg 100% 95%);
   --color-on-accent: hsl(220deg 20% 100%);
   --color-status-green: hsl(130, 60%, 40%);
   --color-status-yellow: hsl(40, 100%, 40%);
@@ -49,17 +49,17 @@
 
 /* Dark mode colours */
 @variant dark {
-  --color-background: hsl(220deg 20% 0%);
+  --color-background: hsl(220deg 20% 5%); /* Update pages/utils.ts too! */
   --color-foreground: hsl(220deg 20% 80%);
   --color-foreground-strong: hsl(220deg 20% 100%);
   --color-soft: hsl(220deg 20% 15%);
   --color-soft-hover: hsl(220deg 20% 20%);
   --color-soft-active: hsl(220deg 20% 25%);
   --color-soft-border: hsl(220deg 20% 20%);
-  --color-accent: hsl(220deg 100% 70%);
-  --color-accent-hover: hsl(220deg 100% 65%);
-  --color-accent-active: hsl(220deg 100% 60%);
-  --color-accent-soft: hsl(220deg 50% 20%);
+  --color-accent: hsl(220deg 100% 73%);
+  --color-accent-hover: hsl(220deg 80% 68%);
+  --color-accent-active: hsl(220deg 70% 63%);
+  --color-accent-soft: hsl(220deg 50% 17%);
   --color-on-accent: hsl(220deg 20% 0%);
   --color-status-green: hsl(130, 60%, 60%);
   --color-status-yellow: hsl(40, 100%, 60%);

--- a/layouts/tailwind.css
+++ b/layouts/tailwind.css
@@ -20,7 +20,8 @@
 
   --color-*: initial;
   --color-surface: white;
-  --color-typography: black;
+  --color-typography: hsl(220deg 30% 20%);
+  --color-typography-strong: black;
   --color-soft: hsl(220deg 30% 90%);
   --color-soft-hover: hsl(220deg 30% 85%);
   --color-soft-active: hsl(220deg 30% 80%);
@@ -37,28 +38,6 @@
   --color-switch-hover: hsl(220deg 30% 70%);
   --color-switch-knob: hsl(220deg 0% 100%);
 
-  /* --color-surface: var(--color-white);
-  --color-surface-secondary: var(--color-white);
-  --color-typography: var(--color-black);
-  --color-action: var(--color-slate-100);
-  --color-action-secondary: var(--color-slate-200);
-  --color-active: var(--color-blue-800);
-  --color-link: var(--color-blue-700);
-  --color-button-bg: var(--color-slate-200);
-  --color-button-bg-hover: var(--color-slate-300);
-  --color-button-bg-active: var(--color-slate-400);
-
-  --color-calendar-cell: var(--color-slate-200);
-  --color-calendar-accent: oklch(65% 0.23 35);
-  --color-calendar-today: var(--color-black);
-  --color-calendar-on-cell: var(--color-black);
-  --color-calendar-on-accent: var(--color-white);
-  --color-calendar-on-today: var(--color-white);
-
-  --color-status-clear: oklch(76.47% 0.2289 146.12);
-  --color-status-delays: oklch(77.48% 0.1544 78.87);
-  --color-status-buses: oklch(61.76% 0.2511 28.06); */
-
   --leading-*: initial;
   --leading-none: 0em;
   --leading-tight: 0.25em;
@@ -71,7 +50,8 @@
 /* Dark mode colours */
 @variant dark {
   --color-surface: black;
-  --color-typography: white;
+  --color-typography: hsl(220deg 30% 80%);
+  --color-typography-strong: white;
   --color-soft: hsl(220deg 30% 15%);
   --color-soft-hover: hsl(220deg 30% 20%);
   --color-soft-active: hsl(220deg 30% 25%);
@@ -87,23 +67,6 @@
   --color-switch: hsl(220deg 30% 30%);
   --color-switch-hover: hsl(220deg 30% 35%);
   --color-switch-knob: hsl(220deg 0% 100%);
-
-  /* --color-surface: oklch(18.23% 0 0);
-  --color-surface-secondary: oklch(25% 0 0);
-  --color-typography: var(--color-white);
-  --color-action: oklch(27.68% 0 0);
-  --color-action-secondary: oklch(33.78% 0.0223 256.39);
-  --color-active: oklch(60.81% 0.2097 267.74);
-  --color-link: oklch(66.18% 0.1648 267.74);
-  --color-button-bg: var(--color-action-secondary);
-  --color-button-bg-hover: oklch(41.02% 0.0223 256.39);
-  --color-button-bg-active: oklch(29.02% 0.0223 256.39);
-  --color-calendar-cell: oklch(28% 0.0223 256.39);
-  --color-calendar-accent: oklch(65% 0.23 35);
-  --color-calendar-today: var(--color-white);
-  --color-calendar-on-cell: var(--color-white);
-  --color-calendar-on-accent: var(--color-white);
-  --color-calendar-on-today: var(--color-black); */
 }
 
 /* Override leading to set --line-spacing instead (see ./css/text.css). */

--- a/layouts/tailwind.css
+++ b/layouts/tailwind.css
@@ -33,6 +33,9 @@
   --color-status-green: hsl(130, 60%, 40%);
   --color-status-yellow: hsl(40, 100%, 40%);
   --color-status-red: hsl(0, 100%, 45%);
+  --color-switch: hsl(220deg 30% 75%);
+  --color-switch-hover: hsl(220deg 30% 70%);
+  --color-switch-knob: hsl(220deg 0% 100%);
 
   /* --color-surface: var(--color-white);
   --color-surface-secondary: var(--color-white);
@@ -81,6 +84,9 @@
   --color-status-green: hsl(130, 60%, 60%);
   --color-status-yellow: hsl(40, 100%, 60%);
   --color-status-red: hsl(0, 100%, 70%);
+  --color-switch: hsl(220deg 30% 30%);
+  --color-switch-hover: hsl(220deg 30% 35%);
+  --color-switch-knob: hsl(220deg 0% 100%);
 
   /* --color-surface: oklch(18.23% 0 0);
   --color-surface-secondary: oklch(25% 0 0);

--- a/layouts/tailwind.css
+++ b/layouts/tailwind.css
@@ -19,13 +19,13 @@
   --font-sans: "Outfit", sans-serif;
 
   --color-*: initial;
-  --color-surface: hsl(220deg 20% 100%);
-  --color-typography: hsl(220deg 20% 20%);
-  --color-typography-strong: hsl(220deg 20% 0%);
-  --color-soft: hsl(220deg 20% 90%);
-  --color-soft-hover: hsl(220deg 20% 85%);
-  --color-soft-active: hsl(220deg 20% 80%);
-  --color-soft-border: hsl(220deg 20% 85%);
+  --color-background: hsl(220deg 20% 100%);
+  --color-foreground: hsl(220deg 20% 20%);
+  --color-foreground-strong: hsl(220deg 20% 0%);
+  --color-soft: hsl(220deg 20% 93%);
+  --color-soft-hover: hsl(220deg 20% 89%);
+  --color-soft-active: hsl(220deg 20% 85%);
+  --color-soft-border: hsl(220deg 20% 89%);
   --color-accent: hsl(220deg 100% 40%);
   --color-accent-hover: hsl(220deg 100% 50%);
   --color-accent-active: hsl(220deg 100% 60%);
@@ -34,8 +34,8 @@
   --color-status-green: hsl(130, 60%, 40%);
   --color-status-yellow: hsl(40, 100%, 40%);
   --color-status-red: hsl(0, 100%, 45%);
-  --color-switch: hsl(220deg 20% 75%);
-  --color-switch-hover: hsl(220deg 20% 70%);
+  --color-switch: hsl(220deg 20% 70%);
+  --color-switch-hover: hsl(220deg 20% 65%);
   --color-switch-knob: hsl(220deg 0% 100%);
 
   --leading-*: initial;
@@ -49,9 +49,9 @@
 
 /* Dark mode colours */
 @variant dark {
-  --color-surface: hsl(220deg 20% 0%);
-  --color-typography: hsl(220deg 20% 80%);
-  --color-typography-strong: hsl(220deg 20% 100%);
+  --color-background: hsl(220deg 20% 0%);
+  --color-foreground: hsl(220deg 20% 80%);
+  --color-foreground-strong: hsl(220deg 20% 100%);
   --color-soft: hsl(220deg 20% 15%);
   --color-soft-hover: hsl(220deg 20% 20%);
   --color-soft-active: hsl(220deg 20% 25%);
@@ -64,8 +64,8 @@
   --color-status-green: hsl(130, 60%, 60%);
   --color-status-yellow: hsl(40, 100%, 60%);
   --color-status-red: hsl(0, 100%, 70%);
-  --color-switch: hsl(220deg 20% 30%);
-  --color-switch-hover: hsl(220deg 20% 35%);
+  --color-switch: hsl(220deg 20% 35%);
+  --color-switch-hover: hsl(220deg 20% 40%);
   --color-switch-knob: hsl(220deg 20% 100%);
 }
 

--- a/layouts/tailwind.css
+++ b/layouts/tailwind.css
@@ -19,23 +19,23 @@
   --font-sans: "Outfit", sans-serif;
 
   --color-*: initial;
-  --color-surface: white;
-  --color-typography: hsl(220deg 30% 20%);
-  --color-typography-strong: black;
-  --color-soft: hsl(220deg 30% 90%);
-  --color-soft-hover: hsl(220deg 30% 85%);
-  --color-soft-active: hsl(220deg 30% 80%);
-  --color-soft-border: hsl(220deg 30% 85%);
+  --color-surface: hsl(220deg 20% 100%);
+  --color-typography: hsl(220deg 20% 20%);
+  --color-typography-strong: hsl(220deg 20% 0%);
+  --color-soft: hsl(220deg 20% 90%);
+  --color-soft-hover: hsl(220deg 20% 85%);
+  --color-soft-active: hsl(220deg 20% 80%);
+  --color-soft-border: hsl(220deg 20% 85%);
   --color-accent: hsl(220deg 100% 40%);
   --color-accent-hover: hsl(220deg 100% 50%);
   --color-accent-active: hsl(220deg 100% 60%);
-  --color-accent-soft: hsl(220deg 100% 93%);
-  --color-on-accent: white;
+  --color-accent-soft: hsl(220deg 100% 90%);
+  --color-on-accent: hsl(220deg 20% 100%);
   --color-status-green: hsl(130, 60%, 40%);
   --color-status-yellow: hsl(40, 100%, 40%);
   --color-status-red: hsl(0, 100%, 45%);
-  --color-switch: hsl(220deg 30% 75%);
-  --color-switch-hover: hsl(220deg 30% 70%);
+  --color-switch: hsl(220deg 20% 75%);
+  --color-switch-hover: hsl(220deg 20% 70%);
   --color-switch-knob: hsl(220deg 0% 100%);
 
   --leading-*: initial;
@@ -49,24 +49,24 @@
 
 /* Dark mode colours */
 @variant dark {
-  --color-surface: black;
-  --color-typography: hsl(220deg 30% 80%);
-  --color-typography-strong: white;
-  --color-soft: hsl(220deg 30% 15%);
-  --color-soft-hover: hsl(220deg 30% 20%);
-  --color-soft-active: hsl(220deg 30% 25%);
-  --color-soft-border: hsl(220deg 30% 20%);
+  --color-surface: hsl(220deg 20% 0%);
+  --color-typography: hsl(220deg 20% 80%);
+  --color-typography-strong: hsl(220deg 20% 100%);
+  --color-soft: hsl(220deg 20% 15%);
+  --color-soft-hover: hsl(220deg 20% 20%);
+  --color-soft-active: hsl(220deg 20% 25%);
+  --color-soft-border: hsl(220deg 20% 20%);
   --color-accent: hsl(220deg 100% 70%);
   --color-accent-hover: hsl(220deg 100% 65%);
   --color-accent-active: hsl(220deg 100% 60%);
-  --color-accent-soft: hsl(220deg 30% 20%);
-  --color-on-accent: black;
+  --color-accent-soft: hsl(220deg 50% 20%);
+  --color-on-accent: hsl(220deg 20% 0%);
   --color-status-green: hsl(130, 60%, 60%);
   --color-status-yellow: hsl(40, 100%, 60%);
   --color-status-red: hsl(0, 100%, 70%);
-  --color-switch: hsl(220deg 30% 30%);
-  --color-switch-hover: hsl(220deg 30% 35%);
-  --color-switch-knob: hsl(220deg 0% 100%);
+  --color-switch: hsl(220deg 20% 30%);
+  --color-switch-hover: hsl(220deg 20% 35%);
+  --color-switch-knob: hsl(220deg 20% 100%);
 }
 
 /* Override leading to set --line-spacing instead (see ./css/text.css). */

--- a/pages/+Head.tsx
+++ b/pages/+Head.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { usePageContext } from "vike-react/usePageContext";
+import { getThemeColor } from "@/pages/utils";
 
 export default function HeadDefault() {
   const { custom } = usePageContext();
@@ -14,12 +15,12 @@ export default function HeadDefault() {
       <meta
         name="theme-color"
         media="(prefers-color-scheme: light)"
-        content={custom.settings.theme === "dark" ? "#121212" : "#ffffff"}
+        content={getThemeColor(custom.settings.theme, "light")}
       />
       <meta
         name="theme-color"
         media="(prefers-color-scheme: dark)"
-        content={custom.settings.theme === "light" ? "#ffffff" : "#121212"}
+        content={getThemeColor(custom.settings.theme, "dark")}
       />
       <RegisterPwa />
     </>

--- a/pages/+onAfterRenderHtml.ts
+++ b/pages/+onAfterRenderHtml.ts
@@ -1,5 +1,6 @@
 import { PageContext } from "vike/types";
 import { useConfig } from "vike-react/useConfig";
+import clsx from "clsx";
 
 export default (pageContext: PageContext) => {
   const { theme } = pageContext.custom.settings;
@@ -9,8 +10,7 @@ export default (pageContext: PageContext) => {
   // Configured here as it would cause the screen to flash from light to dark mode
   config({
     htmlAttributes: {
-      class:
-        theme === "dark" ? "dark" : theme === "light" ? "light" : undefined,
+      class: clsx("bg-surface text-typography", theme),
     },
   });
 };

--- a/pages/+onAfterRenderHtml.ts
+++ b/pages/+onAfterRenderHtml.ts
@@ -10,7 +10,7 @@ export default (pageContext: PageContext) => {
   // Configured here as it would cause the screen to flash from light to dark mode
   config({
     htmlAttributes: {
-      class: clsx("bg-surface text-typography", theme),
+      class: clsx("bg-background text-foreground", theme),
     },
   });
 };

--- a/pages/disruption/@id/Disruption.tsx
+++ b/pages/disruption/@id/Disruption.tsx
@@ -48,7 +48,7 @@ export function Disruption(props: DisruptionProps) {
       <Calendar data={calendar} />
 
       {/* TODO: Draw the disruption on the map. */}
-      <With className="border-soft-border bg-surface-secondary rounded-md border">
+      <With className="border-soft-border bg-background-secondary rounded-md border">
         <Map />
       </With>
     </Column>

--- a/pages/disruption/@id/Disruption.tsx
+++ b/pages/disruption/@id/Disruption.tsx
@@ -48,7 +48,7 @@ export function Disruption(props: DisruptionProps) {
       <Calendar data={calendar} />
 
       {/* TODO: Draw the disruption on the map. */}
-      <With className="border-action-secondary bg-surface-secondary rounded-md border">
+      <With className="border-soft-border bg-surface-secondary rounded-md border">
         <Map />
       </With>
     </Column>

--- a/pages/disruption/@id/Disruption.tsx
+++ b/pages/disruption/@id/Disruption.tsx
@@ -48,7 +48,7 @@ export function Disruption(props: DisruptionProps) {
       <Calendar data={calendar} />
 
       {/* TODO: Draw the disruption on the map. */}
-      <With className="border-soft-border bg-background-secondary rounded-md border">
+      <With className="border-soft-border rounded-md border">
         <Map />
       </With>
     </Column>

--- a/pages/index/+Page.tsx
+++ b/pages/index/+Page.tsx
@@ -31,20 +31,20 @@ export default function Page() {
           <Row align="center" className="max-w-md gap-1.5" wrap>
             <Row align="center" className="flex-grow gap-1.5">
               <Text>Show</Text>
-              <select className="dark:bg-background-secondary border-soft-border flex-grow rounded border">
+              <select className="border-soft-border flex-grow rounded border">
                 <option value={"all"}>all disruptions</option>
               </select>
             </Row>
             <Row align="center" className="flex-grow gap-1.5">
               <Text>occurring</Text>
-              <select className="dark:bg-background-secondary border-soft-border flex-grow rounded border">
+              <select className="border-soft-border flex-grow rounded border">
                 <option value={"now"}>right now</option>
               </select>
             </Row>
           </Row>
           <Spacer h="4" />
 
-          <With className="bg-background-secondary border-soft-border rounded-md border">
+          <With className="border-soft-border rounded-md border">
             <Map />
           </With>
           <Spacer h="4" />

--- a/pages/index/+Page.tsx
+++ b/pages/index/+Page.tsx
@@ -31,25 +31,25 @@ export default function Page() {
           <Row align="center" className="max-w-md gap-1.5" wrap>
             <Row align="center" className="flex-grow gap-1.5">
               <Text>Show</Text>
-              <select className="dark:bg-surface-secondary flex-grow rounded border border-black">
+              <select className="dark:bg-surface-secondary border-soft-border flex-grow rounded border">
                 <option value={"all"}>all disruptions</option>
               </select>
             </Row>
             <Row align="center" className="flex-grow gap-1.5">
               <Text>occurring</Text>
-              <select className="dark:bg-surface-secondary flex-grow rounded border border-black">
+              <select className="dark:bg-surface-secondary border-soft-border flex-grow rounded border">
                 <option value={"now"}>right now</option>
               </select>
             </Row>
           </Row>
           <Spacer h="4" />
 
-          <With className="bg-surface-secondary border-action-secondary rounded-md border">
+          <With className="bg-surface-secondary border-soft-border rounded-md border">
             <Map />
           </With>
           <Spacer h="4" />
 
-          <Column>
+          <Column className="divide-soft-border divide-y-1">
             {disruptions.map((x) => (
               <DisruptionButton key={x.id} data={x} />
             ))}

--- a/pages/index/+Page.tsx
+++ b/pages/index/+Page.tsx
@@ -31,20 +31,20 @@ export default function Page() {
           <Row align="center" className="max-w-md gap-1.5" wrap>
             <Row align="center" className="flex-grow gap-1.5">
               <Text>Show</Text>
-              <select className="dark:bg-surface-secondary border-soft-border flex-grow rounded border">
+              <select className="dark:bg-background-secondary border-soft-border flex-grow rounded border">
                 <option value={"all"}>all disruptions</option>
               </select>
             </Row>
             <Row align="center" className="flex-grow gap-1.5">
               <Text>occurring</Text>
-              <select className="dark:bg-surface-secondary border-soft-border flex-grow rounded border">
+              <select className="dark:bg-background-secondary border-soft-border flex-grow rounded border">
                 <option value={"now"}>right now</option>
               </select>
             </Row>
           </Row>
           <Spacer h="4" />
 
-          <With className="bg-surface-secondary border-soft-border rounded-md border">
+          <With className="bg-background-secondary border-soft-border rounded-md border">
             <Map />
           </With>
           <Spacer h="4" />

--- a/pages/index/DisruptionButton.tsx
+++ b/pages/index/DisruptionButton.tsx
@@ -60,7 +60,7 @@ function DisruptionIcon({
   } else if (icon === "altered-route") {
     return (
       <div className="bg-soft flex size-8 items-center justify-center rounded-full">
-        <MingcuteRouteFill className="color-accent size-full p-1" />
+        <MingcuteRouteFill className="text-accent size-full p-1" />
       </div>
     );
   } else {

--- a/pages/index/DisruptionButton.tsx
+++ b/pages/index/DisruptionButton.tsx
@@ -20,7 +20,7 @@ export function DisruptionButton(props: DisruptionButtonProps) {
       <Grid
         columns="2rem 1fr 1.5rem"
         align="center"
-        className="group-active:bg-action gap-2 p-2 transition-colors"
+        className="group-active:bg-soft-active group-hover:bg-soft-hover gap-2 p-2"
       >
         <DisruptionIcon icon={icon} />
         <Column className="gap-1.5">
@@ -49,22 +49,22 @@ function DisruptionIcon({
 }) {
   if (icon.startsWith("line")) {
     return (
-      <div className="flex size-8 items-center justify-center overflow-hidden rounded-full bg-gray-200">
-        <div className="grid h-full w-2 rotate-45 bg-pink-400" />
+      <div className="bg-soft flex size-8 items-center justify-center overflow-hidden rounded-full">
+        <div className="bg-accent grid h-full w-2 rotate-45" />
       </div>
     );
   } else if (icon === "cross") {
     return <MingcuteCloseCircleFill className="size-8" />;
   } else if (icon === "altered-route") {
     return (
-      <div className="flex size-8 items-center justify-center rounded-full bg-gray-200">
-        <MingcuteRouteFill className="color-cyan-500 size-full p-1" />
+      <div className="bg-soft flex size-8 items-center justify-center rounded-full">
+        <MingcuteRouteFill className="color-accent size-full p-1" />
       </div>
     );
   } else {
     // An empty circle. (TODO: Maybe we can define some default icon, idk.)
     return (
-      <div className="flex size-8 items-center justify-center overflow-hidden rounded-full bg-gray-200" />
+      <div className="bg-soft flex size-8 items-center justify-center overflow-hidden rounded-full" />
     );
   }
 }

--- a/pages/index/DisruptionButton.tsx
+++ b/pages/index/DisruptionButton.tsx
@@ -29,7 +29,9 @@ export function DisruptionButton(props: DisruptionButtonProps) {
               {headline}
             </Text>
           )}
-          <Text>{subject}</Text>
+          <Text style="custom" className="text-foreground-strong">
+            {subject}
+          </Text>
           {period != null && (
             <Text style="custom" className="text-xs">
               {period}

--- a/pages/index/LineButton.tsx
+++ b/pages/index/LineButton.tsx
@@ -33,7 +33,7 @@ export function LineButton({ line }: LineButtonProps) {
       <Grid
         columns="auto 1fr auto"
         align="center"
-        className="group-active:bg-action gap-2 p-1 transition-colors lg:p-2"
+        className="group-active:bg-soft-active group-hover:bg-soft-hover gap-2 p-1 lg:p-2"
       >
         <Row align="center" className="gap-2">
           <div

--- a/pages/index/LineButton.tsx
+++ b/pages/index/LineButton.tsx
@@ -16,15 +16,15 @@ type LineButtonProps = {
 };
 
 const bgClassMapping: Record<OverviewPageLineStatusColor, string> = {
-  green: "bg-status-clear",
-  yellow: "bg-status-delays",
-  red: "bg-status-buses",
+  green: "bg-status-green",
+  yellow: "bg-status-yellow",
+  red: "bg-status-red",
 };
 
 const textClassMapping: Record<OverviewPageLineStatusColor, string> = {
-  green: "text-status-clear",
-  yellow: "text-status-delays",
-  red: "text-status-buses",
+  green: "text-status-green",
+  yellow: "text-status-yellow",
+  red: "text-status-red",
 };
 
 export function LineButton({ line }: LineButtonProps) {

--- a/pages/index/Lines.tsx
+++ b/pages/index/Lines.tsx
@@ -13,7 +13,7 @@ type LinesProps = {
 export function Lines(props: LinesProps) {
   return (
     <Column className="gap-2">
-      <Text style="custom" className="text-typography-strong text-lg font-bold">
+      <Text style="custom" className="text-foreground-strong text-lg font-bold">
         {props.title}
       </Text>
       <Column className="divide-soft-border divide-y-1">

--- a/pages/index/Lines.tsx
+++ b/pages/index/Lines.tsx
@@ -13,7 +13,7 @@ type LinesProps = {
 export function Lines(props: LinesProps) {
   return (
     <Column className="gap-2">
-      <Text style="custom" className="text-lg font-bold">
+      <Text style="custom" className="text-typography-strong text-lg font-bold">
         {props.title}
       </Text>
       <Column className="divide-soft-border divide-y-1">

--- a/pages/index/Lines.tsx
+++ b/pages/index/Lines.tsx
@@ -16,7 +16,7 @@ export function Lines(props: LinesProps) {
       <Text style="custom" className="text-lg font-bold">
         {props.title}
       </Text>
-      <Column className="divide-action-secondary divide-y-1">
+      <Column className="divide-soft-border divide-y-1">
         {props.lines.map((line) => (
           <LineButton key={line.id} line={line} />
         ))}

--- a/pages/line/@id/+Page.tsx
+++ b/pages/line/@id/+Page.tsx
@@ -25,7 +25,7 @@ export default function Page() {
                   on the <b>{line.name}</b> line?
                 </Text>
 
-                <hr className="border-slate-200" />
+                <hr className="border-soft-border" />
 
                 <Column className="gap-6">
                   <Text style="title">Buses replace trains...</Text>

--- a/pages/settings/SettingsAdmin.tsx
+++ b/pages/settings/SettingsAdmin.tsx
@@ -19,7 +19,7 @@ export function SettingsAdmin({ settings, setSettings }: SettingsAdminProps) {
   }
   return (
     <Column>
-      <Text style="custom" className="text-typography-strong text-lg font-bold">
+      <Text style="custom" className="text-foreground-strong text-lg font-bold">
         Admin
       </Text>
 
@@ -35,7 +35,7 @@ export function SettingsAdmin({ settings, setSettings }: SettingsAdminProps) {
         <Column className="gap-1">
           <Text>Show Admin Tab</Text>
         </Column>
-        <div className="bg-switch peer-checked:bg-accent hover:bg-switch-hover hover:peer-checked:bg-accent-hover flex h-5 w-9 items-center rounded-full p-0.5 transition-all ease-in-out peer-checked:*:translate-x-full peer-disabled:opacity-50">
+        <div className="bg-switch peer-checked:bg-accent hover:bg-switch-hover hover:peer-checked:bg-accent-hover flex h-5 w-9 items-center rounded-full p-0.5 transition-transform ease-in-out peer-checked:*:translate-x-full peer-disabled:opacity-50">
           <div className="bg-switch-knob size-4 rounded-full transition-all" />
         </div>
       </label>

--- a/pages/settings/SettingsAdmin.tsx
+++ b/pages/settings/SettingsAdmin.tsx
@@ -35,8 +35,8 @@ export function SettingsAdmin({ settings, setSettings }: SettingsAdminProps) {
         <Column className="gap-1">
           <Text>Show Admin Tab</Text>
         </Column>
-        <div className="flex h-5 w-9 items-center rounded-full bg-gray-400 p-0.5 transition-all duration-500 ease-in-out peer-checked:bg-blue-600 peer-checked:*:translate-x-full peer-checked:*:border-white peer-disabled:opacity-50 hover:bg-blue-400 hover:peer-checked:bg-blue-500">
-          <div className="size-4 rounded-full border border-gray-300 bg-white transition-all" />
+        <div className="bg-switch peer-checked:bg-accent hover:bg-switch-hover hover:peer-checked:bg-accent-hover flex h-5 w-9 items-center rounded-full p-0.5 transition-all ease-in-out peer-checked:*:translate-x-full peer-disabled:opacity-50">
+          <div className="bg-switch-knob size-4 rounded-full transition-all" />
         </div>
       </label>
     </Column>

--- a/pages/settings/SettingsAdmin.tsx
+++ b/pages/settings/SettingsAdmin.tsx
@@ -19,7 +19,7 @@ export function SettingsAdmin({ settings, setSettings }: SettingsAdminProps) {
   }
   return (
     <Column>
-      <Text style="custom" className="text-lg font-bold">
+      <Text style="custom" className="text-typography-strong text-lg font-bold">
         Admin
       </Text>
 

--- a/pages/settings/SettingsAdmin.tsx
+++ b/pages/settings/SettingsAdmin.tsx
@@ -23,7 +23,7 @@ export function SettingsAdmin({ settings, setSettings }: SettingsAdminProps) {
         Admin
       </Text>
 
-      <label className="flex h-9 cursor-pointer items-center justify-between hover:bg-gray-200 dark:hover:bg-gray-600">
+      <label className="hover:bg-soft-hover flex h-9 cursor-pointer items-center justify-between">
         <input
           type="checkbox"
           value={"showAdminTab"}

--- a/pages/settings/SettingsCommute.tsx
+++ b/pages/settings/SettingsCommute.tsx
@@ -26,7 +26,7 @@ export function SettingsCommute({
 
   return (
     <Column>
-      <Text style="custom" className="text-typography-strong text-lg font-bold">
+      <Text style="custom" className="text-foreground-strong text-lg font-bold">
         Commute
       </Text>
       <Spacer h="2" />

--- a/pages/settings/SettingsCommute.tsx
+++ b/pages/settings/SettingsCommute.tsx
@@ -26,7 +26,7 @@ export function SettingsCommute({
 
   return (
     <Column>
-      <Text style="custom" className="text-lg font-bold">
+      <Text style="custom" className="text-typography-strong text-lg font-bold">
         Commute
       </Text>
       <Spacer h="2" />

--- a/pages/settings/SettingsDisruptions.tsx
+++ b/pages/settings/SettingsDisruptions.tsx
@@ -57,7 +57,7 @@ export function SettingsDisruptions({
 
   return (
     <Column>
-      <Text style="custom" className="text-typography-strong text-lg font-bold">
+      <Text style="custom" className="text-foreground-strong text-lg font-bold">
         Disruptions to show
       </Text>
       <Spacer h="2" />
@@ -92,7 +92,7 @@ export function SettingsDisruptions({
                 </Text>
               )}
             </Column>
-            <div className="bg-switch peer-checked:bg-accent hover:bg-switch-hover hover:peer-checked:bg-accent-hover flex h-5 w-9 items-center rounded-full p-0.5 transition-all ease-in-out peer-checked:*:translate-x-full peer-disabled:opacity-50">
+            <div className="bg-switch peer-checked:bg-accent hover:bg-switch-hover hover:peer-checked:bg-accent-hover flex h-5 w-9 items-center rounded-full p-0.5 transition-transform ease-in-out peer-checked:*:translate-x-full peer-disabled:opacity-50">
               <div className="bg-switch-knob size-4 rounded-full transition-all" />
             </div>
           </label>

--- a/pages/settings/SettingsDisruptions.tsx
+++ b/pages/settings/SettingsDisruptions.tsx
@@ -57,7 +57,7 @@ export function SettingsDisruptions({
 
   return (
     <Column>
-      <Text style="custom" className="text-lg font-bold">
+      <Text style="custom" className="text-typography-strong text-lg font-bold">
         Disruptions to show
       </Text>
       <Spacer h="2" />

--- a/pages/settings/SettingsDisruptions.tsx
+++ b/pages/settings/SettingsDisruptions.tsx
@@ -66,7 +66,7 @@ export function SettingsDisruptions({
         {allCategories.map((category) => (
           <label
             key={category}
-            className="flex h-9 cursor-pointer items-center justify-between hover:bg-gray-200 dark:hover:bg-gray-600"
+            className="hover:bg-soft-hover flex h-9 cursor-pointer items-center justify-between"
           >
             <input
               type="checkbox"

--- a/pages/settings/SettingsDisruptions.tsx
+++ b/pages/settings/SettingsDisruptions.tsx
@@ -92,8 +92,8 @@ export function SettingsDisruptions({
                 </Text>
               )}
             </Column>
-            <div className="flex h-5 w-9 items-center rounded-full bg-gray-400 p-0.5 transition-all duration-500 ease-in-out peer-checked:bg-blue-600 peer-checked:*:translate-x-full peer-checked:*:border-white peer-disabled:opacity-50 hover:bg-blue-400 hover:peer-checked:bg-blue-500">
-              <div className="size-4 rounded-full border border-gray-300 bg-white transition-all" />
+            <div className="bg-switch peer-checked:bg-accent hover:bg-switch-hover hover:peer-checked:bg-accent-hover flex h-5 w-9 items-center rounded-full p-0.5 transition-all ease-in-out peer-checked:*:translate-x-full peer-disabled:opacity-50">
+              <div className="bg-switch-knob size-4 rounded-full transition-all" />
             </div>
           </label>
         ))}

--- a/pages/settings/SettingsHome.tsx
+++ b/pages/settings/SettingsHome.tsx
@@ -31,7 +31,7 @@ export function SettingsHome({ settings, setSettings }: HomepageProps) {
 
   return (
     <Column>
-      <Text style="custom" className="text-lg font-bold">
+      <Text style="custom" className="text-typography-strong text-lg font-bold">
         Start page
       </Text>
       <Spacer h="2" />

--- a/pages/settings/SettingsHome.tsx
+++ b/pages/settings/SettingsHome.tsx
@@ -40,7 +40,7 @@ export function SettingsHome({ settings, setSettings }: HomepageProps) {
         {homepageOptions.map((option) => (
           <label
             key={option}
-            className="flex cursor-pointer gap-2 py-1 hover:bg-gray-200 dark:hover:bg-gray-600"
+            className="hover:bg-soft-hover flex cursor-pointer gap-2 py-1"
           >
             <input
               type="radio"

--- a/pages/settings/SettingsHome.tsx
+++ b/pages/settings/SettingsHome.tsx
@@ -48,6 +48,7 @@ export function SettingsHome({ settings, setSettings }: HomepageProps) {
               value={option}
               checked={(settings.startPage as string).includes(option)}
               onChange={() => updateStart(option)}
+              className="accent-accent"
             />
             <Text>{formattedHomepage[option].name}</Text>
           </label>

--- a/pages/settings/SettingsHome.tsx
+++ b/pages/settings/SettingsHome.tsx
@@ -31,7 +31,7 @@ export function SettingsHome({ settings, setSettings }: HomepageProps) {
 
   return (
     <Column>
-      <Text style="custom" className="text-typography-strong text-lg font-bold">
+      <Text style="custom" className="text-foreground-strong text-lg font-bold">
         Start page
       </Text>
       <Spacer h="2" />

--- a/pages/settings/SettingsReset.tsx
+++ b/pages/settings/SettingsReset.tsx
@@ -20,7 +20,7 @@ export function SettingsReset({ setSettings }: SettingsResetProps) {
 
   return (
     <Column>
-      <Text style="custom" className="text-typography-strong text-lg font-bold">
+      <Text style="custom" className="text-foreground-strong text-lg font-bold">
         Reset
       </Text>
       <Spacer h="2" />

--- a/pages/settings/SettingsReset.tsx
+++ b/pages/settings/SettingsReset.tsx
@@ -19,7 +19,7 @@ export function SettingsReset({ setSettings }: SettingsResetProps) {
 
   return (
     <Column>
-      <Text style="custom" className="text-lg font-bold">
+      <Text style="custom" className="text-typography-strong text-lg font-bold">
         Reset
       </Text>
       <Spacer h="2" />

--- a/pages/settings/SettingsReset.tsx
+++ b/pages/settings/SettingsReset.tsx
@@ -5,6 +5,7 @@ import { Settings } from "@/shared/settings";
 import { Column } from "@/components/core/Column";
 import { Text } from "@/components/core/Text";
 import { Spacer } from "@/components/core/Spacer";
+import { applyTheme } from "@/pages/settings/utils";
 
 export type SettingsResetProps = {
   settings: Settings;
@@ -14,7 +15,7 @@ export type SettingsResetProps = {
 export function SettingsReset({ setSettings }: SettingsResetProps) {
   function handleResetCookies() {
     setSettings(Settings.default);
-    document.documentElement.className = Settings.default.theme;
+    applyTheme(Settings.default.theme);
   }
 
   return (

--- a/pages/settings/SettingsTheme.tsx
+++ b/pages/settings/SettingsTheme.tsx
@@ -3,22 +3,20 @@ import React from "react";
 import { Column } from "@/components/core/Column";
 import { Text } from "@/components/core/Text";
 import { Spacer } from "@/components/core/Spacer";
-import { Settings, Theme } from "@/shared/settings";
+import { Settings, Theme, themes } from "@/shared/settings";
+import { applyTheme } from "@/pages/settings/utils";
 
-const themeOptions = ["system", "light", "dark"] as const;
-
-const formattedTheme: Record<(typeof themeOptions)[number], { name: string }> =
-  {
-    system: {
-      name: "Auto",
-    },
-    light: {
-      name: "Light",
-    },
-    dark: {
-      name: "Dark",
-    },
-  };
+const formattedTheme: Record<(typeof themes)[number], { name: string }> = {
+  system: {
+    name: "Auto",
+  },
+  light: {
+    name: "Light",
+  },
+  dark: {
+    name: "Dark",
+  },
+};
 
 export type SettingsResetProps = {
   settings: Settings;
@@ -27,23 +25,8 @@ export type SettingsResetProps = {
 
 export function SettingsTheme({ settings, setSettings }: SettingsResetProps) {
   function updateTheme(theme: Theme) {
-    setSettings(settings.with({ theme: theme }));
-    themeOptions.forEach((x) => {
-      document.documentElement.classList.toggle(x, theme === x);
-    });
-
-    // Update status bar theme for PWA
-    document.querySelectorAll("meta[name=theme-color]").forEach((meta) => {
-      const colour =
-        theme === "system"
-          ? meta.getAttribute("media") === "(prefers-color-scheme: light)"
-            ? "#ffffff"
-            : "#121212"
-          : window
-              .getComputedStyle(document.documentElement)
-              .getPropertyValue("--color-surface");
-      meta.setAttribute("content", colour);
-    });
+    setSettings(settings.with({ theme }));
+    applyTheme(theme);
   }
 
   return (
@@ -53,7 +36,7 @@ export function SettingsTheme({ settings, setSettings }: SettingsResetProps) {
       </Text>
       <Spacer h="2" />
       <Column>
-        {themeOptions.map((theme) => (
+        {themes.map((theme) => (
           <label
             key={theme}
             className="flex cursor-pointer gap-2 py-1 hover:bg-gray-200 dark:hover:bg-gray-600"

--- a/pages/settings/SettingsTheme.tsx
+++ b/pages/settings/SettingsTheme.tsx
@@ -28,7 +28,9 @@ export type SettingsResetProps = {
 export function SettingsTheme({ settings, setSettings }: SettingsResetProps) {
   function updateTheme(theme: Theme) {
     setSettings(settings.with({ theme: theme }));
-    document.documentElement.className = theme;
+    themeOptions.forEach((x) => {
+      document.documentElement.classList.toggle(x, theme === x);
+    });
 
     // Update status bar theme for PWA
     document.querySelectorAll("meta[name=theme-color]").forEach((meta) => {
@@ -46,7 +48,7 @@ export function SettingsTheme({ settings, setSettings }: SettingsResetProps) {
 
   return (
     <Column>
-      <Text style="custom" className="text-lg font-bold">
+      <Text style="custom" className="text-typography-strong text-lg font-bold">
         Colour theme
       </Text>
       <Spacer h="2" />

--- a/pages/settings/SettingsTheme.tsx
+++ b/pages/settings/SettingsTheme.tsx
@@ -31,7 +31,7 @@ export function SettingsTheme({ settings, setSettings }: SettingsResetProps) {
 
   return (
     <Column>
-      <Text style="custom" className="text-typography-strong text-lg font-bold">
+      <Text style="custom" className="text-foreground-strong text-lg font-bold">
         Colour theme
       </Text>
       <Spacer h="2" />

--- a/pages/settings/SettingsTheme.tsx
+++ b/pages/settings/SettingsTheme.tsx
@@ -62,6 +62,7 @@ export function SettingsTheme({ settings, setSettings }: SettingsResetProps) {
               value={theme}
               checked={(settings.theme as string).includes(theme)}
               onChange={() => updateTheme(theme)}
+              className="accent-accent"
             />
             <Text>{formattedTheme[theme].name}</Text>
           </label>

--- a/pages/settings/SettingsTheme.tsx
+++ b/pages/settings/SettingsTheme.tsx
@@ -39,7 +39,7 @@ export function SettingsTheme({ settings, setSettings }: SettingsResetProps) {
         {themes.map((theme) => (
           <label
             key={theme}
-            className="flex cursor-pointer gap-2 py-1 hover:bg-gray-200 dark:hover:bg-gray-600"
+            className="hover:bg-soft-hover flex cursor-pointer gap-2 py-1"
           >
             <input
               type="radio"

--- a/pages/settings/utils.ts
+++ b/pages/settings/utils.ts
@@ -14,7 +14,7 @@ export function applyTheme(theme: Theme) {
           : "#121212"
         : window
             .getComputedStyle(document.documentElement)
-            .getPropertyValue("--color-surface");
+            .getPropertyValue("--color-background");
     meta.setAttribute("content", colour);
   });
 }

--- a/pages/settings/utils.ts
+++ b/pages/settings/utils.ts
@@ -1,0 +1,20 @@
+import { Theme, themes } from "@/shared/settings";
+
+export function applyTheme(theme: Theme) {
+  themes.forEach((x) => {
+    document.documentElement.classList.toggle(x, theme === x);
+  });
+
+  // Update status bar theme for PWA
+  document.querySelectorAll("meta[name=theme-color]").forEach((meta) => {
+    const colour =
+      theme === "system"
+        ? meta.getAttribute("media") === "(prefers-color-scheme: light)"
+          ? "#ffffff"
+          : "#121212"
+        : window
+            .getComputedStyle(document.documentElement)
+            .getPropertyValue("--color-surface");
+    meta.setAttribute("content", colour);
+  });
+}

--- a/pages/settings/utils.ts
+++ b/pages/settings/utils.ts
@@ -1,4 +1,5 @@
 import { Theme, themes } from "@/shared/settings";
+import { getThemeColor } from "@/pages/utils";
 
 export function applyTheme(theme: Theme) {
   themes.forEach((x) => {
@@ -7,14 +8,12 @@ export function applyTheme(theme: Theme) {
 
   // Update status bar theme for PWA
   document.querySelectorAll("meta[name=theme-color]").forEach((meta) => {
-    const colour =
-      theme === "system"
-        ? meta.getAttribute("media") === "(prefers-color-scheme: light)"
-          ? "#ffffff"
-          : "#121212"
-        : window
-            .getComputedStyle(document.documentElement)
-            .getPropertyValue("--color-background");
-    meta.setAttribute("content", colour);
+    const preferredColorScheme = extractPreferredColorScheme(meta);
+    meta.setAttribute("content", getThemeColor(theme, preferredColorScheme));
   });
+}
+
+function extractPreferredColorScheme(meta: Element) {
+  const media = meta.getAttribute("media");
+  return media === "(prefers-color-scheme: light)" ? "light" : "dark";
 }

--- a/pages/trip/ChooseTripPage.tsx
+++ b/pages/trip/ChooseTripPage.tsx
@@ -58,7 +58,7 @@ function StationSelect(props: StationSelectProps) {
       <select
         id={props.id}
         name={props.id}
-        className="dark:bg-background-secondary border-soft-border rounded border"
+        className="border-soft-border rounded border"
       >
         {props.stations.map((station) => (
           <option key={station.id} value={station.id}>

--- a/pages/trip/ChooseTripPage.tsx
+++ b/pages/trip/ChooseTripPage.tsx
@@ -58,7 +58,7 @@ function StationSelect(props: StationSelectProps) {
       <select
         id={props.id}
         name={props.id}
-        className="dark:bg-surface-secondary border-soft-border rounded border"
+        className="dark:bg-background-secondary border-soft-border rounded border"
       >
         {props.stations.map((station) => (
           <option key={station.id} value={station.id}>

--- a/pages/trip/ChooseTripPage.tsx
+++ b/pages/trip/ChooseTripPage.tsx
@@ -58,7 +58,7 @@ function StationSelect(props: StationSelectProps) {
       <select
         id={props.id}
         name={props.id}
-        className="dark:bg-surface-secondary rounded border border-black"
+        className="dark:bg-surface-secondary border-soft-border rounded border"
       >
         {props.stations.map((station) => (
           <option key={station.id} value={station.id}>

--- a/pages/trip/DisplayTripPage.tsx
+++ b/pages/trip/DisplayTripPage.tsx
@@ -44,7 +44,7 @@ export function DisplayTripPage(props: DisplayTripPageProps) {
             {!props.data.isCurrentCommute && (
               <Column
                 align="left"
-                className="gap-4 border border-slate-200 p-4"
+                className="border-soft-border gap-4 border p-4"
               >
                 <Text style="subtitle">Check this trip often?</Text>
                 <Text>Have it show in the My Commute tab by default.</Text>
@@ -55,7 +55,7 @@ export function DisplayTripPage(props: DisplayTripPageProps) {
                   />
                 ) : (
                   <Row
-                    className="h-8 gap-2 border border-slate-200 px-4"
+                    className="border-soft-border h-8 gap-2 border px-4"
                     align="center"
                   >
                     <MingcuteCheckLine />

--- a/pages/utils.ts
+++ b/pages/utils.ts
@@ -1,0 +1,15 @@
+import { Theme } from "@/shared/settings";
+
+const themeColorLight = "hsl(220deg 20% 100%)";
+const themeColorDark = "hsl(220deg 20% 5%)";
+
+export function getThemeColor(
+  theme: Theme,
+  preferredColorScheme: "light" | "dark",
+) {
+  const resolvedTheme = theme === "system" ? preferredColorScheme : theme;
+  return {
+    light: themeColorLight,
+    dark: themeColorDark,
+  }[resolvedTheme];
+}

--- a/shared/settings.ts
+++ b/shared/settings.ts
@@ -26,7 +26,9 @@ export const filterableDisruptionCategories = [
 export type FilterableDisruptionCategory =
   (typeof filterableDisruptionCategories)[number];
 
-export type Theme = "system" | "light" | "dark";
+export const themes = ["system", "light", "dark"] as const;
+
+export type Theme = (typeof themes)[number];
 
 export type Startpage = "overview" | "commute";
 


### PR DESCRIPTION
### Changes
- Remove all default Tailwind color classes, meaning only the colors defined in `tailwind.css` can be used. (I'll refer to these as "themed colors" as they come with dark mode variants.)
- Migrate all components using these old colors to the themed colors.
- Rename some themed colors to better reflect their possible uses, e.g.:
  - `color-typography` to `color-foreground`, to cover use cases like icons and the "Today" indicator.
  - `color-link` to `color-accent`, to cover use cases like primary buttons.
  - The `color-action` family to `color-soft`, to cover use cases like the calendar cell background.
- Tweak some colors, and use `hsl` to define them rather than `oklch`. `hsl` has better browser support (and VS Code support).
- Set styles like `bg-background` and `text-foreground` on the `<html>` instead of the layout, so that Android navigation bar (bottom of the screen) adopts them.
- Fix bug where `theme-color` is not updated when the user resets their settings.

### Controversial changes
In this PR I've removed all uses of `transition-colors`. This was used to provide a smoother transition between dark/light mode. My justification is:
- The dark/light mode animation was not entirely smooth. Any element using a color class that didn't also use `transition-colors` would not animate, making the animation look a little janky. To fix, we'd need to add `transition-colors` each time we set colors (or globally using custom CSS, I guess).
- Even fast 100ms animations still slow down the time between an action occuring and the visual feedback displaying. This means if `transition-colors` is added to `<Button>` elements, they appear less responsive (a.k.a. laggy).

If you feel strongly that we should keep the transition, let me know! 💣

### Screenshots

#### Before
<img width="150" src="https://github.com/user-attachments/assets/34e1dfe5-9bcb-4494-ba3f-b15fea5b02a7">
<img width="150" src="https://github.com/user-attachments/assets/e6dca796-9545-4cfb-9cfc-e6a92253babd">
<img width="150" src="https://github.com/user-attachments/assets/473223d7-42eb-4759-9194-ba6cb47ec1c0">
<img width="150" src="https://github.com/user-attachments/assets/f381a12e-2bf6-431d-8fa0-5225106300e6">

#### After

<img width="150" src="https://github.com/user-attachments/assets/9dc8f5b9-aec1-48e9-8e8b-e6b918f9c69d">
<img width="150" src="https://github.com/user-attachments/assets/882d3502-350b-4e7a-95b6-bcd068306240">
<img width="150" src="https://github.com/user-attachments/assets/0624d65e-8d7c-4286-9c0a-0c3ac4a82df7">
<img width="150" src="https://github.com/user-attachments/assets/97f7e403-abf0-49ad-8cb3-50ee8dec9210">
