### PR TITLE
Text styles

### DIFF
--- a/components/calendar/TodayIndicator.tsx
+++ b/components/calendar/TodayIndicator.tsx
@@ -18,11 +18,7 @@ export function TodayIndicator({ column }: TodayIndicatorProps) {
           align="center"
           justify="center"
         >
-          <Text
-            style="custom"
-            className="text-background text-xs"
-            align="center"
-          >
+          <Text style="tiny-inverted" align="center">
             TODAY
           </Text>
         </Column>

--- a/components/common/Marquee.tsx
+++ b/components/common/Marquee.tsx
@@ -5,9 +5,35 @@ export type MarqueeProps = {
 };
 
 export function Marquee(props: MarqueeProps) {
+  const outerRef = React.useRef<HTMLDivElement>(null);
+  const innerRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    const outerDiv = outerRef.current;
+    const innerDiv = innerRef.current;
+    if (outerDiv == null || innerDiv == null) return;
+
+    const observer = new ResizeObserver(() => setupMarquee(outerDiv, innerDiv));
+    observer.observe(outerDiv);
+    observer.observe(innerDiv);
+    setupMarquee(outerDiv, innerDiv);
+
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <div className="overflow-hidden">
-      <div className="_marquee">{props.children}</div>
+    <div className="_marquee" ref={outerRef}>
+      <div ref={innerRef}>{props.children}</div>
     </div>
   );
+}
+
+function setupMarquee(outerDiv: HTMLDivElement, innerDiv: HTMLDivElement) {
+  outerDiv.classList.toggle(
+    "active",
+    innerDiv.clientWidth > outerDiv.clientWidth,
+  );
+  const duration = (innerDiv.clientWidth + outerDiv.clientWidth) * 0.03;
+  outerDiv.style.setProperty("--duration", `${duration}s`);
+  outerDiv.style.setProperty("--width", `${outerDiv.clientWidth}px`);
 }

--- a/components/common/Marquee.tsx
+++ b/components/common/Marquee.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export type MarqueeProps = {
+  children: React.ReactNode;
+};
+
+export function Marquee(props: MarqueeProps) {
+  return (
+    <div className="overflow-hidden">
+      <div className="_marquee">{props.children}</div>
+    </div>
+  );
+}

