### PR TITLE
Show loading spinner between page navigations

### DIFF
--- a/components/common/LoadingSpinner.tsx
+++ b/components/common/LoadingSpinner.tsx
@@ -3,6 +3,7 @@ import clsx from "clsx";
 
 const styles = {
   default: "text-2xl text-foreground",
+  large: "text-4xl text-foreground",
 };
 
 export type LoadingSpinnerProps = {

--- a/components/navigation/CenterAccountingForNav.tsx
+++ b/components/navigation/CenterAccountingForNav.tsx
@@ -12,12 +12,12 @@ export function CenterAccountingForNav(props: CenterAccountingForNavProps) {
       className={clsx(
         "fixed left-1/2 -translate-x-1/2 -translate-y-1/2 transform-gpu",
 
-        // Center on the page, excluding the space used by the mobile nav bar
-        // (--spacing(16)).
+        // In mobile view, render 2rem higher than the center to account for the
+        // 4rem (16 Tailwind units) high mobile nav bar.
         "top-[calc((100%---spacing(16))*0.5)]",
 
-        // Center on the page, excluding the space used by the desktop nav bar
-        // (--spacing(12)).
+        // In desktop view, render 1.5rem higher than the center to account for
+        // the 3rem (12 Tailwind units) high mobile nav bar.
         "md:top-[calc((100%+--spacing(12))*0.5)]",
 
         props.className,

--- a/components/navigation/CenterAccountingForNav.tsx
+++ b/components/navigation/CenterAccountingForNav.tsx
@@ -16,7 +16,7 @@ export function CenterAccountingForNav(props: CenterAccountingForNavProps) {
         // 4rem (16 Tailwind units) high mobile nav bar.
         "top-[calc((100%---spacing(16))*0.5)]",
 
-        // In desktop view, render 1.5rem higher than the center to account for
+        // In desktop view, render 1.5rem lower than the center to account for
         // the 3rem (12 Tailwind units) high mobile nav bar.
         "md:top-[calc((100%+--spacing(12))*0.5)]",
 

--- a/components/navigation/CenterAccountingForNav.tsx
+++ b/components/navigation/CenterAccountingForNav.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import clsx from "clsx";
+
+export type CenterAccountingForNavProps = {
+  className?: string;
+  children: React.ReactNode;
+};
+
+export function CenterAccountingForNav(props: CenterAccountingForNavProps) {
+  return (
+    <div
+      className={clsx(
+        "fixed left-1/2 -translate-x-1/2 -translate-y-1/2 transform-gpu",
+
+        // Center on the page, excluding the space used by the mobile nav bar
+        // (--spacing(16)).
+        "top-[calc((100%---spacing(16))*0.5)]",
+
+        // Center on the page, excluding the space used by the desktop nav bar
+        // (--spacing(12)).
+        "md:top-[calc((100%+--spacing(12))*0.5)]",
+
+        props.className,
+      )}
+    >
+      {props.children}
+    </div>
+  );
+}

--- a/components/navigation/DesktopNavBar.tsx
+++ b/components/navigation/DesktopNavBar.tsx
@@ -1,44 +1,53 @@
 import React from "react";
 import { PageCenterer } from "@/components/common/PageCenterer";
 import { Text } from "@/components/core/Text";
-import {
-  admin,
-  myCommute,
-  overview,
-  settings,
-} from "@/components/navigation/utils";
 import { Grid } from "@/components/core/Grid";
 import { Row } from "@/components/core/Row";
 import { DesktopTabButton } from "@/components/navigation/DesktopTabButton";
 import { Favicon } from "@/components/icons/Favicon";
 import { Button } from "@/components/core/Button";
-import { useSettings } from "@/hooks/useSettings";
+import {
+  NavBarOrchestrator,
+  OrchestreeProps,
+} from "@/components/navigation/NavBarOrchestrator";
 
 export function DesktopNavBar() {
-  const [userSettings] = useSettings();
+  return <NavBarOrchestrator Layout={DesktopNavBarLayout} />;
+}
 
-  const leftAlignedTabs = userSettings.showAdminTab
-    ? [overview, myCommute, admin]
-    : [overview, myCommute];
+function DesktopNavBarLayout(props: OrchestreeProps) {
+  const { nonSettingsTabs, settingsTab, isActiveTab, onTabClick } = props;
 
   return (
     <nav className="bg-background border-b-soft-border fixed top-0 right-0 left-0 z-50 hidden border-b md:block">
       <PageCenterer>
-        <Grid columns="auto 1fr auto" className="gap-4 px-4">
+        <Grid columns="auto 1fr auto" className="gap-8 px-6">
           <Button href="/">
-            <Row align="center" className="gap-2 px-2">
+            <Row align="center" className="gap-2">
               <Favicon />
               <Text style="subtitle" oneLine>
                 Is it buses?
               </Text>
             </Row>
           </Button>
-          <Row>
-            {leftAlignedTabs.map((route) => (
-              <DesktopTabButton key={route.name} tab={route} />
+          <Row className="gap-8">
+            {nonSettingsTabs.map((tab) => (
+              <DesktopTabButton
+                key={tab.name}
+                name={tab.name}
+                icon={tab.icon}
+                active={isActiveTab(tab)}
+                onClick={() => onTabClick(tab)}
+              />
             ))}
           </Row>
-          <DesktopTabButton tab={settings} />
+          <DesktopTabButton
+            key={settingsTab.name}
+            name={settingsTab.name}
+            icon={settingsTab.icon}
+            active={isActiveTab(settingsTab)}
+            onClick={() => onTabClick(settingsTab)}
+          />
         </Grid>
       </PageCenterer>
     </nav>

--- a/components/navigation/DesktopNavBar.tsx
+++ b/components/navigation/DesktopNavBar.tsx
@@ -8,14 +8,14 @@ import { Favicon } from "@/components/icons/Favicon";
 import { Button } from "@/components/core/Button";
 import {
   NavBarOrchestrator,
-  OrchestreeProps,
+  NavBarOrchestratorLayoutProps,
 } from "@/components/navigation/NavBarOrchestrator";
 
 export function DesktopNavBar() {
   return <NavBarOrchestrator Layout={DesktopNavBarLayout} />;
 }
 
-function DesktopNavBarLayout(props: OrchestreeProps) {
+function DesktopNavBarLayout(props: NavBarOrchestratorLayoutProps) {
   const { nonSettingsTabs, settingsTab, isActiveTab, onTabClick } = props;
 
   return (
@@ -34,17 +34,14 @@ function DesktopNavBarLayout(props: OrchestreeProps) {
             {nonSettingsTabs.map((tab) => (
               <DesktopTabButton
                 key={tab.name}
-                name={tab.name}
-                icon={tab.icon}
+                tab={tab}
                 isActive={isActiveTab(tab)}
                 onClick={() => onTabClick(tab)}
               />
             ))}
           </Row>
           <DesktopTabButton
-            key={settingsTab.name}
-            name={settingsTab.name}
-            icon={settingsTab.icon}
+            tab={settingsTab}
             isActive={isActiveTab(settingsTab)}
             onClick={() => onTabClick(settingsTab)}
           />

--- a/components/navigation/DesktopNavBar.tsx
+++ b/components/navigation/DesktopNavBar.tsx
@@ -36,7 +36,7 @@ function DesktopNavBarLayout(props: OrchestreeProps) {
                 key={tab.name}
                 name={tab.name}
                 icon={tab.icon}
-                active={isActiveTab(tab)}
+                isActive={isActiveTab(tab)}
                 onClick={() => onTabClick(tab)}
               />
             ))}
@@ -45,7 +45,7 @@ function DesktopNavBarLayout(props: OrchestreeProps) {
             key={settingsTab.name}
             name={settingsTab.name}
             icon={settingsTab.icon}
-            active={isActiveTab(settingsTab)}
+            isActive={isActiveTab(settingsTab)}
             onClick={() => onTabClick(settingsTab)}
           />
         </Grid>

--- a/components/navigation/DesktopTabButton.tsx
+++ b/components/navigation/DesktopTabButton.tsx
@@ -5,28 +5,27 @@ import { Row } from "@/components/core/Row";
 import { Text } from "@/components/core/Text";
 import { With } from "@/components/core/With";
 import clsx from "clsx";
-import { NavTab } from "@/components/navigation/utils";
-import { usePageContext } from "vike-react/usePageContext";
 
 export type DesktopTabButtonProps = {
-  tab: NavTab;
+  name: string;
+  icon: React.ReactElement;
+  active: boolean;
+  onClick: () => void;
 };
 
 export function DesktopTabButton(props: DesktopTabButtonProps) {
-  const { urlPathname } = usePageContext();
-  const active = props.tab.active(urlPathname);
-
   return (
-    <Button href={props.tab.path}>
+    <Button onClick={props.onClick}>
       <Row
-        className={clsx(
-          "group-hover:bg-soft-hover group-active:bg-soft-active h-12 gap-2 border-y-2 border-transparent px-4",
-          { "border-b-accent": active },
-        )}
+        className={clsx("h-12 gap-2 border-y-2 border-transparent", {
+          "border-b-accent": props.active,
+          "group-hover:border-b-switch group-active:border-b-switch-hover":
+            !props.active,
+        })}
         align="center"
       >
-        <With className="-ml-0.5 text-lg">{props.tab.icon}</With>
-        <Text>{props.tab.name}</Text>
+        <With className="-ml-0.5 text-lg">{props.icon}</With>
+        <Text>{props.name}</Text>
       </Row>
     </Button>
   );

--- a/components/navigation/DesktopTabButton.tsx
+++ b/components/navigation/DesktopTabButton.tsx
@@ -9,7 +9,7 @@ import clsx from "clsx";
 export type DesktopTabButtonProps = {
   name: string;
   icon: React.ReactElement;
-  active: boolean;
+  isActive: boolean;
   onClick: () => void;
 };
 
@@ -18,9 +18,9 @@ export function DesktopTabButton(props: DesktopTabButtonProps) {
     <Button onClick={props.onClick}>
       <Row
         className={clsx("h-12 gap-2 border-y-2 border-transparent", {
-          "border-b-accent": props.active,
+          "border-b-accent": props.isActive,
           "group-hover:border-b-switch group-active:border-b-switch-hover":
-            !props.active,
+            !props.isActive,
         })}
         align="center"
       >

--- a/components/navigation/DesktopTabButton.tsx
+++ b/components/navigation/DesktopTabButton.tsx
@@ -5,10 +5,10 @@ import { Row } from "@/components/core/Row";
 import { Text } from "@/components/core/Text";
 import { With } from "@/components/core/With";
 import clsx from "clsx";
+import { NavTab } from "@/components/navigation/utils";
 
 export type DesktopTabButtonProps = {
-  name: string;
-  icon: React.ReactElement;
+  tab: NavTab;
   isActive: boolean;
   onClick: () => void;
 };
@@ -24,8 +24,8 @@ export function DesktopTabButton(props: DesktopTabButtonProps) {
         })}
         align="center"
       >
-        <With className="-ml-0.5 text-lg">{props.icon}</With>
-        <Text>{props.name}</Text>
+        <With className="-ml-0.5 text-lg">{props.tab.icon}</With>
+        <Text>{props.tab.name}</Text>
       </Row>
     </Button>
   );

--- a/components/navigation/MobileNavBar.tsx
+++ b/components/navigation/MobileNavBar.tsx
@@ -3,14 +3,14 @@ import { MobileTabButton } from "@/components/navigation/MobileTabButton";
 import { Grid } from "@/components/core/Grid";
 import {
   NavBarOrchestrator,
-  OrchestreeProps,
+  NavBarOrchestratorLayoutProps,
 } from "@/components/navigation/NavBarOrchestrator";
 
 export function MobileNavBar() {
   return <NavBarOrchestrator Layout={MobileNavBarLayout} />;
 }
 
-function MobileNavBarLayout(props: OrchestreeProps) {
+function MobileNavBarLayout(props: NavBarOrchestratorLayoutProps) {
   const { nonSettingsTabs, settingsTab, isActiveTab, onTabClick } = props;
 
   return (
@@ -19,9 +19,7 @@ function MobileNavBarLayout(props: OrchestreeProps) {
         {[...nonSettingsTabs, settingsTab].map((tab) => (
           <MobileTabButton
             key={tab.name}
-            name={tab.name}
-            icon={tab.icon}
-            iconFill={tab.iconFill}
+            tab={tab}
             isActive={isActiveTab(tab)}
             onClick={() => onTabClick(tab)}
           />

--- a/components/navigation/MobileNavBar.tsx
+++ b/components/navigation/MobileNavBar.tsx
@@ -1,26 +1,30 @@
 import React from "react";
-import {
-  admin,
-  myCommute,
-  overview,
-  settings,
-} from "@/components/navigation/utils";
 import { MobileTabButton } from "@/components/navigation/MobileTabButton";
 import { Grid } from "@/components/core/Grid";
-import { useSettings } from "@/hooks/useSettings";
+import {
+  NavBarOrchestrator,
+  OrchestreeProps,
+} from "@/components/navigation/NavBarOrchestrator";
 
 export function MobileNavBar() {
-  const [userSettings] = useSettings();
+  return <NavBarOrchestrator Layout={MobileNavBarLayout} />;
+}
 
-  const tabs = userSettings.showAdminTab
-    ? [overview, myCommute, admin, settings]
-    : [overview, myCommute, settings];
+function MobileNavBarLayout(props: OrchestreeProps) {
+  const { nonSettingsTabs, settingsTab, isActiveTab, onTabClick } = props;
 
   return (
     <nav className="bg-background border-t-soft-border fixed right-0 bottom-0 left-0 z-50 min-w-(--page-min-width) border-t md:hidden">
       <Grid className="auto-cols-[1fr] grid-flow-col px-4">
-        {tabs.map((route) => (
-          <MobileTabButton key={route.name} tab={route} />
+        {[...nonSettingsTabs, settingsTab].map((tab) => (
+          <MobileTabButton
+            key={tab.name}
+            name={tab.name}
+            icon={tab.icon}
+            iconFill={tab.iconFill}
+            active={isActiveTab(tab)}
+            onClick={() => onTabClick(tab)}
+          />
         ))}
       </Grid>
     </nav>

--- a/components/navigation/MobileNavBar.tsx
+++ b/components/navigation/MobileNavBar.tsx
@@ -22,7 +22,7 @@ function MobileNavBarLayout(props: OrchestreeProps) {
             name={tab.name}
             icon={tab.icon}
             iconFill={tab.iconFill}
-            active={isActiveTab(tab)}
+            isActive={isActiveTab(tab)}
             onClick={() => onTabClick(tab)}
           />
         ))}

--- a/components/navigation/MobileTabButton.tsx
+++ b/components/navigation/MobileTabButton.tsx
@@ -5,11 +5,10 @@ import { Text } from "@/components/core/Text";
 import { With } from "@/components/core/With";
 import clsx from "clsx";
 import { Column } from "@/components/core/Column";
+import { NavTab } from "@/components/navigation/utils";
 
 export type MobileTabButtonProps = {
-  name: string;
-  icon: React.ReactElement;
-  iconFill: React.ReactElement;
+  tab: NavTab;
   isActive: boolean;
   onClick: () => void;
 };
@@ -24,10 +23,10 @@ export function MobileTabButton(props: MobileTabButtonProps) {
             "group-hover:bg-soft-hover": !props.isActive,
           })}
         >
-          {props.isActive ? props.iconFill : props.icon}
+          {props.isActive ? props.tab.iconFill : props.tab.icon}
         </With>
         <Text style={props.isActive ? "tiny-accent" : "tiny"} oneLine>
-          {props.name}
+          {props.tab.name}
         </Text>
       </Column>
     </Button>

--- a/components/navigation/MobileTabButton.tsx
+++ b/components/navigation/MobileTabButton.tsx
@@ -4,8 +4,8 @@ import { Button } from "@/components/core/Button";
 import { Text } from "@/components/core/Text";
 import { With } from "@/components/core/With";
 import clsx from "clsx";
-import { Column } from "@/components/core/Column";
 import { NavTab } from "@/components/navigation/utils";
+import { Column } from "@/components/core/Column";
 
 export type MobileTabButtonProps = {
   tab: NavTab;

--- a/components/navigation/MobileTabButton.tsx
+++ b/components/navigation/MobileTabButton.tsx
@@ -4,30 +4,29 @@ import { Button } from "@/components/core/Button";
 import { Text } from "@/components/core/Text";
 import { With } from "@/components/core/With";
 import clsx from "clsx";
-import { NavTab } from "@/components/navigation/utils";
-import { usePageContext } from "vike-react/usePageContext";
 import { Column } from "@/components/core/Column";
 
 export type MobileTabButtonProps = {
-  tab: NavTab;
+  name: string;
+  icon: React.ReactElement;
+  iconFill: React.ReactElement;
+  active: boolean;
+  onClick: () => void;
 };
 
 export function MobileTabButton(props: MobileTabButtonProps) {
-  const { urlPathname } = usePageContext();
-  const active = props.tab.active(urlPathname);
-
   return (
-    <Button href={props.tab.path}>
+    <Button onClick={props.onClick}>
       <Column className={clsx("h-16 gap-1")} align="center" justify="center">
         <With
           className={clsx("-mt-1 rounded-full px-4 py-1 text-xl", {
-            "bg-accent-soft text-accent": active,
+            "bg-accent-soft text-accent": props.active,
           })}
         >
-          {active ? props.tab.iconFill : props.tab.icon}
+          {props.active ? props.iconFill : props.icon}
         </With>
-        <Text style={active ? "tiny-accent" : "tiny"} oneLine>
-          {props.tab.name}
+        <Text style={props.active ? "tiny-accent" : "tiny"} oneLine>
+          {props.name}
         </Text>
       </Column>
     </Button>

--- a/components/navigation/MobileTabButton.tsx
+++ b/components/navigation/MobileTabButton.tsx
@@ -10,7 +10,7 @@ export type MobileTabButtonProps = {
   name: string;
   icon: React.ReactElement;
   iconFill: React.ReactElement;
-  active: boolean;
+  isActive: boolean;
   onClick: () => void;
 };
 
@@ -20,12 +20,13 @@ export function MobileTabButton(props: MobileTabButtonProps) {
       <Column className={clsx("h-16 gap-1")} align="center" justify="center">
         <With
           className={clsx("-mt-1 rounded-full px-4 py-1 text-xl", {
-            "bg-accent-soft text-accent": props.active,
+            "bg-accent-soft text-accent": props.isActive,
+            "group-hover:bg-soft-hover": !props.isActive,
           })}
         >
-          {props.active ? props.iconFill : props.icon}
+          {props.isActive ? props.iconFill : props.icon}
         </With>
-        <Text style={props.active ? "tiny-accent" : "tiny"} oneLine>
+        <Text style={props.isActive ? "tiny-accent" : "tiny"} oneLine>
           {props.name}
         </Text>
       </Column>

--- a/components/navigation/NavBarOrchestrator.tsx
+++ b/components/navigation/NavBarOrchestrator.tsx
@@ -22,6 +22,11 @@ export type NavBarOrchestratorProps = {
   Layout: (props: NavBarOrchestratorLayoutProps) => React.ReactNode;
 };
 
+/**
+ * A helper component for the mobile & desktop nav bar. Manages the "instant"
+ * navigation (a.k.a. not waiting for the new page to be fully loaded before
+ * changing the active tab), and hiding the admin tab for regular users.
+ */
 export function NavBarOrchestrator(props: NavBarOrchestratorProps) {
   const [settings] = useSettings();
   const nonSettingsTabs = settings.showAdminTab

--- a/components/navigation/NavBarOrchestrator.tsx
+++ b/components/navigation/NavBarOrchestrator.tsx
@@ -11,7 +11,7 @@ import React from "react";
 import { usePageContext } from "vike-react/usePageContext";
 import { navigate } from "vike/client/router";
 
-export type OrchestreeProps = {
+export type NavBarOrchestratorLayoutProps = {
   nonSettingsTabs: NavTab[];
   settingsTab: NavTab;
   isActiveTab: (tab: NavTab) => boolean;
@@ -19,13 +19,12 @@ export type OrchestreeProps = {
 };
 
 export type NavBarOrchestratorProps = {
-  Layout: (props: OrchestreeProps) => React.ReactNode;
+  Layout: (props: NavBarOrchestratorLayoutProps) => React.ReactNode;
 };
 
 export function NavBarOrchestrator(props: NavBarOrchestratorProps) {
-  const [userSettings] = useSettings();
-
-  const nonSettingsTabs = userSettings.showAdminTab
+  const [settings] = useSettings();
+  const nonSettingsTabs = settings.showAdminTab
     ? [overview, myCommute, admin]
     : [overview, myCommute];
 
@@ -42,6 +41,8 @@ export function NavBarOrchestrator(props: NavBarOrchestratorProps) {
   }
 
   function onTabClick(tab: NavTab) {
+    // Don't rely on loadedTab to update, since it only updates when the new
+    // page has loaded.
     setActiveTabName(tab.name);
     navigate(tab.path);
   }

--- a/components/navigation/NavBarOrchestrator.tsx
+++ b/components/navigation/NavBarOrchestrator.tsx
@@ -1,0 +1,55 @@
+import {
+  admin,
+  navTabs,
+  myCommute,
+  NavTab,
+  overview,
+  settings as settingsTab,
+} from "@/components/navigation/utils";
+import { useSettings } from "@/hooks/useSettings";
+import React from "react";
+import { usePageContext } from "vike-react/usePageContext";
+import { navigate } from "vike/client/router";
+
+export type OrchestreeProps = {
+  nonSettingsTabs: NavTab[];
+  settingsTab: NavTab;
+  isActiveTab: (tab: NavTab) => boolean;
+  onTabClick: (tab: NavTab) => void;
+};
+
+export type NavBarOrchestratorProps = {
+  Layout: (props: OrchestreeProps) => React.ReactNode;
+};
+
+export function NavBarOrchestrator(props: NavBarOrchestratorProps) {
+  const [userSettings] = useSettings();
+
+  const nonSettingsTabs = userSettings.showAdminTab
+    ? [overview, myCommute, admin]
+    : [overview, myCommute];
+
+  const { urlPathname } = usePageContext();
+  const loadedTab = navTabs.find((x) => x.active(urlPathname))?.name ?? null;
+  const [activeTabName, setActiveTabName] = React.useState(loadedTab);
+
+  React.useEffect(() => {
+    setActiveTabName(loadedTab);
+  }, [loadedTab]);
+
+  function isActiveTab(tab: NavTab) {
+    return activeTabName === tab.name;
+  }
+
+  function onTabClick(tab: NavTab) {
+    setActiveTabName(tab.name);
+    navigate(tab.path);
+  }
+
+  return props.Layout({
+    nonSettingsTabs,
+    settingsTab,
+    isActiveTab,
+    onTabClick,
+  });
+}

--- a/components/navigation/utils.tsx
+++ b/components/navigation/utils.tsx
@@ -48,3 +48,5 @@ export const settings: NavTab = {
   path: "/settings",
   active: (url: string) => url === "/settings",
 };
+
+export const navTabs = [overview, myCommute, admin, settings];

--- a/layouts/LayoutDefault.tsx
+++ b/layouts/LayoutDefault.tsx
@@ -7,6 +7,7 @@ import { MobileNavBar } from "@/components/navigation/MobileNavBar";
 import { Column } from "@/components/core/Column";
 import { With } from "@/components/core/With";
 import { SettingsProvider } from "@/components/SettingsProvider";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 
 export default function LayoutDefault({
   children,
@@ -22,7 +23,11 @@ export default function LayoutDefault({
       <SettingsProvider>
         <DesktopNavBar />
         <MobileNavBar />
-        <With flexGrow="1" className="pb-16 md:pt-12 md:pb-0">
+        {/* TODO: [DS] This is a bit messy! */}
+        <div className="_page-loader fixed top-[calc((100%---spacing(16))*0.5)] left-1/2 -translate-x-1/2 -translate-y-1/2 transform-gpu md:top-[calc((100%+--spacing(12))*0.5)]">
+          <LoadingSpinner style="large" />
+        </div>
+        <With flexGrow="1" className="_page-container pb-16 md:pt-12 md:pb-0">
           {children}
         </With>
       </SettingsProvider>

--- a/layouts/LayoutDefault.tsx
+++ b/layouts/LayoutDefault.tsx
@@ -8,6 +8,7 @@ import { Column } from "@/components/core/Column";
 import { With } from "@/components/core/With";
 import { SettingsProvider } from "@/components/SettingsProvider";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
+import { CenterAccountingForNav } from "@/components/navigation/CenterAccountingForNav";
 
 export default function LayoutDefault({
   children,
@@ -23,10 +24,9 @@ export default function LayoutDefault({
       <SettingsProvider>
         <DesktopNavBar />
         <MobileNavBar />
-        {/* TODO: [DS] This is a bit messy! */}
-        <div className="_page-loader fixed top-[calc((100%---spacing(16))*0.5)] left-1/2 -translate-x-1/2 -translate-y-1/2 transform-gpu md:top-[calc((100%+--spacing(12))*0.5)]">
+        <CenterAccountingForNav className="_page-loader">
           <LoadingSpinner style="large" />
-        </div>
+        </CenterAccountingForNav>
         <With flexGrow="1" className="_page-container pb-16 md:pt-12 md:pb-0">
           {children}
         </With>

--- a/layouts/css/page-transition.css
+++ b/layouts/css/page-transition.css
@@ -1,0 +1,25 @@
+._page-loading ._page-container {
+  opacity: 0%;
+}
+
+._page-loader {
+  /* 
+   * Using `display: none` instead of `opacity: 0` so the loading spinner's 
+   * animation always plays from the start. 
+   */
+  display: none;
+}
+
+._page-loading ._page-loader {
+  display: block;
+  animation: fade-in 0.5s forwards;
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0%;
+  }
+  100% {
+    opacity: 100%;
+  }
+}

--- a/layouts/tailwind.css
+++ b/layouts/tailwind.css
@@ -2,6 +2,7 @@
 @import "./css/loading-spinner.css" layer(base);
 @import "./css/text.css" layer(base);
 @import "./css/marquee.css" layer(base);
+@import "./css/page-transition.css" layer(base);
 
 @custom-variant dark {
   &:where(.dark, .dark *) {

--- a/pages/+onPageTransitionEnd.ts
+++ b/pages/+onPageTransitionEnd.ts
@@ -1,0 +1,3 @@
+export async function onPageTransitionEnd() {
+  document.body.classList.remove("_page-loading");
+}

--- a/pages/+onPageTransitionStart.ts
+++ b/pages/+onPageTransitionStart.ts
@@ -1,0 +1,3 @@
+export async function onPageTransitionStart() {
+  document.body.classList.add("_page-loading");
+}

--- a/pages/index/+data.ts
+++ b/pages/index/+data.ts
@@ -37,14 +37,8 @@ type PreprocessedDisruption = {
   writeup: DisruptionWriteup;
 };
 
-export async function data(
-  pageContext: PageContext,
-): Promise<Data & JsonSerializable> {
+export function data(pageContext: PageContext): Data & JsonSerializable {
   const { app } = pageContext.custom;
-
-  // TODO: [DS] Remove this and the async and Promise stuff above! It's just for
-  // testing a slow page load.
-  await new Promise((resolve) => setTimeout(resolve, 4000));
 
   const disruptions: PreprocessedDisruption[] = getDemoDisruptions(app)
     .filter((x) => x.period.occursAt(app.time.now()))

--- a/pages/index/+data.ts
+++ b/pages/index/+data.ts
@@ -37,8 +37,14 @@ type PreprocessedDisruption = {
   writeup: DisruptionWriteup;
 };
 
-export function data(pageContext: PageContext): Data & JsonSerializable {
+export async function data(
+  pageContext: PageContext,
+): Promise<Data & JsonSerializable> {
   const { app } = pageContext.custom;
+
+  // TODO: [DS] Remove this and the async and Promise stuff above! It's just for
+  // testing a slow page load.
+  await new Promise((resolve) => setTimeout(resolve, 4000));
 
   const disruptions: PreprocessedDisruption[] = getDemoDisruptions(app)
     .filter((x) => x.period.occursAt(app.time.now()))


### PR DESCRIPTION
- Use two effects to make navigation feel snappier:
  - Replace the page with a loading spinner as soon as the user navigates for instant feedback.
  - Update the active tab displayed on the mobile & desktop nav bars instantly if the nav bars were used for navigation.
- Other improvements:
  - Minor design tweaks to the desktop nav bar buttons so that the right edge of the page can align with the "Settings" tab.
  - Mouse hover styles for the mobile nav buttons (even though rarely used with a mouse in practice).
  - Reduce duplication of logic to hide the admin tab across mobile and desktop nav bars.