### PR TITLE
Styled RadioButton & extract Switch component from settings page

### DIFF
--- a/components/common/RadioButton.tsx
+++ b/components/common/RadioButton.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import {
+  extractRadioControl,
+  Radio,
+  RadioControl,
+} from "@/components/core/Radio";
+import { Grid } from "@/components/core/Grid";
+
+export type RadioButtonProps = {
+  children?: React.ReactNode;
+  className?: string;
+} & RadioControl;
+
+export function RadioButton(props: RadioButtonProps) {
+  return (
+    <Radio {...extractRadioControl(props)} className={props.className}>
+      <Grid columns="auto 1fr" align="center" className="gap-4">
+        <RadioButtonGraphic />
+        {props.children}
+      </Grid>
+    </Radio>
+  );
+}
+
+function RadioButtonGraphic() {
+  return (
+    <div className="border-switch group-has-[input:checked]:border-accent -my-2.5 flex size-5 items-center justify-center rounded-full border-2 group-has-[input:disabled]:opacity-50">
+      <div className="bg-accent size-2.5 rounded-full transition-transform group-has-[input:not(:checked)]:scale-0" />
+    </div>
+  );
+}

--- a/components/common/RadioButton.tsx
+++ b/components/common/RadioButton.tsx
@@ -7,7 +7,7 @@ import {
 import { Grid } from "@/components/core/Grid";
 
 export type RadioButtonProps = {
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   className?: string;
 } & RadioControl;
 

--- a/components/common/SimpleButton.tsx
+++ b/components/common/SimpleButton.tsx
@@ -31,7 +31,10 @@ export function SimpleButton(props: SimpleButtonProps) {
   if (layout === "tile") {
     return (
       <Button {...action} alt={props.alt}>
-        <Column className={clsx("gap-2 px-4 py-2", theme)} align="center">
+        <Column
+          className={clsx("gap-2 px-4 py-2 select-none", theme)}
+          align="center"
+        >
           {props.icon && <With className="-ml-0.5 text-2xl">{props.icon}</With>}
           {props.text && <Text align="center">{props.text}</Text>}
         </Column>
@@ -44,7 +47,7 @@ export function SimpleButton(props: SimpleButtonProps) {
       return (
         <Button {...action} alt={props.alt}>
           <Row
-            className={clsx("h-8 w-8 gap-2 text-lg", theme)}
+            className={clsx("h-8 w-8 gap-2 text-lg select-none", theme)}
             align="center"
             justify="center"
           >
@@ -55,7 +58,10 @@ export function SimpleButton(props: SimpleButtonProps) {
     } else {
       return (
         <Button {...action} alt={props.alt}>
-          <Row className={clsx("h-8 gap-2 px-4", theme)} align="center">
+          <Row
+            className={clsx("h-8 gap-2 px-4 select-none", theme)}
+            align="center"
+          >
             {props.icon != null && (
               <With className="-ml-0.5 text-lg">{props.icon}</With>
             )}

--- a/components/common/Switch.tsx
+++ b/components/common/Switch.tsx
@@ -7,7 +7,7 @@ import {
 import { Grid } from "@/components/core/Grid";
 
 export type SwitchProps = {
-  children?: React.ReactNode;
+  children?: React.ReactElement;
   className?: string;
 } & CheckboxControl;
 

--- a/components/common/Switch.tsx
+++ b/components/common/Switch.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import {
+  Checkbox,
+  CheckboxControl,
+  extractCheckboxControl,
+} from "@/components/core/Checkbox";
+import { Grid } from "@/components/core/Grid";
+
+export type SwitchProps = {
+  children?: React.ReactNode;
+  className?: string;
+} & CheckboxControl;
+
+export function Switch(props: SwitchProps) {
+  return (
+    <Checkbox {...extractCheckboxControl(props)} className={props.className}>
+      <Grid columns="1fr auto" align="center" className="gap-4">
+        {props.children}
+        <SwitchGraphic />
+      </Grid>
+    </Checkbox>
+  );
+}
+
+function SwitchGraphic() {
+  return (
+    <div className="bg-switch group-has-[input:checked]:bg-accent group-hover:bg-switch-hover group-has-[input:checked]:group-hover:bg-accent-hover -my-2.5 h-5 w-9 rounded-full p-0.5 group-has-[input:disabled]:opacity-50">
+      <div className="bg-switch-knob size-4 rounded-full transition-transform ease-in-out group-has-[input:checked]:translate-x-full" />
+    </div>
+  );
+}

--- a/components/core/Checkbox.tsx
+++ b/components/core/Checkbox.tsx
@@ -28,7 +28,7 @@ export function Checkbox(props: CheckboxProps) {
       <input
         type="checkbox"
         autoComplete="off"
-        className="peer sr-only"
+        className="sr-only"
         checked={props.checked}
         onChange={(e) => props.onChange(e.target.checked)}
         disabled={props.disabled}

--- a/components/core/Checkbox.tsx
+++ b/components/core/Checkbox.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import clsx from "clsx";
+
+export type CheckboxProps = {
+  className?: string;
+  children?: React.ReactNode;
+} & CheckboxControl;
+
+export type CheckboxControl = {
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (checked: boolean) => void;
+};
+
+/**
+ * A checkbox without any styling.
+ *
+ * Rules:
+ * - Are you sure you don't want `<Switch>`?
+ * - Child elements should use `group-has-[input:checked]` and
+ *   `group-has-[input:disabled]` for styling.
+ *
+ * ([More info](https://github.com/dan-schel/train-disruptions/blob/master/docs/ui-conventions.md))
+ */
+export function Checkbox(props: CheckboxProps) {
+  return (
+    <label className={clsx("group grid cursor-pointer", props.className)}>
+      <input
+        type="checkbox"
+        autoComplete="off"
+        className="peer sr-only"
+        checked={props.checked}
+        onChange={(e) => props.onChange(e.target.checked)}
+        disabled={props.disabled}
+      />
+      {props.children}
+    </label>
+  );
+}
+
+export function extractCheckboxControl(
+  props: CheckboxControl,
+): CheckboxControl {
+  return {
+    checked: props.checked,
+    disabled: props.disabled,
+    onChange: props.onChange,
+  };
+}

--- a/components/core/Radio.tsx
+++ b/components/core/Radio.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import clsx from "clsx";
+
+export type RadioProps = {
+  className?: string;
+  children?: React.ReactNode;
+} & RadioControl;
+
+export type RadioControl = {
+  group: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (checked: boolean) => void;
+};
+
+/**
+ * A radio button without any styling.
+ *
+ * Rules:
+ * - Are you sure you don't want `<RadioButton>`?
+ * - Child elements should use `group-has-[input:checked]` and
+ *   `group-has-[input:disabled]` for styling.
+ *
+ * ([More info](https://github.com/dan-schel/train-disruptions/blob/master/docs/ui-conventions.md))
+ */
+export function Radio(props: RadioProps) {
+  return (
+    <label className={clsx("group grid cursor-pointer", props.className)}>
+      <input
+        type="radio"
+        name={props.group}
+        autoComplete="off"
+        className="peer sr-only"
+        checked={props.checked}
+        onChange={(e) => props.onChange(e.target.checked)}
+        disabled={props.disabled}
+      />
+      {props.children}
+    </label>
+  );
+}
+
+export function extractRadioControl(props: RadioControl): RadioControl {
+  return {
+    group: props.group,
+    checked: props.checked,
+    disabled: props.disabled,
+    onChange: props.onChange,
+  };
+}

--- a/components/core/Radio.tsx
+++ b/components/core/Radio.tsx
@@ -30,7 +30,7 @@ export function Radio(props: RadioProps) {
         type="radio"
         name={props.group}
         autoComplete="off"
-        className="peer sr-only"
+        className="sr-only"
         checked={props.checked}
         onChange={(e) => props.onChange(e.target.checked)}
         disabled={props.disabled}

--- a/components/settings/SettingsRadioButton.tsx
+++ b/components/settings/SettingsRadioButton.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { RadioButton } from "@/components/common/RadioButton";
+import { RadioControl, extractRadioControl } from "@/components/core/Radio";
+import { Column } from "@/components/core/Column";
+import { Text } from "@/components/core/Text";
+
+export type SettingsRadioButtonProps = {
+  title: string;
+  description?: string;
+} & RadioControl;
+
+export function SettingsRadioButton(props: SettingsRadioButtonProps) {
+  return (
+    <RadioButton
+      {...extractRadioControl(props)}
+      className="hover:bg-soft-hover -mx-4 -my-2 px-4 py-2"
+    >
+      <Column className="gap-2 select-none">
+        <Text>{props.title}</Text>
+        {props.description != null && (
+          <Text style="tiny-weak">{props.description}</Text>
+        )}
+      </Column>
+    </RadioButton>
+  );
+}

--- a/components/settings/SettingsSwitch.tsx
+++ b/components/settings/SettingsSwitch.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Switch } from "@/components/common/Switch";
+import {
+  CheckboxControl,
+  extractCheckboxControl,
+} from "@/components/core/Checkbox";
+import { Column } from "@/components/core/Column";
+import { Text } from "@/components/core/Text";
+
+export type SettingsSwitchProps = {
+  title: string;
+  description?: string;
+} & CheckboxControl;
+
+export function SettingsSwitch(props: SettingsSwitchProps) {
+  return (
+    <Switch
+      {...extractCheckboxControl(props)}
+      className="hover:bg-soft-hover -mx-4 -my-2 px-4 py-2"
+    >
+      <Column className="gap-2 select-none">
+        <Text>{props.title}</Text>
+        {props.description != null && (
+          <Text style="tiny-weak">{props.description}</Text>
+        )}
+      </Column>
+    </Switch>
+  );
+}

--- a/docs/ui-conventions.md
+++ b/docs/ui-conventions.md
@@ -260,6 +260,54 @@ Clickable inline underlined text.
 
   - **Reasoning:** You'd just be working against the built-in styling of this component otherwise!
 
+### `<Checkbox>`
+
+A checkbox without any styling.
+
+#### Examples <!-- omit in toc -->
+
+```tsx
+<Checkbox checked={checked} onChange={handleChange}>
+  <Text style="custom" className="group-has-[input:checked]:color-red">
+    Content.
+  </Text>
+</Checkbox>
+```
+
+#### Rules of `<Checkbox>` <!-- omit in toc -->
+
+- Are you sure you don't want `<Switch>`?
+
+  - **Reasoning:** `<Checkbox>` is a low-level component that's completely unstyled. `<Switch>` is what gives you the visual switch component.
+
+- Child elements should use `group-has-[input:checked]` and `group-has-[input:disabled]` for styling.
+
+  - **Reasoning:** That enables them to apply styles based on the value of the inner `<input type="checkbox">`.
+
+### `<Radio>`
+
+A radio button without any styling.
+
+#### Examples <!-- omit in toc -->
+
+```tsx
+<Radio group="theme" checked={checked} onChange={handleChange}>
+  <Text style="custom" className="group-has-[input:checked]:color-red">
+    Content.
+  </Text>
+</Radio>
+```
+
+#### Rules of `<Radio>` <!-- omit in toc -->
+
+- Are you sure you don't want `<RadioButton>`?
+
+  - **Reasoning:** `<Radio>` is a low-level component that's completely unstyled. `<RadioButton>` is what gives you the visual radio button component.
+
+- Child elements should use `group-has-[input:checked]` and `group-has-[input:disabled]` for styling.
+
+  - **Reasoning:** That enables them to apply styles based on the value of the inner `<input type="radio">`.
+
 ## Icons
 
 All icons can be found under `/components/icons`, and the code for an icon component looks something like [this](/components/icons/RiAddCircleLine.tsx).

--- a/docs/ui-conventions.md
+++ b/docs/ui-conventions.md
@@ -16,6 +16,8 @@ Some notes on what I think is a good strategy for UI and how the core components
   - [`<With>`](#with)
   - [`<Button>`](#button)
   - [`<Link>`](#link)
+  - [`<Checkbox>`](#checkbox)
+  - [`<Radio>`](#radio)
 - [Icons](#icons)
   - [Adding new icons](#adding-new-icons)
 

--- a/pages/settings/+Page.tsx
+++ b/pages/settings/+Page.tsx
@@ -13,7 +13,6 @@ import { SettingsReset } from "@/pages/settings/SettingsReset";
 import { SettingsAdmin } from "@/pages/settings/SettingsAdmin";
 import { useSettings } from "@/hooks/useSettings";
 import { SettingsTitle } from "@/pages/settings/SettingsTitle";
-import { Spacer } from "@/components/core/Spacer";
 
 export default function Page() {
   const { stations } = useData<Data>();
@@ -30,24 +29,16 @@ export default function Page() {
   return (
     <PageCenterer>
       <PagePadding>
-        <Column>
+        <Column className="gap-4">
           <SettingsTitle onRepeatedClicks={handleRepeatedTitleClicks} />
-          <Spacer h="4" />
-          <SettingsStartPage />
-          <Spacer h="8" />
-          <SettingsDisruptions />
-          <Spacer h="8" />
-          <SettingsTheme />
-          <Spacer h="8" />
-          <SettingsCommute stations={stations} />
-          {showAdminTabSetting && (
-            <>
-              <Spacer h="8" />
-              <SettingsAdmin />
-            </>
-          )}
-          <Spacer h="8" />
-          <SettingsReset />
+          <Column className="gap-8">
+            <SettingsStartPage />
+            <SettingsDisruptions />
+            <SettingsTheme />
+            <SettingsCommute stations={stations} />
+            {showAdminTabSetting && <SettingsAdmin />}
+            <SettingsReset />
+          </Column>
         </Column>
       </PagePadding>
     </PageCenterer>

--- a/pages/settings/SettingsAdmin.tsx
+++ b/pages/settings/SettingsAdmin.tsx
@@ -4,6 +4,7 @@ import { Column } from "@/components/core/Column";
 import { Text } from "@/components/core/Text";
 import { useSettings } from "@/hooks/useSettings";
 import { Spacer } from "@/components/core/Spacer";
+import { SettingsSwitch } from "@/components/settings/SettingsSwitch";
 
 export function SettingsAdmin() {
   const [settings, setSettings] = useSettings();
@@ -15,24 +16,12 @@ export function SettingsAdmin() {
   return (
     <Column>
       <Text style="subtitle">Admin</Text>
-      <Spacer h="2" />
-
-      <label className="hover:bg-soft-hover flex cursor-pointer items-center justify-between py-2">
-        <input
-          type="checkbox"
-          value={"showAdminTab"}
-          autoComplete="off"
-          className="peer sr-only"
-          checked={settings.showAdminTab}
-          onChange={handleChange}
-        />
-        <Column className="gap-1">
-          <Text>Show Admin Tab</Text>
-        </Column>
-        <div className="bg-switch peer-checked:bg-accent hover:bg-switch-hover hover:peer-checked:bg-accent-hover flex h-5 w-9 items-center rounded-full p-0.5 transition-transform ease-in-out peer-checked:*:translate-x-full peer-disabled:opacity-50">
-          <div className="bg-switch-knob size-4 rounded-full transition-all" />
-        </div>
-      </label>
+      <Spacer h="4" />
+      <SettingsSwitch
+        title="Show Admin tab"
+        onChange={handleChange}
+        checked={settings.showAdminTab}
+      />
     </Column>
   );
 }

--- a/pages/settings/SettingsCommute.tsx
+++ b/pages/settings/SettingsCommute.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import { SimpleButton } from "@/components/common/SimpleButton";
-import { Spacer } from "@/components/core/Spacer";
 import { Column } from "@/components/core/Column";
 import { Text } from "@/components/core/Text";
 import { useSettings } from "@/hooks/useSettings";
@@ -21,9 +20,8 @@ export function SettingsCommute({ stations }: SettingsCommuteProps) {
   }
 
   return (
-    <Column align="left">
+    <Column align="left" className="gap-4">
       <Text style="subtitle">Commute</Text>
-      <Spacer h="4" />
       {settings.commute == null ? (
         <Text>No commute set.</Text>
       ) : (
@@ -61,7 +59,6 @@ function ResetCommuteButton({
         <b>{stations.find((x) => x.id === commuteA)?.name}</b> to{" "}
         <b>{stations.find((x) => x.id === commuteB)?.name}</b>.
       </Text>
-      <Spacer h="4" />
       <SimpleButton onClick={handleResetCookies} text="Reset commute" />
     </>
   );

--- a/pages/settings/SettingsDisruptions.tsx
+++ b/pages/settings/SettingsDisruptions.tsx
@@ -2,17 +2,16 @@ import React from "react";
 
 import { Column } from "@/components/core/Column";
 import { Text } from "@/components/core/Text";
-import { Spacer } from "@/components/core/Spacer";
-import {
-  filterableDisruptionCategories,
-  FilterableDisruptionCategory,
-} from "@/shared/settings";
+import { filterableDisruptionCategories } from "@/shared/settings";
 import { useSettings } from "@/hooks/useSettings";
+import { SettingsSwitch } from "@/components/settings/SettingsSwitch";
 
 const allCategories = ["essential", ...filterableDisruptionCategories] as const;
 
+type AnyDisruptionCategory = (typeof allCategories)[number];
+
 const formattedCategories: Record<
-  (typeof allCategories)[number],
+  AnyDisruptionCategory,
   { name: string; description?: string; disabled?: boolean }
 > = {
   essential: {
@@ -41,55 +40,34 @@ const formattedCategories: Record<
 export function SettingsDisruptions() {
   const [settings, setSettings] = useSettings();
 
-  function toggleCategory(category: FilterableDisruptionCategory) {
-    if (settings.enabledCategories.includes(category)) {
-      setSettings(settings.withoutEnabledCategories(category));
-    } else {
+  function toggleCategory(category: AnyDisruptionCategory, newValue: boolean) {
+    if (category === "essential") {
+      return;
+    }
+
+    if (newValue) {
       setSettings(settings.withEnabledCategories(category));
+    } else {
+      setSettings(settings.withoutEnabledCategories(category));
     }
   }
 
   return (
-    <Column>
+    <Column className="gap-4">
       <Text style="subtitle">Disruptions to show</Text>
-      <Spacer h="2" />
-
-      <Column>
-        {allCategories.map((category) => (
-          <label
-            key={category}
-            className="hover:bg-soft-hover flex cursor-pointer items-center justify-between py-2"
-          >
-            <input
-              type="checkbox"
-              value={category}
-              autoComplete="off"
-              className="peer sr-only"
-              checked={
-                (settings.enabledCategories as string[]).includes(category) ||
-                formattedCategories[category].disabled === true
-              }
-              disabled={formattedCategories[category].disabled}
-              onChange={
-                category !== "essential"
-                  ? () => toggleCategory(category)
-                  : undefined
-              }
-            />
-            <Column className="gap-2">
-              <Text>{formattedCategories[category].name}</Text>
-              {formattedCategories[category].description && (
-                <Text style="tiny-weak">
-                  {formattedCategories[category].description}
-                </Text>
-              )}
-            </Column>
-            <div className="bg-switch peer-checked:bg-accent hover:bg-switch-hover hover:peer-checked:bg-accent-hover flex h-5 w-9 items-center rounded-full p-0.5 transition-transform ease-in-out peer-checked:*:translate-x-full peer-disabled:opacity-50">
-              <div className="bg-switch-knob size-4 rounded-full transition-all" />
-            </div>
-          </label>
-        ))}
-      </Column>
+      {allCategories.map((category) => (
+        <SettingsSwitch
+          key={category}
+          title={formattedCategories[category].name}
+          description={formattedCategories[category].description}
+          onChange={(checked) => toggleCategory(category, checked)}
+          checked={
+            (settings.enabledCategories as string[]).includes(category) ||
+            formattedCategories[category].disabled === true
+          }
+          disabled={formattedCategories[category].disabled}
+        />
+      ))}
     </Column>
   );
 }

--- a/pages/settings/SettingsReset.tsx
+++ b/pages/settings/SettingsReset.tsx
@@ -4,7 +4,6 @@ import { SimpleButton } from "@/components/common/SimpleButton";
 import { Settings } from "@/shared/settings";
 import { Column } from "@/components/core/Column";
 import { Text } from "@/components/core/Text";
-import { Spacer } from "@/components/core/Spacer";
 import { applyTheme } from "@/pages/settings/utils";
 import { useSettings } from "@/hooks/useSettings";
 
@@ -17,13 +16,11 @@ export function SettingsReset() {
   }
 
   return (
-    <Column align="left">
+    <Column align="left" className="gap-4">
       <Text style="subtitle">Reset</Text>
-      <Spacer h="4" />
       <Text>
         Reset all settings to their default values. This cannot be undone!
       </Text>
-      <Spacer h="4" />
       <SimpleButton onClick={handleResetCookies} text="Reset" />
     </Column>
   );

--- a/pages/settings/SettingsStartPage.tsx
+++ b/pages/settings/SettingsStartPage.tsx
@@ -2,9 +2,9 @@ import React from "react";
 
 import { Column } from "@/components/core/Column";
 import { Text } from "@/components/core/Text";
-import { Spacer } from "@/components/core/Spacer";
 import { Startpage, startPages } from "@/shared/settings";
 import { useSettings } from "@/hooks/useSettings";
+import { SettingsRadioButton } from "@/components/settings/SettingsRadioButton";
 
 const formattedOptions: Record<(typeof startPages)[number], string> = {
   overview: "Overview",
@@ -19,28 +19,17 @@ export function SettingsStartPage() {
   }
 
   return (
-    <Column>
+    <Column className="gap-4">
       <Text style="subtitle">Start page</Text>
-      <Spacer h="2" />
-
-      <Column>
-        {startPages.map((option) => (
-          <label
-            key={option}
-            className="hover:bg-soft-hover flex cursor-pointer gap-2 py-2"
-          >
-            <input
-              type="radio"
-              name="start-page"
-              value={option}
-              checked={(settings.startPage as string).includes(option)}
-              onChange={() => updateStart(option)}
-              className="accent-accent"
-            />
-            <Text>{formattedOptions[option]}</Text>
-          </label>
-        ))}
-      </Column>
+      {startPages.map((option) => (
+        <SettingsRadioButton
+          key={option}
+          title={formattedOptions[option]}
+          group="start-page"
+          checked={(settings.startPage as string).includes(option)}
+          onChange={() => updateStart(option)}
+        />
+      ))}
     </Column>
   );
 }

--- a/pages/settings/SettingsTheme.tsx
+++ b/pages/settings/SettingsTheme.tsx
@@ -7,15 +7,13 @@ import { applyTheme } from "@/pages/settings/utils";
 import { useSettings } from "@/hooks/useSettings";
 import { SettingsRadioButton } from "@/components/settings/SettingsRadioButton";
 
-const titles: Record<(typeof themes)[number], string> = {
-  system: "Auto",
-  light: "Light",
-  dark: "Dark",
-};
-const descriptions: Record<(typeof themes)[number], string | null> = {
-  system: "Matches your device's/browser's settings.",
-  light: null,
-  dark: null,
+const formattedTheme: Record<
+  (typeof themes)[number],
+  { name: string; description: string | null }
+> = {
+  system: { name: "Auto", description: "Matches your device's settings." },
+  light: { name: "Light", description: null },
+  dark: { name: "Dark", description: null },
 };
 
 export function SettingsTheme() {
@@ -32,8 +30,8 @@ export function SettingsTheme() {
       {themes.map((theme) => (
         <SettingsRadioButton
           key={theme}
-          title={titles[theme]}
-          description={descriptions[theme] ?? undefined}
+          title={formattedTheme[theme].name}
+          description={formattedTheme[theme].description ?? undefined}
           group="theme"
           checked={(settings.theme as string).includes(theme)}
           onChange={() => updateTheme(theme)}

--- a/pages/settings/SettingsTheme.tsx
+++ b/pages/settings/SettingsTheme.tsx
@@ -2,15 +2,20 @@ import React from "react";
 
 import { Column } from "@/components/core/Column";
 import { Text } from "@/components/core/Text";
-import { Spacer } from "@/components/core/Spacer";
 import { Theme, themes } from "@/shared/settings";
 import { applyTheme } from "@/pages/settings/utils";
 import { useSettings } from "@/hooks/useSettings";
+import { SettingsRadioButton } from "@/components/settings/SettingsRadioButton";
 
-const formattedTheme: Record<(typeof themes)[number], string> = {
+const titles: Record<(typeof themes)[number], string> = {
   system: "Auto",
   light: "Light",
   dark: "Dark",
+};
+const descriptions: Record<(typeof themes)[number], string | null> = {
+  system: "Matches your device's/browser's settings.",
+  light: null,
+  dark: null,
 };
 
 export function SettingsTheme() {
@@ -22,27 +27,18 @@ export function SettingsTheme() {
   }
 
   return (
-    <Column>
+    <Column className="gap-4">
       <Text style="subtitle">Colour theme</Text>
-      <Spacer h="2" />
-      <Column>
-        {themes.map((theme) => (
-          <label
-            key={theme}
-            className="hover:bg-soft-hover flex cursor-pointer gap-2 py-2"
-          >
-            <input
-              type="radio"
-              name="theme"
-              value={theme}
-              checked={(settings.theme as string).includes(theme)}
-              onChange={() => updateTheme(theme)}
-              className="accent-accent"
-            />
-            <Text>{formattedTheme[theme]}</Text>
-          </label>
-        ))}
-      </Column>
+      {themes.map((theme) => (
+        <SettingsRadioButton
+          key={theme}
+          title={titles[theme]}
+          description={descriptions[theme] ?? undefined}
+          group="theme"
+          checked={(settings.theme as string).includes(theme)}
+          onChange={() => updateTheme(theme)}
+        />
+      ))}
     </Column>
   );
 }


### PR DESCRIPTION
### Changes
- Adds `<SettingsSwitch>` which uses `<Switch>` behind the scenes, which in turn uses `<Checkbox>`.
- Adds `<SettingsRadioButton>` which uses `<RadioButton>` behind the scenes, which in turn uses `<Radio>`.
- Update the settings page to use the new components.

### Structure
- `<Checkbox>` and `<Radio>` setup the invisible `<input>` element and wrap everything in `<label>`.
- `<Switch>` and `<RadioButton>` provide and position the styled switch and radio button graphics.
- `<SettingsSwitch>` and `<SettingsRadioButton>` are designed specifically for the settings page. They set the `<Text>` styles and provide the hover highlighting.