--- a/components/core/Text.tsx
+++ b/components/core/Text.tsx
@@ -19,9 +19,16 @@ const sizeScale = [
 
 const styles = {
   regular: "",
-  title: "text-2xl text-foreground-strong",
-  subtitle: "text-lg text-foreground-strong",
+  title: "text-4xl text-foreground-strong",
+  subtitle: "text-xl text-foreground-strong",
+
   small: "text-sm",
+  // TODO: [DS] Can't use these yet because there's no way to apply marquee
+  // class. Should it be a prop on the <Text> component?
+  // "small-red": "text-sm",
+  // "small-yellow": "text-sm",
+  // "small-green": "text-sm",
+
   "mobile-nav-bar": "text-xs",
   "mobile-nav-bar-active": "text-xs text-accent",
 };

--- a/components/core/Text.tsx
+++ b/components/core/Text.tsx
@@ -28,11 +28,10 @@ const styles = {
   "small-yellow": "text-sm text-status-yellow",
   "small-red": "text-sm text-status-red",
 
+  tiny: "text-xs",
   "tiny-inverted": "text-xs text-background",
   "tiny-weak": "text-xs text-foreground-weak",
-
-  "mobile-nav-bar": "text-xs",
-  "mobile-nav-bar-active": "text-xs text-accent",
+  "tiny-accent": "text-xs text-accent",
 };
 
 type Style =

--- a/components/core/Text.tsx
+++ b/components/core/Text.tsx
@@ -19,7 +19,8 @@ const sizeScale = [
 
 const styles = {
   regular: "",
-  title: "text-4xl text-foreground-strong",
+  megatitle: "text-4xl text-foreground-strong",
+  title: "text-2xl text-foreground-strong",
   subtitle: "text-xl text-foreground-strong",
 
   small: "text-sm",
@@ -28,6 +29,9 @@ const styles = {
   // "small-red": "text-sm",
   // "small-yellow": "text-sm",
   // "small-green": "text-sm",
+
+  "tiny-inverted": "text-xs text-background",
+  "tiny-weak": "text-xs text-foreground-weak",
 
   "mobile-nav-bar": "text-xs",
   "mobile-nav-bar-active": "text-xs text-accent",

--- a/components/core/Text.tsx
+++ b/components/core/Text.tsx
@@ -24,11 +24,9 @@ const styles = {
   subtitle: "text-xl text-foreground-strong",
 
   small: "text-sm",
-  // TODO: [DS] Can't use these yet because there's no way to apply marquee
-  // class. Should it be a prop on the <Text> component?
-  // "small-red": "text-sm",
-  // "small-yellow": "text-sm",
-  // "small-green": "text-sm",
+  "small-green": "text-sm text-status-green",
+  "small-yellow": "text-sm text-status-yellow",
+  "small-red": "text-sm text-status-red",
 
   "tiny-inverted": "text-xs text-background",
   "tiny-weak": "text-xs text-foreground-weak",

--- a/components/navigation/DesktopNavBar.tsx
+++ b/components/navigation/DesktopNavBar.tsx
@@ -28,11 +28,7 @@ export function DesktopNavBar() {
           <Button href="/">
             <Row align="center" className="gap-2 px-2">
               <Favicon />
-              <Text
-                style="custom"
-                className="text-foreground-strong text-xl"
-                oneLine
-              >
+              <Text style="subtitle" oneLine>
                 Is it buses?
               </Text>
             </Row>

--- a/components/navigation/MobileTabButton.tsx
+++ b/components/navigation/MobileTabButton.tsx
@@ -26,10 +26,7 @@ export function MobileTabButton(props: MobileTabButtonProps) {
         >
           {active ? props.tab.iconFill : props.tab.icon}
         </With>
-        <Text
-          style={active ? "mobile-nav-bar-active" : "mobile-nav-bar"}
-          oneLine
-        >
+        <Text style={active ? "tiny-accent" : "tiny"} oneLine>
           {props.tab.name}
         </Text>
       </Column>

--- a/docs/ui-conventions.md
+++ b/docs/ui-conventions.md
@@ -74,7 +74,7 @@ Renders text.
 ```
 
 ```tsx
-<Text style="custom" className="text-status-green text-sm">
+<Text style="custom" className="text-status-green text-xl">
   Some text, where <b>this bit</b> is bold.
 </Text>
 ```

--- a/docs/ui-conventions.md
+++ b/docs/ui-conventions.md
@@ -74,7 +74,7 @@ Renders text.
 ```
 
 ```tsx
-<Text style="custom" className="text-status-green text-xl">
+<Text style="custom" className="text-status-green text-sm">
   Some text, where <b>this bit</b> is bold.
 </Text>
 ```

--- a/layouts/css/marquee.css
+++ b/layouts/css/marquee.css
@@ -1,7 +1,5 @@
-.marquee {
-  display: inline-block;
-  min-width: 100%; /* This is to prevent shorter text from needing to animate */
-  white-space: nowrap;
+._marquee {
+  min-width: max-content;
   animation: marqueeAnimation 8s ease-in-out infinite;
 }
 

--- a/layouts/css/marquee.css
+++ b/layouts/css/marquee.css
@@ -1,15 +1,20 @@
 ._marquee {
-  min-width: max-content;
-  animation: marqueeAnimation 8s ease-in-out infinite;
+  --duration: 0;
+  --width: 0;
+  overflow: hidden;
+}
+._marquee > div {
+  width: max-content;
+}
+._marquee.active > div {
+  animation: _marquee-keyframes var(--duration) linear infinite;
 }
 
-@keyframes marqueeAnimation {
-  20% {
-    transform: translateX(0);
-    margin-left: 0;
+@keyframes _marquee-keyframes {
+  0% {
+    transform: translateX(var(--width));
   }
-  80% {
+  100% {
     transform: translateX(-100%);
-    margin-left: 100%;
   }
 }

--- a/layouts/tailwind.css
+++ b/layouts/tailwind.css
@@ -102,3 +102,8 @@ html {
     cursor: pointer;
   }
 }
+
+b,
+strong {
+  color: var(--color-foreground-strong);
+}

--- a/layouts/tailwind.css
+++ b/layouts/tailwind.css
@@ -20,8 +20,9 @@
 
   --color-*: initial;
   --color-background: hsl(220deg 20% 100%); /* Update pages/utils.ts too! */
-  --color-foreground: hsl(220deg 20% 20%);
+  --color-foreground: hsl(220deg 20% 15%);
   --color-foreground-strong: hsl(220deg 20% 0%);
+  --color-foreground-weak: hsl(220deg 20% 30%);
   --color-soft: hsl(220deg 20% 93%);
   --color-soft-hover: hsl(220deg 20% 89%);
   --color-soft-active: hsl(220deg 20% 85%);
@@ -50,8 +51,9 @@
 /* Dark mode colours */
 @variant dark {
   --color-background: hsl(220deg 20% 5%); /* Update pages/utils.ts too! */
-  --color-foreground: hsl(220deg 20% 80%);
+  --color-foreground: hsl(220deg 20% 85%);
   --color-foreground-strong: hsl(220deg 20% 100%);
+  --color-foreground-weak: hsl(220deg 20% 70%);
   --color-soft: hsl(220deg 20% 15%);
   --color-soft-hover: hsl(220deg 20% 20%);
   --color-soft-active: hsl(220deg 20% 25%);

--- a/pages/admin/+Page.tsx
+++ b/pages/admin/+Page.tsx
@@ -17,7 +17,7 @@ export default function Page() {
     <PageCenterer>
       <PagePadding>
         <Column className="gap-4">
-          <Text style="title">Admin</Text>
+          <Text style="megatitle">Admin</Text>
           <Text>
             {historicalAlertsCount}{" "}
             {historicalAlertsCount === 1

--- a/pages/commute/+Page.tsx
+++ b/pages/commute/+Page.tsx
@@ -18,7 +18,7 @@ export default function Page() {
         <Column align="left">
           {commute != null && (
             <>
-              <Text style="title">Is it buses...</Text>
+              <Text style="megatitle">Is it buses...</Text>
               <Spacer h="4" />
               <Text>
                 between <b>{commute.stationAName}</b> and{" "}
@@ -28,7 +28,7 @@ export default function Page() {
           )}
           {commute == null && (
             <>
-              <Text style="title">My commute</Text>
+              <Text style="megatitle">My commute</Text>
               <Spacer h="4" />
               <Text>
                 Tell us the two stations you&apos;re travelling between, and

--- a/pages/disruption/@id/NotFound.tsx
+++ b/pages/disruption/@id/NotFound.tsx
@@ -6,7 +6,7 @@ import { Column } from "@/components/core/Column";
 export function NotFound() {
   return (
     <Column align="center" justify="center" className="h-full gap-4">
-      <Text style="custom" align="center" className="md:text-2xl">
+      <Text align="center">
         {
           "It looks like the train left without you because we couldn't find the disruption you were looking for."
         }

--- a/pages/index/+Page.tsx
+++ b/pages/index/+Page.tsx
@@ -21,7 +21,7 @@ export default function Page() {
     <PageCenterer>
       <PagePadding>
         <Column>
-          <Text style="title">Is it buses?</Text>
+          <Text style="megatitle">Is it buses?</Text>
           <Spacer h="4" />
 
           <Text>Melbourne&apos;s train disruptions, visualised</Text>

--- a/pages/index/+Page.tsx
+++ b/pages/index/+Page.tsx
@@ -25,7 +25,7 @@ export default function Page() {
           <Spacer h="4" />
 
           <Text>Melbourne&apos;s train disruptions, visualised</Text>
-          <Spacer h="6" />
+          <Spacer h="8" />
 
           {/* TODO: determine the options for both selects */}
           <Row align="center" className="max-w-md gap-1.5" wrap>
@@ -47,18 +47,19 @@ export default function Page() {
           <With className="border-soft-border rounded-md border">
             <Map />
           </With>
-          <Spacer h="4" />
+          <Spacer h="2" />
 
           <Column className="divide-soft-border divide-y-1">
             {disruptions.map((x) => (
               <DisruptionButton key={x.id} data={x} />
             ))}
           </Column>
-          <Spacer h="4" />
+          <Spacer h="8" />
 
-          <Lines title="Suburban lines" lines={suburban} />
-          <Spacer h="4" />
-          <Lines title="Regional lines" lines={regional} />
+          <div className="grid gap-8 md:grid-cols-2">
+            <Lines title="Suburban lines" lines={suburban} />
+            <Lines title="Regional lines" lines={regional} />
+          </div>
         </Column>
       </PagePadding>
     </PageCenterer>

--- a/pages/index/DisruptionButton.tsx
+++ b/pages/index/DisruptionButton.tsx
@@ -18,9 +18,9 @@ export function DisruptionButton(props: DisruptionButtonProps) {
   return (
     <Button href={`/disruption/${id}`}>
       <Grid
-        columns="1.5rem 1fr auto"
+        columns="2rem 1fr 1.5rem"
         align="center"
-        className="group-active:bg-soft-active group-hover:bg-soft-hover -mx-4 gap-2 px-4 py-2"
+        className="group-active:bg-soft-active group-hover:bg-soft-hover gap-2 p-2"
       >
         <DisruptionIcon icon={icon} />
         <Column className="gap-2">
@@ -28,7 +28,7 @@ export function DisruptionButton(props: DisruptionButtonProps) {
           <Text>{subject}</Text>
           {period != null && <Text style="tiny-weak">{period}</Text>}
         </Column>
-        <MingcuteRightLine className="-mr-1" />
+        <MingcuteRightLine className="size-full" />
       </Grid>
     </Button>
   );
@@ -41,22 +41,22 @@ function DisruptionIcon({
 }) {
   if (icon.startsWith("line")) {
     return (
-      <div className="bg-soft flex size-6 items-center justify-center overflow-hidden rounded-full">
-        <div className="bg-accent grid h-full w-1.5 rotate-45" />
+      <div className="bg-soft flex size-8 items-center justify-center overflow-hidden rounded-full">
+        <div className="bg-accent grid h-full w-2 rotate-45" />
       </div>
     );
   } else if (icon === "cross") {
-    return <MingcuteCloseCircleFill className="size-6" />;
+    return <MingcuteCloseCircleFill className="size-8" />;
   } else if (icon === "altered-route") {
     return (
-      <div className="bg-soft flex size-6 items-center justify-center rounded-full">
+      <div className="bg-soft flex size-8 items-center justify-center rounded-full">
         <MingcuteRouteFill className="text-accent size-full p-1" />
       </div>
     );
   } else {
     // An empty circle. (TODO: Maybe we can define some default icon, idk.)
     return (
-      <div className="bg-soft flex size-6 items-center justify-center overflow-hidden rounded-full" />
+      <div className="bg-soft flex size-8 items-center justify-center overflow-hidden rounded-full" />
     );
   }
 }

--- a/pages/index/DisruptionButton.tsx
+++ b/pages/index/DisruptionButton.tsx
@@ -23,20 +23,10 @@ export function DisruptionButton(props: DisruptionButtonProps) {
         className="group-active:bg-soft-active group-hover:bg-soft-hover -mx-4 gap-2 px-4 py-2"
       >
         <DisruptionIcon icon={icon} />
-        <Column className="gap-1.5">
-          {headline != null && (
-            <Text style="custom" className="text-xs">
-              {headline}
-            </Text>
-          )}
-          <Text style="custom" className="text-foreground-strong">
-            {subject}
-          </Text>
-          {period != null && (
-            <Text style="custom" className="text-xs">
-              {period}
-            </Text>
-          )}
+        <Column className="gap-2">
+          {headline != null && <Text style="tiny-weak">{headline}</Text>}
+          <Text>{subject}</Text>
+          {period != null && <Text style="tiny-weak">{period}</Text>}
         </Column>
         <MingcuteRightLine className="-mr-1" />
       </Grid>

--- a/pages/index/DisruptionButton.tsx
+++ b/pages/index/DisruptionButton.tsx
@@ -18,9 +18,9 @@ export function DisruptionButton(props: DisruptionButtonProps) {
   return (
     <Button href={`/disruption/${id}`}>
       <Grid
-        columns="2rem 1fr 1.5rem"
+        columns="1.5rem 1fr auto"
         align="center"
-        className="group-active:bg-soft-active group-hover:bg-soft-hover gap-2 p-2"
+        className="group-active:bg-soft-active group-hover:bg-soft-hover -mx-4 gap-2 px-4 py-2"
       >
         <DisruptionIcon icon={icon} />
         <Column className="gap-1.5">
@@ -38,7 +38,7 @@ export function DisruptionButton(props: DisruptionButtonProps) {
             </Text>
           )}
         </Column>
-        <MingcuteRightLine className="size-full" />
+        <MingcuteRightLine className="-mr-1" />
       </Grid>
     </Button>
   );
@@ -51,22 +51,22 @@ function DisruptionIcon({
 }) {
   if (icon.startsWith("line")) {
     return (
-      <div className="bg-soft flex size-8 items-center justify-center overflow-hidden rounded-full">
-        <div className="bg-accent grid h-full w-2 rotate-45" />
+      <div className="bg-soft flex size-6 items-center justify-center overflow-hidden rounded-full">
+        <div className="bg-accent grid h-full w-1.5 rotate-45" />
       </div>
     );
   } else if (icon === "cross") {
-    return <MingcuteCloseCircleFill className="size-8" />;
+    return <MingcuteCloseCircleFill className="size-6" />;
   } else if (icon === "altered-route") {
     return (
-      <div className="bg-soft flex size-8 items-center justify-center rounded-full">
+      <div className="bg-soft flex size-6 items-center justify-center rounded-full">
         <MingcuteRouteFill className="text-accent size-full p-1" />
       </div>
     );
   } else {
     // An empty circle. (TODO: Maybe we can define some default icon, idk.)
     return (
-      <div className="bg-soft flex size-8 items-center justify-center overflow-hidden rounded-full" />
+      <div className="bg-soft flex size-6 items-center justify-center overflow-hidden rounded-full" />
     );
   }
 }

--- a/pages/index/LineButton.tsx
+++ b/pages/index/LineButton.tsx
@@ -6,26 +6,25 @@ import { Grid } from "@/components/core/Grid";
 import { Text } from "@/components/core/Text";
 import { Button } from "@/components/core/Button";
 import { MingcuteRightLine } from "@/components/icons/MingcuteRightLine";
-import {
-  OverviewPageLineData,
-  OverviewPageLineStatusColor,
-} from "@/shared/types/overview-page";
+import { OverviewPageLineData } from "@/shared/types/overview-page";
+import { Marquee } from "@/components/common/Marquee";
+import { With } from "@/components/core/With";
 
 type LineButtonProps = {
   line: OverviewPageLineData;
 };
 
-const bgClassMapping: Record<OverviewPageLineStatusColor, string> = {
+const bgClassMapping = {
   green: "bg-status-green",
   yellow: "bg-status-yellow",
   red: "bg-status-red",
-};
+} as const;
 
-const textClassMapping: Record<OverviewPageLineStatusColor, string> = {
-  green: "text-status-green",
-  yellow: "text-status-yellow",
-  red: "text-status-red",
-};
+const textStyleMapping = {
+  green: "small-green",
+  yellow: "small-yellow",
+  red: "small-red",
+} as const;
 
 export function LineButton({ line }: LineButtonProps) {
   return (
@@ -46,16 +45,13 @@ export function LineButton({ line }: LineButtonProps) {
             {line.name}
           </Text>
         </Row>
-        <div className="flex overflow-hidden text-end">
-          <span
-            className={clsx(
-              "marquee text-sm",
-              textClassMapping[line.statusColor],
-            )}
-          >
-            {line.status}
-          </span>
-        </div>
+        <With className="justify-self-end">
+          <Marquee>
+            <Text style={textStyleMapping[line.statusColor]}>
+              {line.status}
+            </Text>
+          </Marquee>
+        </With>
         <MingcuteRightLine />
       </Grid>
     </Button>

--- a/pages/index/LineButton.tsx
+++ b/pages/index/LineButton.tsx
@@ -33,7 +33,7 @@ export function LineButton({ line }: LineButtonProps) {
       <Grid
         columns="auto 1fr auto"
         align="center"
-        className="group-active:bg-soft-active group-hover:bg-soft-hover gap-2 p-1 lg:p-2"
+        className="group-active:bg-soft-active group-hover:bg-soft-hover -mx-4 gap-2 px-4 py-1"
       >
         <Row align="center" className="gap-2">
           <div
@@ -42,21 +42,21 @@ export function LineButton({ line }: LineButtonProps) {
               bgClassMapping[line.statusColor],
             )}
           />
-          <Text oneLine style="custom" className="text-sm lg:text-base">
+          <Text oneLine style="small">
             {line.name}
           </Text>
         </Row>
         <div className="flex overflow-hidden text-end">
           <span
             className={clsx(
-              "marquee text-sm lg:text-base",
+              "marquee text-sm",
               textClassMapping[line.statusColor],
             )}
           >
             {line.status}
           </span>
         </div>
-        <MingcuteRightLine />
+        <MingcuteRightLine className="-mr-1" />
       </Grid>
     </Button>
   );

--- a/pages/index/LineButton.tsx
+++ b/pages/index/LineButton.tsx
@@ -33,7 +33,7 @@ export function LineButton({ line }: LineButtonProps) {
       <Grid
         columns="auto 1fr auto"
         align="center"
-        className="group-active:bg-soft-active group-hover:bg-soft-hover -mx-4 gap-2 px-4 py-1"
+        className="group-active:bg-soft-active group-hover:bg-soft-hover gap-2 p-1"
       >
         <Row align="center" className="gap-2">
           <div
@@ -56,7 +56,7 @@ export function LineButton({ line }: LineButtonProps) {
             {line.status}
           </span>
         </div>
-        <MingcuteRightLine className="-mr-1" />
+        <MingcuteRightLine />
       </Grid>
     </Button>
   );

--- a/pages/index/Lines.tsx
+++ b/pages/index/Lines.tsx
@@ -13,9 +13,7 @@ type LinesProps = {
 export function Lines(props: LinesProps) {
   return (
     <Column className="gap-2">
-      <Text style="custom" className="text-foreground-strong text-lg font-bold">
-        {props.title}
-      </Text>
+      <Text style="subtitle">{props.title}</Text>
       <Column className="divide-soft-border divide-y-1">
         {props.lines.map((line) => (
           <LineButton key={line.id} line={line} />

--- a/pages/line/@id/+Page.tsx
+++ b/pages/line/@id/+Page.tsx
@@ -20,7 +20,7 @@ export default function Page() {
           <Column className="gap-4">
             {line != null ? (
               <>
-                <Text style="title">Is it buses...</Text>
+                <Text style="megatitle">Is it buses...</Text>
                 <Text>
                   on the <b>{line.name}</b> line?
                 </Text>
@@ -28,7 +28,7 @@ export default function Page() {
                 <hr className="border-soft-border" />
 
                 <Column className="gap-6">
-                  <Text style="title">Buses replace trains...</Text>
+                  <Text style="subtitle">Buses replace trains...</Text>
 
                   <Calendar data={line.calendar} />
                 </Column>

--- a/pages/settings/+Page.tsx
+++ b/pages/settings/+Page.tsx
@@ -13,6 +13,7 @@ import { SettingsReset } from "@/pages/settings/SettingsReset";
 import { SettingsAdmin } from "@/pages/settings/SettingsAdmin";
 import { useSettings } from "@/hooks/useSettings";
 import { SettingsTitle } from "@/pages/settings/SettingsTitle";
+import { Spacer } from "@/components/core/Spacer";
 
 export default function Page() {
   const { stations } = useData<Data>();
@@ -29,13 +30,23 @@ export default function Page() {
   return (
     <PageCenterer>
       <PagePadding>
-        <Column className="gap-4">
+        <Column>
           <SettingsTitle onRepeatedClicks={handleRepeatedTitleClicks} />
+          <Spacer h="4" />
           <SettingsStartPage />
+          <Spacer h="8" />
           <SettingsDisruptions />
+          <Spacer h="8" />
           <SettingsTheme />
+          <Spacer h="8" />
           <SettingsCommute stations={stations} />
-          {showAdminTabSetting && <SettingsAdmin />}
+          {showAdminTabSetting && (
+            <>
+              <Spacer h="8" />
+              <SettingsAdmin />
+            </>
+          )}
+          <Spacer h="8" />
           <SettingsReset />
         </Column>
       </PagePadding>

--- a/pages/settings/SettingsAdmin.tsx
+++ b/pages/settings/SettingsAdmin.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Column } from "@/components/core/Column";
 import { Text } from "@/components/core/Text";
 import { useSettings } from "@/hooks/useSettings";
+import { Spacer } from "@/components/core/Spacer";
 
 export function SettingsAdmin() {
   const [settings, setSettings] = useSettings();
@@ -14,8 +15,9 @@ export function SettingsAdmin() {
   return (
     <Column>
       <Text style="subtitle">Admin</Text>
+      <Spacer h="2" />
 
-      <label className="hover:bg-soft-hover flex h-9 cursor-pointer items-center justify-between">
+      <label className="hover:bg-soft-hover flex cursor-pointer items-center justify-between py-2">
         <input
           type="checkbox"
           value={"showAdminTab"}

--- a/pages/settings/SettingsAdmin.tsx
+++ b/pages/settings/SettingsAdmin.tsx
@@ -13,9 +13,7 @@ export function SettingsAdmin() {
 
   return (
     <Column>
-      <Text style="custom" className="text-foreground-strong text-lg font-bold">
-        Admin
-      </Text>
+      <Text style="subtitle">Admin</Text>
 
       <label className="hover:bg-soft-hover flex h-9 cursor-pointer items-center justify-between">
         <input

--- a/pages/settings/SettingsCommute.tsx
+++ b/pages/settings/SettingsCommute.tsx
@@ -21,9 +21,9 @@ export function SettingsCommute({ stations }: SettingsCommuteProps) {
   }
 
   return (
-    <Column>
+    <Column align="left">
       <Text style="subtitle">Commute</Text>
-      <Spacer h="2" />
+      <Spacer h="4" />
       {settings.commute == null ? (
         <Text>No commute set.</Text>
       ) : (

--- a/pages/settings/SettingsCommute.tsx
+++ b/pages/settings/SettingsCommute.tsx
@@ -22,9 +22,7 @@ export function SettingsCommute({ stations }: SettingsCommuteProps) {
 
   return (
     <Column>
-      <Text style="custom" className="text-foreground-strong text-lg font-bold">
-        Commute
-      </Text>
+      <Text style="subtitle">Commute</Text>
       <Spacer h="2" />
       {settings.commute == null ? (
         <Text>No commute set.</Text>

--- a/pages/settings/SettingsDisruptions.tsx
+++ b/pages/settings/SettingsDisruptions.tsx
@@ -79,7 +79,7 @@ export function SettingsDisruptions() {
             <Column className="gap-1">
               <Text>{formattedCategories[category].name}</Text>
               {formattedCategories[category].description && (
-                <Text style="custom" className="text-sm">
+                <Text style="tiny-weak">
                   {formattedCategories[category].description}
                 </Text>
               )}

--- a/pages/settings/SettingsDisruptions.tsx
+++ b/pages/settings/SettingsDisruptions.tsx
@@ -58,7 +58,7 @@ export function SettingsDisruptions() {
         {allCategories.map((category) => (
           <label
             key={category}
-            className="hover:bg-soft-hover flex h-9 cursor-pointer items-center justify-between"
+            className="hover:bg-soft-hover flex cursor-pointer items-center justify-between py-2"
           >
             <input
               type="checkbox"
@@ -76,7 +76,7 @@ export function SettingsDisruptions() {
                   : undefined
               }
             />
-            <Column className="gap-1">
+            <Column className="gap-2">
               <Text>{formattedCategories[category].name}</Text>
               {formattedCategories[category].description && (
                 <Text style="tiny-weak">

--- a/pages/settings/SettingsDisruptions.tsx
+++ b/pages/settings/SettingsDisruptions.tsx
@@ -51,9 +51,7 @@ export function SettingsDisruptions() {
 
   return (
     <Column>
-      <Text style="custom" className="text-foreground-strong text-lg font-bold">
-        Disruptions to show
-      </Text>
+      <Text style="subtitle">Disruptions to show</Text>
       <Spacer h="2" />
 
       <Column>

--- a/pages/settings/SettingsReset.tsx
+++ b/pages/settings/SettingsReset.tsx
@@ -17,9 +17,9 @@ export function SettingsReset() {
   }
 
   return (
-    <Column>
+    <Column align="left">
       <Text style="subtitle">Reset</Text>
-      <Spacer h="2" />
+      <Spacer h="4" />
       <Text>
         Reset all settings to their default values. This cannot be undone!
       </Text>

--- a/pages/settings/SettingsReset.tsx
+++ b/pages/settings/SettingsReset.tsx
@@ -18,9 +18,7 @@ export function SettingsReset() {
 
   return (
     <Column>
-      <Text style="custom" className="text-foreground-strong text-lg font-bold">
-        Reset
-      </Text>
+      <Text style="subtitle">Reset</Text>
       <Spacer h="2" />
       <Text>
         Reset all settings to their default values. This cannot be undone!

--- a/pages/settings/SettingsStartPage.tsx
+++ b/pages/settings/SettingsStartPage.tsx
@@ -27,7 +27,7 @@ export function SettingsStartPage() {
         {startPages.map((option) => (
           <label
             key={option}
-            className="hover:bg-soft-hover flex cursor-pointer gap-2 py-1"
+            className="hover:bg-soft-hover flex cursor-pointer gap-2 py-2"
           >
             <input
               type="radio"

--- a/pages/settings/SettingsStartPage.tsx
+++ b/pages/settings/SettingsStartPage.tsx
@@ -20,9 +20,7 @@ export function SettingsStartPage() {
 
   return (
     <Column>
-      <Text style="custom" className="text-foreground-strong text-lg font-bold">
-        Start page
-      </Text>
+      <Text style="subtitle">Start page</Text>
       <Spacer h="2" />
 
       <Column>

--- a/pages/settings/SettingsTheme.tsx
+++ b/pages/settings/SettingsTheme.tsx
@@ -29,7 +29,7 @@ export function SettingsTheme() {
         {themes.map((theme) => (
           <label
             key={theme}
-            className="hover:bg-soft-hover flex cursor-pointer gap-2 py-1"
+            className="hover:bg-soft-hover flex cursor-pointer gap-2 py-2"
           >
             <input
               type="radio"

--- a/pages/settings/SettingsTheme.tsx
+++ b/pages/settings/SettingsTheme.tsx
@@ -23,9 +23,7 @@ export function SettingsTheme() {
 
   return (
     <Column>
-      <Text style="custom" className="text-foreground-strong text-lg font-bold">
-        Colour theme
-      </Text>
+      <Text style="subtitle">Colour theme</Text>
       <Spacer h="2" />
       <Column>
         {themes.map((theme) => (

--- a/pages/settings/SettingsTitle.tsx
+++ b/pages/settings/SettingsTitle.tsx
@@ -27,7 +27,7 @@ export function SettingsTitle(props: SettingsTitleProps) {
   return (
     <With className="self-start">
       <Button onClick={handleClick}>
-        <Text style="title">Settings</Text>
+        <Text style="megatitle">Settings</Text>
       </Button>
     </With>
   );

--- a/pages/trip/ChooseTripPage.tsx
+++ b/pages/trip/ChooseTripPage.tsx
@@ -27,7 +27,7 @@ export function ChooseTripPage(props: ChooseTripPageProps) {
       <PageCenterer>
         <PagePadding>
           <Column as="form" align="left">
-            <Text style="title">Trip</Text>
+            <Text style="megatitle">Trip</Text>
             <Spacer h="4" />
             <StationSelect
               id="from"

--- a/pages/trip/DisplayTripPage.tsx
+++ b/pages/trip/DisplayTripPage.tsx
@@ -34,7 +34,7 @@ export function DisplayTripPage(props: DisplayTripPageProps) {
       <PageCenterer>
         <PagePadding>
           <Column>
-            <Text style="title">Is it buses...</Text>
+            <Text style="megatitle">Is it buses...</Text>
             <Spacer h="4" />
             <Text>
               between <b>{props.data.stationA.name}</b> and{" "}


### PR DESCRIPTION
- Replace all uses of `<Text style="custom">` with defined styles.
- Introduce side-by-side layout for lines on overview page.
- Increase spacing on settings page.
- Extract `<Marquee>` element, so a regular `<Text>` element can be used inside.