### PR TITLE
Map highlighting (Part 5: Assigning map segments to line shape edges)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
 
   // Configures VSCode's auto import to use "@/..." paths.
   "typescript.preferences.importModuleSpecifier": "non-relative",
-  "javascript.preferences.importModuleSpecifier": "non-relative"
+  "javascript.preferences.importModuleSpecifier": "non-relative",
+  "editor.formatOnPaste": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,5 @@
 
   // Configures VSCode's auto import to use "@/..." paths.
   "typescript.preferences.importModuleSpecifier": "non-relative",
-  "javascript.preferences.importModuleSpecifier": "non-relative",
-  "editor.formatOnPaste": false
+  "javascript.preferences.importModuleSpecifier": "non-relative"
 }

--- a/server/data/line/line-routes/line-shape.ts
+++ b/server/data/line/line-routes/line-shape.ts
@@ -1,10 +1,14 @@
 import { unique } from "@dan-schel/js-utils";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import { Edge, Tree } from "@/server/data/line/line-routes/tree";
+import { MapSegment } from "@/server/data/map-segment";
 
 export type LineShapeNode = number | "the-city";
 
-export type LineShapeEdgeData = { routeGraphPairs: StationPair[] };
+export type LineShapeEdgeData = {
+  routeGraphPairs: StationPair[];
+  mapSegments: MapSegment[];
+};
 
 /**
  * An edge in the LineShape tree. Each edge stores the route graph pairs that
@@ -15,8 +19,12 @@ export class LineShapeEdge extends Edge<LineShapeNode, LineShapeEdgeData> {
     from: LineShapeNode,
     to: LineShapeNode,
     routeGraphPairs: StationPair[],
+    mapSegments: MapSegment[],
   ) {
-    super(from, to, { routeGraphPairs });
+    super(from, to, {
+      routeGraphPairs,
+      mapSegments: mapSegments.map((x) => x.normalize()),
+    });
 
     if (routeGraphPairs.length === 0) {
       throw new Error("LineShapeEdge created without any routeGraphPairs.");

--- a/server/data/map-segment.ts
+++ b/server/data/map-segment.ts
@@ -62,4 +62,8 @@ export class MapSegment {
       return condensedRanges.map((r) => group.items[0].withRange(r));
     });
   }
+
+  static full(mapNodeA: number, mapNodeB: number): MapSegment {
+    return new MapSegment(mapNodeA, mapNodeB, new Range(0, 1));
+  }
 }

--- a/server/data/map-segment.ts
+++ b/server/data/map-segment.ts
@@ -50,6 +50,14 @@ export class MapSegment {
     return new MapSegment(this.mapNodeA, this.mapNodeB, range);
   }
 
+  part(part: number, total: number): MapSegment {
+    return new MapSegment(
+      this.mapNodeA,
+      this.mapNodeB,
+      new Range((part - 1) / total, part / total),
+    );
+  }
+
   static condense(segments: MapSegment[]): MapSegment[] {
     function key(s: MapSegment): string {
       return `${s.mapNodeA}-${s.mapNodeB}`;

--- a/server/entry-point/data/lines/alamein.ts
+++ b/server/entry-point/data/lines/alamein.ts
@@ -39,43 +39,43 @@ const lineShapeEdges = [
     routeGraph.flagstaffToMelbourneCentral,
     routeGraph.melbourneCentralToParliament,
     routeGraph.parliamentToRichmond,
-  ]),
+  ], []),
   new LineShapeEdge(station.RICHMOND, station.EAST_RICHMOND, [
     routeGraph.richmondToEastRichmond,
-  ]),
+  ], []),
   new LineShapeEdge(station.EAST_RICHMOND, station.BURNLEY, [
     routeGraph.eastRichmondToBurnley,
-  ]),
+  ], []),
   new LineShapeEdge(station.BURNLEY, station.HAWTHORN, [
     routeGraph.burnleyToHawthorn,
-  ]),
+  ], []),
   new LineShapeEdge(station.HAWTHORN, station.GLENFERRIE, [
     routeGraph.hawthornToGlenferrie,
-  ]),
+  ], []),
   new LineShapeEdge(station.GLENFERRIE, station.AUBURN, [
     routeGraph.glenferrieToAuburn,
-  ]),
+  ], []),
   new LineShapeEdge(station.AUBURN, station.CAMBERWELL, [
     routeGraph.auburnToCamberwell,
-  ]),
+  ], []),
   new LineShapeEdge(station.CAMBERWELL, station.RIVERSDALE, [
     routeGraph.camberwellToRiversdale,
-  ]),
+  ], []),
   new LineShapeEdge(station.RIVERSDALE, station.WILLISON, [
     routeGraph.riversdaleToWillison,
-  ]),
+  ], []),
   new LineShapeEdge(station.WILLISON, station.HARTWELL, [
     routeGraph.willisonToHartwell,
-  ]),
+  ], []),
   new LineShapeEdge(station.HARTWELL, station.BURWOOD, [
     routeGraph.hartwellToBurwood,
-  ]),
+  ], []),
   new LineShapeEdge(station.BURWOOD, station.ASHBURTON, [
     routeGraph.burwoodToAshburton,
-  ]),
+  ], []),
   new LineShapeEdge(station.ASHBURTON, station.ALAMEIN, [
     routeGraph.ashburtonToAlamein,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/alamein.ts
+++ b/server/entry-point/data/lines/alamein.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -28,6 +30,19 @@ const routeGraph = {
   hartwellToBurwood: new StationPair(station.HARTWELL, station.BURWOOD),
   burwoodToAshburton: new StationPair(station.BURWOOD, station.ASHBURTON),
   ashburtonToAlamein: new StationPair(station.ASHBURTON, station.ALAMEIN),
+};
+
+// prettier-ignore
+const mapSegment = {
+  flindersStreetToRichmond: MapSegment.full(map.BURNLEY.FLINDERS_STREET_DIRECT, map.BURNLEY.RICHMOND),
+  flindersStreetToSouthernCross: MapSegment.full(map.BURNLEY.FLINDERS_STREET_LOOP, map.BURNLEY.SOUTHERN_CROSS),
+  southernCrossToFlagstaff: MapSegment.full(map.BURNLEY.SOUTHERN_CROSS, map.BURNLEY.FLAGSTAFF),
+  flagstaffToMelbourneCentral: MapSegment.full(map.BURNLEY.FLAGSTAFF, map.BURNLEY.MELBOURNE_CENTRAL),
+  melbourneCentralToParliament: MapSegment.full(map.BURNLEY.MELBOURNE_CENTRAL, map.BURNLEY.PARLIAMENT),
+  parliamentToRichmond: MapSegment.full(map.BURNLEY.PARLIAMENT, map.BURNLEY.RICHMOND),
+  richmondToBurnley: MapSegment.full(map.BURNLEY.RICHMOND, map.BURNLEY.BURNLEY),
+  burnleyToCamberwell: MapSegment.full(map.BURNLEY.BURNLEY, map.BURNLEY.CAMBERWELL),
+  camberwellToAlamein: MapSegment.full(map.BURNLEY.CAMBERWELL, map.BURNLEY.ALAMEIN),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/alamein.ts
+++ b/server/entry-point/data/lines/alamein.ts
@@ -54,43 +54,74 @@ const lineShapeEdges = [
     routeGraph.flagstaffToMelbourneCentral,
     routeGraph.melbourneCentralToParliament,
     routeGraph.parliamentToRichmond,
-  ], []),
+  ], [
+    mapSegment.flindersStreetToRichmond,
+    mapSegment.flindersStreetToSouthernCross,
+    mapSegment.southernCrossToFlagstaff,
+    mapSegment.flagstaffToMelbourneCentral,
+    mapSegment.melbourneCentralToParliament,
+    mapSegment.parliamentToRichmond,
+  ]),
   new LineShapeEdge(station.RICHMOND, station.EAST_RICHMOND, [
     routeGraph.richmondToEastRichmond,
-  ], []),
+  ], [
+    mapSegment.richmondToBurnley.part(1, 2),
+  ]),
   new LineShapeEdge(station.EAST_RICHMOND, station.BURNLEY, [
     routeGraph.eastRichmondToBurnley,
-  ], []),
+  ], [
+    mapSegment.richmondToBurnley.part(2, 2),
+  ]),
   new LineShapeEdge(station.BURNLEY, station.HAWTHORN, [
     routeGraph.burnleyToHawthorn,
-  ], []),
+  ], [
+    mapSegment.burnleyToCamberwell.part(1, 4),
+  ]),
   new LineShapeEdge(station.HAWTHORN, station.GLENFERRIE, [
     routeGraph.hawthornToGlenferrie,
-  ], []),
+  ], [
+    mapSegment.burnleyToCamberwell.part(2, 4),
+  ]),
   new LineShapeEdge(station.GLENFERRIE, station.AUBURN, [
     routeGraph.glenferrieToAuburn,
-  ], []),
+  ], [
+    mapSegment.burnleyToCamberwell.part(3, 4),
+  ]),
   new LineShapeEdge(station.AUBURN, station.CAMBERWELL, [
     routeGraph.auburnToCamberwell,
-  ], []),
+  ], [
+    mapSegment.burnleyToCamberwell.part(4, 4),
+  ]),
   new LineShapeEdge(station.CAMBERWELL, station.RIVERSDALE, [
     routeGraph.camberwellToRiversdale,
-  ], []),
+  ], [
+    mapSegment.camberwellToAlamein.part(1, 6),
+  ]),
   new LineShapeEdge(station.RIVERSDALE, station.WILLISON, [
     routeGraph.riversdaleToWillison,
-  ], []),
+  ], [
+    mapSegment.camberwellToAlamein.part(2, 6),
+  ]),
   new LineShapeEdge(station.WILLISON, station.HARTWELL, [
     routeGraph.willisonToHartwell,
-  ], []),
+  ], [
+    mapSegment.camberwellToAlamein.part(3, 6),
+  ]),
   new LineShapeEdge(station.HARTWELL, station.BURWOOD, [
     routeGraph.hartwellToBurwood,
-  ], []),
+  ], [
+    mapSegment.camberwellToAlamein.part(4, 6),
+  ]),
   new LineShapeEdge(station.BURWOOD, station.ASHBURTON, [
     routeGraph.burwoodToAshburton,
-  ], []),
+  ], [
+    mapSegment.camberwellToAlamein.part(5, 6),
+  ]),
   new LineShapeEdge(station.ASHBURTON, station.ALAMEIN, [
     routeGraph.ashburtonToAlamein,
-  ], []),
+  ], [
+    mapSegment.camberwellToAlamein.part(6, 6),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/ballarat.ts
+++ b/server/entry-point/data/lines/ballarat.ts
@@ -49,61 +49,100 @@ const mapSegment = {
 const lineShapeEdges = [
   new LineShapeEdge(station.SOUTHERN_CROSS, station.FOOTSCRAY, [
     routeGraph.southernCrossToArdeer,
-  ], []),
+  ], [
+    mapSegment.southernCrossToNorthMelbourneJunction,
+    mapSegment.northMelbourneJunctionToNorthMelbourne,
+    mapSegment.northMelbourneToFootscray,
+  ]),
   new LineShapeEdge(station.FOOTSCRAY, station.SUNSHINE, [
     routeGraph.southernCrossToArdeer,
     routeGraph.footscrayToArdeer,
-  ], []),
+  ], [
+    mapSegment.footscrayToSunshineJunction,
+    mapSegment.sunshineJunctionToSunshine,
+  ]),
   new LineShapeEdge(station.SUNSHINE, station.ARDEER, [
     routeGraph.southernCrossToArdeer,
     routeGraph.footscrayToArdeer,
     routeGraph.sunshineToArdeer,
-  ], []),
+  ], [
+    mapSegment.sunshineToDeerPark.part(1, 2),
+  ]),
   new LineShapeEdge(station.ARDEER, station.DEER_PARK, [
     routeGraph.ardeerToDeerPark,
-  ], []),
+  ], [
+    mapSegment.sunshineToDeerPark.part(2, 2),
+  ]),
   new LineShapeEdge(station.DEER_PARK, station.CAROLINE_SPRINGS, [
     routeGraph.deerParkToCarolineSprings,
-  ], []),
+  ], [
+    mapSegment.deerParkToBallarat.part(1, 7),
+  ]),
   new LineShapeEdge(station.CAROLINE_SPRINGS, station.ROCKBANK, [
     routeGraph.carolineSpringsToRockbank,
-  ], []),
+  ], [
+    mapSegment.deerParkToBallarat.part(2, 7),
+  ]),
   new LineShapeEdge(station.ROCKBANK, station.COBBLEBANK, [
     routeGraph.rockbankToCobblebank,
-  ], []),
+  ], [
+    mapSegment.deerParkToBallarat.part(3, 7),
+  ]),
   new LineShapeEdge(station.COBBLEBANK, station.MELTON, [
     routeGraph.cobblebankToMelton,
-  ], []),
+  ], [
+    mapSegment.deerParkToBallarat.part(4, 7),
+  ]),
   new LineShapeEdge(station.MELTON, station.BACCHUS_MARSH, [
     routeGraph.meltonToBacchusMarsh,
-  ], []),
+  ], [
+    mapSegment.deerParkToBallarat.part(5, 7),
+  ]),
   new LineShapeEdge(station.BACCHUS_MARSH, station.BALLAN, [
     routeGraph.bacchusMarshToBallan,
-  ], []),
+  ], [
+    mapSegment.deerParkToBallarat.part(6, 7),
+  ]),
   new LineShapeEdge(station.BALLAN, station.BALLARAT, [
     routeGraph.ballanToBallarat,
-  ], []),
+  ], [
+    mapSegment.deerParkToBallarat.part(7, 7),
+  ]),
   new LineShapeEdge(station.BALLARAT, station.CRESWICK, [
     routeGraph.ballaratToCreswick,
-  ], []),
+  ], [
+    mapSegment.ballaratToMaryborough.part(1, 4),
+  ]),
   new LineShapeEdge(station.CRESWICK, station.CLUNES, [
     routeGraph.creswickToClunes,
-  ], []),
+  ], [
+    mapSegment.ballaratToMaryborough.part(2, 4),
+  ]),
   new LineShapeEdge(station.CLUNES, station.TALBOT, [
     routeGraph.clunesToTalbot,
-  ], []),
+  ], [
+    mapSegment.ballaratToMaryborough.part(3, 4),
+  ]),
   new LineShapeEdge(station.TALBOT, station.MARYBOROUGH, [
     routeGraph.talbotToMaryborough,
-  ], []),
+  ], [
+    mapSegment.ballaratToMaryborough.part(4, 4),
+  ]),
   new LineShapeEdge(station.BALLARAT, station.WENDOUREE, [
     routeGraph.ballaratToWendouree,
-  ], []),
+  ], [
+    mapSegment.ballaratToArarat.part(1, 3),
+  ]),
   new LineShapeEdge(station.WENDOUREE, station.BEAUFORT, [
     routeGraph.wendoureeToBeaufort,
-  ], []),
+  ], [
+    mapSegment.ballaratToArarat.part(2, 3),
+  ]),
   new LineShapeEdge(station.BEAUFORT, station.ARARAT, [
     routeGraph.beaufortToArarat,
-  ], []),
+  ], [
+    mapSegment.ballaratToArarat.part(3, 3),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/ballarat.ts
+++ b/server/entry-point/data/lines/ballarat.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -28,6 +30,19 @@ const routeGraph = {
   ballaratToWendouree: new StationPair(station.BALLARAT, station.WENDOUREE),
   wendoureeToBeaufort: new StationPair(station.WENDOUREE, station.BEAUFORT),
   beaufortToArarat: new StationPair(station.BEAUFORT, station.ARARAT),
+};
+
+// prettier-ignore
+const mapSegment = {
+  southernCrossToNorthMelbourneJunction: MapSegment.full(map.REGIONAL_WESTERN.SOUTHERN_CROSS, map.REGIONAL_WESTERN.NORTH_MELBOURNE_JUNCTION),
+  northMelbourneJunctionToNorthMelbourne: MapSegment.full(map.REGIONAL_WESTERN.NORTH_MELBOURNE_JUNCTION, map.REGIONAL_WESTERN.NORTH_MELBOURNE_RRL),
+  northMelbourneToFootscray: MapSegment.full(map.REGIONAL_WESTERN.NORTH_MELBOURNE_RRL, map.REGIONAL_WESTERN.FOOTSCRAY),
+  footscrayToSunshineJunction: MapSegment.full(map.REGIONAL_WESTERN.FOOTSCRAY, map.REGIONAL_WESTERN.SUNSHINE_JUNCTION),
+  sunshineJunctionToSunshine: MapSegment.full(map.REGIONAL_WESTERN.SUNSHINE_JUNCTION, map.REGIONAL_WESTERN.SUNSHINE_DEER_PARK),
+  sunshineToDeerPark: MapSegment.full(map.REGIONAL_WESTERN.SUNSHINE_DEER_PARK, map.REGIONAL_WESTERN.DEER_PARK),
+  deerParkToBallarat: MapSegment.full(map.REGIONAL_WESTERN.DEER_PARK, map.REGIONAL_WESTERN.BALLARAT),
+  ballaratToMaryborough: MapSegment.full(map.REGIONAL_WESTERN.BALLARAT, map.REGIONAL_WESTERN.MARYBOROUGH),
+  ballaratToArarat: MapSegment.full(map.REGIONAL_WESTERN.BALLARAT, map.REGIONAL_WESTERN.ARARAT),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/ballarat.ts
+++ b/server/entry-point/data/lines/ballarat.ts
@@ -34,61 +34,61 @@ const routeGraph = {
 const lineShapeEdges = [
   new LineShapeEdge(station.SOUTHERN_CROSS, station.FOOTSCRAY, [
     routeGraph.southernCrossToArdeer,
-  ]),
+  ], []),
   new LineShapeEdge(station.FOOTSCRAY, station.SUNSHINE, [
     routeGraph.southernCrossToArdeer,
     routeGraph.footscrayToArdeer,
-  ]),
+  ], []),
   new LineShapeEdge(station.SUNSHINE, station.ARDEER, [
     routeGraph.southernCrossToArdeer,
     routeGraph.footscrayToArdeer,
     routeGraph.sunshineToArdeer,
-  ]),
+  ], []),
   new LineShapeEdge(station.ARDEER, station.DEER_PARK, [
     routeGraph.ardeerToDeerPark,
-  ]),
+  ], []),
   new LineShapeEdge(station.DEER_PARK, station.CAROLINE_SPRINGS, [
     routeGraph.deerParkToCarolineSprings,
-  ]),
+  ], []),
   new LineShapeEdge(station.CAROLINE_SPRINGS, station.ROCKBANK, [
     routeGraph.carolineSpringsToRockbank,
-  ]),
+  ], []),
   new LineShapeEdge(station.ROCKBANK, station.COBBLEBANK, [
     routeGraph.rockbankToCobblebank,
-  ]),
+  ], []),
   new LineShapeEdge(station.COBBLEBANK, station.MELTON, [
     routeGraph.cobblebankToMelton,
-  ]),
+  ], []),
   new LineShapeEdge(station.MELTON, station.BACCHUS_MARSH, [
     routeGraph.meltonToBacchusMarsh,
-  ]),
+  ], []),
   new LineShapeEdge(station.BACCHUS_MARSH, station.BALLAN, [
     routeGraph.bacchusMarshToBallan,
-  ]),
+  ], []),
   new LineShapeEdge(station.BALLAN, station.BALLARAT, [
     routeGraph.ballanToBallarat,
-  ]),
+  ], []),
   new LineShapeEdge(station.BALLARAT, station.CRESWICK, [
     routeGraph.ballaratToCreswick,
-  ]),
+  ], []),
   new LineShapeEdge(station.CRESWICK, station.CLUNES, [
     routeGraph.creswickToClunes,
-  ]),
+  ], []),
   new LineShapeEdge(station.CLUNES, station.TALBOT, [
     routeGraph.clunesToTalbot,
-  ]),
+  ], []),
   new LineShapeEdge(station.TALBOT, station.MARYBOROUGH, [
     routeGraph.talbotToMaryborough,
-  ]),
+  ], []),
   new LineShapeEdge(station.BALLARAT, station.WENDOUREE, [
     routeGraph.ballaratToWendouree,
-  ]),
+  ], []),
   new LineShapeEdge(station.WENDOUREE, station.BEAUFORT, [
     routeGraph.wendoureeToBeaufort,
-  ]),
+  ], []),
   new LineShapeEdge(station.BEAUFORT, station.ARARAT, [
     routeGraph.beaufortToArarat,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/belgrave.ts
+++ b/server/entry-point/data/lines/belgrave.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -41,6 +43,20 @@ const routeGraph = {
   upperFerntreeGullyToUpwey: new StationPair(station.UPPER_FERNTREE_GULLY, station.UPWEY),
   upweyToTecoma: new StationPair(station.UPWEY, station.TECOMA),
   tecomaToBelgrave: new StationPair(station.TECOMA, station.BELGRAVE),
+};
+
+// prettier-ignore
+const mapSegment = {
+  flindersStreetToRichmond: MapSegment.full(map.BURNLEY.FLINDERS_STREET_DIRECT, map.BURNLEY.RICHMOND),
+  flindersStreetToSouthernCross: MapSegment.full(map.BURNLEY.FLINDERS_STREET_LOOP, map.BURNLEY.SOUTHERN_CROSS),
+  southernCrossToFlagstaff: MapSegment.full(map.BURNLEY.SOUTHERN_CROSS, map.BURNLEY.FLAGSTAFF),
+  flagstaffToMelbourneCentral: MapSegment.full(map.BURNLEY.FLAGSTAFF, map.BURNLEY.MELBOURNE_CENTRAL),
+  melbourneCentralToParliament: MapSegment.full(map.BURNLEY.MELBOURNE_CENTRAL, map.BURNLEY.PARLIAMENT),
+  parliamentToRichmond: MapSegment.full(map.BURNLEY.PARLIAMENT, map.BURNLEY.RICHMOND),
+  richmondToBurnley: MapSegment.full(map.BURNLEY.RICHMOND, map.BURNLEY.BURNLEY),
+  burnleyToCamberwell: MapSegment.full(map.BURNLEY.BURNLEY, map.BURNLEY.CAMBERWELL),
+  camberwellToRingwood: MapSegment.full(map.BURNLEY.CAMBERWELL, map.BURNLEY.RINGWOOD),
+  ringwoodToBelgrave: MapSegment.full(map.BURNLEY.RINGWOOD, map.BURNLEY.BELGRAVE),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/belgrave.ts
+++ b/server/entry-point/data/lines/belgrave.ts
@@ -68,82 +68,139 @@ const lineShapeEdges = [
     routeGraph.flagstaffToMelbourneCentral,
     routeGraph.melbourneCentralToParliament,
     routeGraph.parliamentToRichmond,
-  ], []),
+  ], [
+    mapSegment.flindersStreetToRichmond,
+    mapSegment.flindersStreetToSouthernCross,
+    mapSegment.southernCrossToFlagstaff,
+    mapSegment.flagstaffToMelbourneCentral,
+    mapSegment.melbourneCentralToParliament,
+    mapSegment.parliamentToRichmond,
+  ]),
   new LineShapeEdge(station.RICHMOND, station.EAST_RICHMOND, [
     routeGraph.richmondToEastRichmond,
-  ], []),
+  ], [
+    mapSegment.richmondToBurnley.part(1, 2),
+  ]),
   new LineShapeEdge(station.EAST_RICHMOND, station.BURNLEY, [
     routeGraph.eastRichmondToBurnley,
-  ], []),
+  ], [
+    mapSegment.richmondToBurnley.part(2, 2),
+  ]),
   new LineShapeEdge(station.BURNLEY, station.HAWTHORN, [
     routeGraph.burnleyToHawthorn,
-  ], []),
+  ], [
+    mapSegment.burnleyToCamberwell.part(1, 4),
+  ]),
   new LineShapeEdge(station.HAWTHORN, station.GLENFERRIE, [
     routeGraph.hawthornToGlenferrie,
-  ], []),
+  ], [
+    mapSegment.burnleyToCamberwell.part(2, 4),
+  ]),
   new LineShapeEdge(station.GLENFERRIE, station.AUBURN, [
     routeGraph.glenferrieToAuburn,
-  ], []),
+  ], [
+    mapSegment.burnleyToCamberwell.part(3, 4),
+  ]),
   new LineShapeEdge(station.AUBURN, station.CAMBERWELL, [
     routeGraph.auburnToCamberwell,
-  ], []),
+  ], [
+    mapSegment.burnleyToCamberwell.part(4, 4),
+  ]),
   new LineShapeEdge(station.CAMBERWELL, station.EAST_CAMBERWELL, [
     routeGraph.camberwellToEastCamberwell,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(1, 11),
+  ]),
   new LineShapeEdge(station.EAST_CAMBERWELL, station.CANTERBURY, [
     routeGraph.eastCamberwellToCanterbury,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(2, 11),
+  ]),
   new LineShapeEdge(station.CANTERBURY, station.CHATHAM, [
     routeGraph.canterburyToChatham,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(3, 11),
+  ]),
   new LineShapeEdge(station.CHATHAM, station.UNION, [
     routeGraph.chathamToUnion,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(4, 11),
+  ]),
   new LineShapeEdge(station.UNION, station.BOX_HILL, [
     routeGraph.unionToBoxHill,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(5, 11),
+  ]),
   new LineShapeEdge(station.BOX_HILL, station.LABURNUM, [
     routeGraph.boxHillToLaburnum,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(6, 11),
+  ]),
   new LineShapeEdge(station.LABURNUM, station.BLACKBURN, [
     routeGraph.laburnumToBlackburn,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(7, 11),
+  ]),
   new LineShapeEdge(station.BLACKBURN, station.NUNAWADING, [
     routeGraph.blackburnToNunawading,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(8, 11),
+  ]),
   new LineShapeEdge(station.NUNAWADING, station.MITCHAM, [
     routeGraph.nunawadingToMitcham,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(9, 11),
+  ]),
   new LineShapeEdge(station.MITCHAM, station.HEATHERDALE, [
     routeGraph.mitchamToHeatherdale,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(10, 11),
+  ]),
   new LineShapeEdge(station.HEATHERDALE, station.RINGWOOD, [
     routeGraph.heatherdaleToRingwood,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(11, 11),
+  ]),
   new LineShapeEdge(station.RINGWOOD, station.HEATHMONT, [
     routeGraph.ringwoodToHeathmont,
-  ], []),
+  ], [
+    mapSegment.ringwoodToBelgrave.part(1, 8),
+  ]),
   new LineShapeEdge(station.HEATHMONT, station.BAYSWATER, [
     routeGraph.heathmontToBayswater,
-  ], []),
+  ], [
+    mapSegment.ringwoodToBelgrave.part(2, 8),
+  ]),
   new LineShapeEdge(station.BAYSWATER, station.BORONIA, [
     routeGraph.bayswaterToBoronia,
-  ], []),
+  ], [
+    mapSegment.ringwoodToBelgrave.part(3, 8),
+  ]),
   new LineShapeEdge(station.BORONIA, station.FERNTREE_GULLY, [
     routeGraph.boroniaToFerntreeGully,
-  ], []),
+  ], [
+    mapSegment.ringwoodToBelgrave.part(4, 8),
+  ]),
   new LineShapeEdge(station.FERNTREE_GULLY, station.UPPER_FERNTREE_GULLY, [
     routeGraph.ferntreeGullyToUpperFerntreeGully,
-  ], []),
+  ], [
+    mapSegment.ringwoodToBelgrave.part(5, 8),
+  ]),
   new LineShapeEdge(station.UPPER_FERNTREE_GULLY, station.UPWEY, [
     routeGraph.upperFerntreeGullyToUpwey,
-  ], []),
+  ], [
+    mapSegment.ringwoodToBelgrave.part(6, 8),
+  ]),
   new LineShapeEdge(station.UPWEY, station.TECOMA, [
     routeGraph.upweyToTecoma,
-  ], []),
+  ], [
+    mapSegment.ringwoodToBelgrave.part(7, 8),
+  ]),
   new LineShapeEdge(station.TECOMA, station.BELGRAVE, [
     routeGraph.tecomaToBelgrave,
-  ], []),
+  ], [
+    mapSegment.ringwoodToBelgrave.part(8, 8),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/belgrave.ts
+++ b/server/entry-point/data/lines/belgrave.ts
@@ -52,82 +52,82 @@ const lineShapeEdges = [
     routeGraph.flagstaffToMelbourneCentral,
     routeGraph.melbourneCentralToParliament,
     routeGraph.parliamentToRichmond,
-  ]),
+  ], []),
   new LineShapeEdge(station.RICHMOND, station.EAST_RICHMOND, [
     routeGraph.richmondToEastRichmond,
-  ]),
+  ], []),
   new LineShapeEdge(station.EAST_RICHMOND, station.BURNLEY, [
     routeGraph.eastRichmondToBurnley,
-  ]),
+  ], []),
   new LineShapeEdge(station.BURNLEY, station.HAWTHORN, [
     routeGraph.burnleyToHawthorn,
-  ]),
+  ], []),
   new LineShapeEdge(station.HAWTHORN, station.GLENFERRIE, [
     routeGraph.hawthornToGlenferrie,
-  ]),
+  ], []),
   new LineShapeEdge(station.GLENFERRIE, station.AUBURN, [
     routeGraph.glenferrieToAuburn,
-  ]),
+  ], []),
   new LineShapeEdge(station.AUBURN, station.CAMBERWELL, [
     routeGraph.auburnToCamberwell,
-  ]),
+  ], []),
   new LineShapeEdge(station.CAMBERWELL, station.EAST_CAMBERWELL, [
     routeGraph.camberwellToEastCamberwell,
-  ]),
+  ], []),
   new LineShapeEdge(station.EAST_CAMBERWELL, station.CANTERBURY, [
     routeGraph.eastCamberwellToCanterbury,
-  ]),
+  ], []),
   new LineShapeEdge(station.CANTERBURY, station.CHATHAM, [
     routeGraph.canterburyToChatham,
-  ]),
+  ], []),
   new LineShapeEdge(station.CHATHAM, station.UNION, [
     routeGraph.chathamToUnion,
-  ]),
+  ], []),
   new LineShapeEdge(station.UNION, station.BOX_HILL, [
     routeGraph.unionToBoxHill,
-  ]),
+  ], []),
   new LineShapeEdge(station.BOX_HILL, station.LABURNUM, [
     routeGraph.boxHillToLaburnum,
-  ]),
+  ], []),
   new LineShapeEdge(station.LABURNUM, station.BLACKBURN, [
     routeGraph.laburnumToBlackburn,
-  ]),
+  ], []),
   new LineShapeEdge(station.BLACKBURN, station.NUNAWADING, [
     routeGraph.blackburnToNunawading,
-  ]),
+  ], []),
   new LineShapeEdge(station.NUNAWADING, station.MITCHAM, [
     routeGraph.nunawadingToMitcham,
-  ]),
+  ], []),
   new LineShapeEdge(station.MITCHAM, station.HEATHERDALE, [
     routeGraph.mitchamToHeatherdale,
-  ]),
+  ], []),
   new LineShapeEdge(station.HEATHERDALE, station.RINGWOOD, [
     routeGraph.heatherdaleToRingwood,
-  ]),
+  ], []),
   new LineShapeEdge(station.RINGWOOD, station.HEATHMONT, [
     routeGraph.ringwoodToHeathmont,
-  ]),
+  ], []),
   new LineShapeEdge(station.HEATHMONT, station.BAYSWATER, [
     routeGraph.heathmontToBayswater,
-  ]),
+  ], []),
   new LineShapeEdge(station.BAYSWATER, station.BORONIA, [
     routeGraph.bayswaterToBoronia,
-  ]),
+  ], []),
   new LineShapeEdge(station.BORONIA, station.FERNTREE_GULLY, [
     routeGraph.boroniaToFerntreeGully,
-  ]),
+  ], []),
   new LineShapeEdge(station.FERNTREE_GULLY, station.UPPER_FERNTREE_GULLY, [
     routeGraph.ferntreeGullyToUpperFerntreeGully,
-  ]),
+  ], []),
   new LineShapeEdge(station.UPPER_FERNTREE_GULLY, station.UPWEY, [
     routeGraph.upperFerntreeGullyToUpwey,
-  ]),
+  ], []),
   new LineShapeEdge(station.UPWEY, station.TECOMA, [
     routeGraph.upweyToTecoma,
-  ]),
+  ], []),
   new LineShapeEdge(station.TECOMA, station.BELGRAVE, [
     routeGraph.tecomaToBelgrave,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/bendigo.ts
+++ b/server/entry-point/data/lines/bendigo.ts
@@ -57,82 +57,136 @@ const mapSegment = {
 const lineShapeEdges = [
   new LineShapeEdge(station.SOUTHERN_CROSS, station.FOOTSCRAY, [
     routeGraph.southernCrossToSunbury,
-  ], []),
+  ], [
+    mapSegment.southernCrossToNorthMelbourneJunction,
+    mapSegment.northMelbourneJunctionToNorthMelbourne,
+    mapSegment.northMelbourneToFootscray,
+  ]),
   new LineShapeEdge(station.FOOTSCRAY, station.WATERGARDENS, [
     routeGraph.southernCrossToSunbury,
     routeGraph.footscrayToSunbury,
-  ], []),
+  ], [
+    mapSegment.footscrayToSunshineJunction,
+    mapSegment.sunshineJunctionToSunshine,
+    mapSegment.sunshineToWatergardens,
+  ]),
   new LineShapeEdge(station.WATERGARDENS, station.SUNBURY, [
     routeGraph.southernCrossToSunbury,
     routeGraph.footscrayToSunbury,
     routeGraph.watergardensToSunbury,
-  ], []),
+  ], [
+    mapSegment.watergardensToSunbury,
+  ]),
   new LineShapeEdge(station.SUNBURY, station.CLARKEFIELD, [
     routeGraph.sunburyToClarkefield,
-  ], []),
+  ], [
+    mapSegment.sunburyToBendigo.part(1, 10),
+  ]),
   new LineShapeEdge(station.CLARKEFIELD, station.RIDDELLS_CREEK, [
     routeGraph.clarkefieldToRiddellsCreek,
-  ], []),
+  ], [
+    mapSegment.sunburyToBendigo.part(2, 10),
+  ]),
   new LineShapeEdge(station.RIDDELLS_CREEK, station.GISBORNE, [
     routeGraph.riddellsCreekToGisborne,
-  ], []),
+  ], [
+    mapSegment.sunburyToBendigo.part(3, 10),
+  ]),
   new LineShapeEdge(station.GISBORNE, station.MACEDON, [
     routeGraph.gisborneToMacedon,
-  ], []),
+  ], [
+    mapSegment.sunburyToBendigo.part(4, 10),
+  ]),
   new LineShapeEdge(station.MACEDON, station.WOODEND, [
     routeGraph.macedonToWoodend,
-  ], []),
+  ], [
+    mapSegment.sunburyToBendigo.part(5, 10),
+  ]),
   new LineShapeEdge(station.WOODEND, station.KYNETON, [
     routeGraph.woodendToKyneton,
-  ], []),
+  ], [
+    mapSegment.sunburyToBendigo.part(6, 10),
+  ]),
   new LineShapeEdge(station.KYNETON, station.MALMSBURY, [
     routeGraph.kynetonToMalmsbury,
-  ], []),
+  ], [
+    mapSegment.sunburyToBendigo.part(7, 10),
+  ]),
   new LineShapeEdge(station.MALMSBURY, station.CASTLEMAINE, [
     routeGraph.malmsburyToCastlemaine,
-  ], []),
+  ], [
+    mapSegment.sunburyToBendigo.part(8, 10),
+  ]),
   new LineShapeEdge(station.CASTLEMAINE, station.KANGAROO_FLAT, [
     routeGraph.castlemaineToKangarooFlat,
-  ], []),
+  ], [
+    mapSegment.sunburyToBendigo.part(9, 10),
+  ]),
   new LineShapeEdge(station.KANGAROO_FLAT, station.BENDIGO, [
     routeGraph.kangarooFlatToBendigo,
-  ], []),
+  ], [
+    mapSegment.sunburyToBendigo.part(10, 10),
+  ]),
   new LineShapeEdge(station.BENDIGO, station.EPSOM, [
     routeGraph.bendigoToEpsom,
-  ], []),
+  ], [
+    mapSegment.bendigoToEchuca.part(1, 6),
+  ]),
   new LineShapeEdge(station.EPSOM, station.HUNTLY, [
     routeGraph.epsomToHuntly,
-  ], []),
+  ], [
+    mapSegment.bendigoToEchuca.part(2, 6),
+  ]),
   new LineShapeEdge(station.HUNTLY, station.GOORNONG, [
     routeGraph.huntlyToGoornong,
-  ], []),
+  ], [
+    mapSegment.bendigoToEchuca.part(3, 6),
+  ]),
   new LineShapeEdge(station.GOORNONG, station.ELMORE, [
     routeGraph.goornongToElmore,
-  ], []),
+  ], [
+    mapSegment.bendigoToEchuca.part(4, 6),
+  ]),
   new LineShapeEdge(station.ELMORE, station.ROCHESTER, [
     routeGraph.elmoreToRochester,
-  ], []),
+  ], [
+    mapSegment.bendigoToEchuca.part(5, 6),
+  ]),
   new LineShapeEdge(station.ROCHESTER, station.ECHUCA, [
     routeGraph.rochesterToEchuca,
-  ], []),
+  ], [
+    mapSegment.bendigoToEchuca.part(6, 6),
+  ]),
   new LineShapeEdge(station.BENDIGO, station.EAGLEHAWK, [
     routeGraph.bendigoToEaglehawk,
-  ], []),
+  ], [
+    mapSegment.bendigoToSwanHill.part(1, 6),
+  ]),
   new LineShapeEdge(station.EAGLEHAWK, station.RAYWOOD, [
     routeGraph.eaglehawkToRaywood,
-  ], []),
+  ], [
+    mapSegment.bendigoToSwanHill.part(2, 6),
+  ]),
   new LineShapeEdge(station.RAYWOOD, station.DINGEE, [
     routeGraph.raywoodToDingee,
-  ], []),
+  ], [
+    mapSegment.bendigoToSwanHill.part(3, 6),
+  ]),
   new LineShapeEdge(station.DINGEE, station.PYRAMID, [
     routeGraph.dingeeToPyramid,
-  ], []),
+  ], [
+    mapSegment.bendigoToSwanHill.part(4, 6),
+  ]),
   new LineShapeEdge(station.PYRAMID, station.KERANG, [
     routeGraph.pyramidToKerang,
-  ], []),
+  ], [
+    mapSegment.bendigoToSwanHill.part(5, 6),
+  ]),
   new LineShapeEdge(station.KERANG, station.SWAN_HILL, [
     routeGraph.kerangToSwanHill,
-  ], []),
+  ], [
+    mapSegment.bendigoToSwanHill.part(6, 6),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/bendigo.ts
+++ b/server/entry-point/data/lines/bendigo.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -35,6 +37,20 @@ const routeGraph = {
   dingeeToPyramid: new StationPair(station.DINGEE, station.PYRAMID),
   pyramidToKerang: new StationPair(station.PYRAMID, station.KERANG),
   kerangToSwanHill: new StationPair(station.KERANG, station.SWAN_HILL),
+};
+
+// prettier-ignore
+const mapSegment = {
+  southernCrossToNorthMelbourneJunction: MapSegment.full(map.REGIONAL_WESTERN.SOUTHERN_CROSS, map.REGIONAL_WESTERN.NORTH_MELBOURNE_JUNCTION),
+  northMelbourneJunctionToNorthMelbourne: MapSegment.full(map.REGIONAL_WESTERN.NORTH_MELBOURNE_JUNCTION, map.REGIONAL_WESTERN.NORTH_MELBOURNE_RRL),
+  northMelbourneToFootscray: MapSegment.full(map.REGIONAL_WESTERN.NORTH_MELBOURNE_RRL, map.REGIONAL_WESTERN.FOOTSCRAY),
+  footscrayToSunshineJunction: MapSegment.full(map.REGIONAL_WESTERN.FOOTSCRAY, map.REGIONAL_WESTERN.SUNSHINE_JUNCTION),
+  sunshineJunctionToSunshine: MapSegment.full(map.REGIONAL_WESTERN.SUNSHINE_JUNCTION, map.REGIONAL_WESTERN.SUNSHINE_BENDIGO),
+  sunshineToWatergardens: MapSegment.full(map.REGIONAL_WESTERN.SUNSHINE_BENDIGO, map.REGIONAL_WESTERN.WATERGARDENS),
+  watergardensToSunbury: MapSegment.full(map.REGIONAL_WESTERN.WATERGARDENS, map.REGIONAL_WESTERN.SUNBURY),
+  sunburyToBendigo: MapSegment.full(map.REGIONAL_WESTERN.SUNBURY, map.REGIONAL_WESTERN.BENDIGO),
+  bendigoToEchuca: MapSegment.full(map.REGIONAL_WESTERN.BENDIGO, map.REGIONAL_WESTERN.ECHUCA),
+  bendigoToSwanHill: MapSegment.full(map.REGIONAL_WESTERN.BENDIGO, map.REGIONAL_WESTERN.SWAN_HILL),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/bendigo.ts
+++ b/server/entry-point/data/lines/bendigo.ts
@@ -41,82 +41,82 @@ const routeGraph = {
 const lineShapeEdges = [
   new LineShapeEdge(station.SOUTHERN_CROSS, station.FOOTSCRAY, [
     routeGraph.southernCrossToSunbury,
-  ]),
+  ], []),
   new LineShapeEdge(station.FOOTSCRAY, station.WATERGARDENS, [
     routeGraph.southernCrossToSunbury,
     routeGraph.footscrayToSunbury,
-  ]),
+  ], []),
   new LineShapeEdge(station.WATERGARDENS, station.SUNBURY, [
     routeGraph.southernCrossToSunbury,
     routeGraph.footscrayToSunbury,
     routeGraph.watergardensToSunbury,
-  ]),
+  ], []),
   new LineShapeEdge(station.SUNBURY, station.CLARKEFIELD, [
     routeGraph.sunburyToClarkefield,
-  ]),
+  ], []),
   new LineShapeEdge(station.CLARKEFIELD, station.RIDDELLS_CREEK, [
     routeGraph.clarkefieldToRiddellsCreek,
-  ]),
+  ], []),
   new LineShapeEdge(station.RIDDELLS_CREEK, station.GISBORNE, [
     routeGraph.riddellsCreekToGisborne,
-  ]),
+  ], []),
   new LineShapeEdge(station.GISBORNE, station.MACEDON, [
     routeGraph.gisborneToMacedon,
-  ]),
+  ], []),
   new LineShapeEdge(station.MACEDON, station.WOODEND, [
     routeGraph.macedonToWoodend,
-  ]),
+  ], []),
   new LineShapeEdge(station.WOODEND, station.KYNETON, [
     routeGraph.woodendToKyneton,
-  ]),
+  ], []),
   new LineShapeEdge(station.KYNETON, station.MALMSBURY, [
     routeGraph.kynetonToMalmsbury,
-  ]),
+  ], []),
   new LineShapeEdge(station.MALMSBURY, station.CASTLEMAINE, [
     routeGraph.malmsburyToCastlemaine,
-  ]),
+  ], []),
   new LineShapeEdge(station.CASTLEMAINE, station.KANGAROO_FLAT, [
     routeGraph.castlemaineToKangarooFlat,
-  ]),
+  ], []),
   new LineShapeEdge(station.KANGAROO_FLAT, station.BENDIGO, [
     routeGraph.kangarooFlatToBendigo,
-  ]),
+  ], []),
   new LineShapeEdge(station.BENDIGO, station.EPSOM, [
     routeGraph.bendigoToEpsom,
-  ]),
+  ], []),
   new LineShapeEdge(station.EPSOM, station.HUNTLY, [
     routeGraph.epsomToHuntly,
-  ]),
+  ], []),
   new LineShapeEdge(station.HUNTLY, station.GOORNONG, [
     routeGraph.huntlyToGoornong,
-  ]),
+  ], []),
   new LineShapeEdge(station.GOORNONG, station.ELMORE, [
     routeGraph.goornongToElmore,
-  ]),
+  ], []),
   new LineShapeEdge(station.ELMORE, station.ROCHESTER, [
     routeGraph.elmoreToRochester,
-  ]),
+  ], []),
   new LineShapeEdge(station.ROCHESTER, station.ECHUCA, [
     routeGraph.rochesterToEchuca,
-  ]),
+  ], []),
   new LineShapeEdge(station.BENDIGO, station.EAGLEHAWK, [
     routeGraph.bendigoToEaglehawk,
-  ]),
+  ], []),
   new LineShapeEdge(station.EAGLEHAWK, station.RAYWOOD, [
     routeGraph.eaglehawkToRaywood,
-  ]),
+  ], []),
   new LineShapeEdge(station.RAYWOOD, station.DINGEE, [
     routeGraph.raywoodToDingee,
-  ]),
+  ], []),
   new LineShapeEdge(station.DINGEE, station.PYRAMID, [
     routeGraph.dingeeToPyramid,
-  ]),
+  ], []),
   new LineShapeEdge(station.PYRAMID, station.KERANG, [
     routeGraph.pyramidToKerang,
-  ]),
+  ], []),
   new LineShapeEdge(station.KERANG, station.SWAN_HILL, [
     routeGraph.kerangToSwanHill,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/craigieburn.ts
+++ b/server/entry-point/data/lines/craigieburn.ts
@@ -42,52 +42,52 @@ const lineShapeEdges = [
     routeGraph.parliamentToMelbourneCentral,
     routeGraph.melbourneCentralToFlagstaff,
     routeGraph.flagstaffToNorthMelbourne,
-  ]),
+  ], []),
   new LineShapeEdge(station.NORTH_MELBOURNE, station.KENSINGTON, [
     routeGraph.northMelbourneToKensington,
-  ]),
+  ], []),
   new LineShapeEdge(station.KENSINGTON, station.NEWMARKET, [
     routeGraph.kensingtonToNewmarket,
-  ]),
+  ], []),
   new LineShapeEdge(station.NEWMARKET, station.ASCOT_VALE, [
     routeGraph.newmarketToAscotVale,
-  ]),
+  ], []),
   new LineShapeEdge(station.ASCOT_VALE, station.MOONEE_PONDS, [
     routeGraph.ascotValeToMooneePonds,
-  ]),
+  ], []),
   new LineShapeEdge(station.MOONEE_PONDS, station.ESSENDON, [
     routeGraph.mooneePondsToEssendon,
-  ]),
+  ], []),
   new LineShapeEdge(station.ESSENDON, station.GLENBERVIE, [
     routeGraph.essendonToGlenbervie,
-  ]),
+  ], []),
   new LineShapeEdge(station.GLENBERVIE, station.STRATHMORE, [
     routeGraph.glenbervieToStrathmore,
-  ]),
+  ], []),
   new LineShapeEdge(station.STRATHMORE, station.PASCOE_VALE, [
     routeGraph.strathmoreToPascoeVale,
-  ]),
+  ], []),
   new LineShapeEdge(station.PASCOE_VALE, station.OAK_PARK, [
     routeGraph.pascoeValeToOakPark,
-  ]),
+  ], []),
   new LineShapeEdge(station.OAK_PARK, station.GLENROY, [
     routeGraph.oakParkToGlenroy,
-  ]),
+  ], []),
   new LineShapeEdge(station.GLENROY, station.JACANA, [
     routeGraph.glenroyToJacana,
-  ]),
+  ], []),
   new LineShapeEdge(station.JACANA, station.BROADMEADOWS, [
     routeGraph.jacanaToBroadmeadows,
-  ]),
+  ], []),
   new LineShapeEdge(station.BROADMEADOWS, station.COOLAROO, [
     routeGraph.broadmeadowsToCoolaroo,
-  ]),
+  ], []),
   new LineShapeEdge(station.COOLAROO, station.ROXBURGH_PARK, [
     routeGraph.coolarooToRoxburghPark,
-  ]),
+  ], []),
   new LineShapeEdge(station.ROXBURGH_PARK, station.CRAIGIEBURN, [
     routeGraph.roxburghParkToCraigieburn,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/craigieburn.ts
+++ b/server/entry-point/data/lines/craigieburn.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -31,6 +33,18 @@ const routeGraph = {
   broadmeadowsToCoolaroo: new StationPair(station.BROADMEADOWS, station.COOLAROO),
   coolarooToRoxburghPark: new StationPair(station.COOLAROO, station.ROXBURGH_PARK),
   roxburghParkToCraigieburn: new StationPair(station.ROXBURGH_PARK, station.CRAIGIEBURN),
+};
+
+// prettier-ignore
+const mapSegment = {
+  flindersStreetToSouthernCross: MapSegment.full(map.NORTHERN.FLINDERS_STREET_DIRECT, map.NORTHERN.SOUTHERN_CROSS),
+  southernCrossToNorthMelbourne: MapSegment.full(map.NORTHERN.SOUTHERN_CROSS, map.NORTHERN.NORTH_MELBOURNE),
+  northMelbourneToFlagstaff: MapSegment.full(map.NORTHERN.NORTH_MELBOURNE, map.NORTHERN.FLAGSTAFF),
+  flagstaffToMelbourneCentral: MapSegment.full(map.NORTHERN.FLAGSTAFF, map.NORTHERN.MELBOURNE_CENTRAL),
+  melbourneCentralToParliament: MapSegment.full(map.NORTHERN.MELBOURNE_CENTRAL, map.NORTHERN.PARLIAMENT),
+  parliamentToFlindersStreet: MapSegment.full(map.NORTHERN.PARLIAMENT, map.NORTHERN.FLINDERS_STREET_LOOP),
+  northMelbourneToBroadmeadows: MapSegment.full(map.NORTHERN.NORTH_MELBOURNE, map.NORTHERN.BROADMEADOWS),
+  broadmeadowsToCraigieburn: MapSegment.full(map.NORTHERN.BROADMEADOWS, map.NORTHERN.CRAIGIEBURN),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/craigieburn.ts
+++ b/server/entry-point/data/lines/craigieburn.ts
@@ -56,52 +56,89 @@ const lineShapeEdges = [
     routeGraph.parliamentToMelbourneCentral,
     routeGraph.melbourneCentralToFlagstaff,
     routeGraph.flagstaffToNorthMelbourne,
-  ], []),
+  ], [
+    mapSegment.flindersStreetToSouthernCross,
+    mapSegment.southernCrossToNorthMelbourne,
+    mapSegment.northMelbourneToFlagstaff,
+    mapSegment.flagstaffToMelbourneCentral,
+    mapSegment.melbourneCentralToParliament,
+    mapSegment.parliamentToFlindersStreet,
+  ]),
   new LineShapeEdge(station.NORTH_MELBOURNE, station.KENSINGTON, [
     routeGraph.northMelbourneToKensington,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToBroadmeadows.part(1, 12),
+  ]),
   new LineShapeEdge(station.KENSINGTON, station.NEWMARKET, [
     routeGraph.kensingtonToNewmarket,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToBroadmeadows.part(2, 12),
+  ]),
   new LineShapeEdge(station.NEWMARKET, station.ASCOT_VALE, [
     routeGraph.newmarketToAscotVale,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToBroadmeadows.part(3, 12),
+  ]),
   new LineShapeEdge(station.ASCOT_VALE, station.MOONEE_PONDS, [
     routeGraph.ascotValeToMooneePonds,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToBroadmeadows.part(4, 12),
+  ]),
   new LineShapeEdge(station.MOONEE_PONDS, station.ESSENDON, [
     routeGraph.mooneePondsToEssendon,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToBroadmeadows.part(5, 12),
+  ]),
   new LineShapeEdge(station.ESSENDON, station.GLENBERVIE, [
     routeGraph.essendonToGlenbervie,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToBroadmeadows.part(6, 12),
+  ]),
   new LineShapeEdge(station.GLENBERVIE, station.STRATHMORE, [
     routeGraph.glenbervieToStrathmore,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToBroadmeadows.part(7, 12),
+  ]),
   new LineShapeEdge(station.STRATHMORE, station.PASCOE_VALE, [
     routeGraph.strathmoreToPascoeVale,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToBroadmeadows.part(8, 12),
+  ]),
   new LineShapeEdge(station.PASCOE_VALE, station.OAK_PARK, [
     routeGraph.pascoeValeToOakPark,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToBroadmeadows.part(9, 12),
+  ]),
   new LineShapeEdge(station.OAK_PARK, station.GLENROY, [
     routeGraph.oakParkToGlenroy,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToBroadmeadows.part(10, 12),
+  ]),
   new LineShapeEdge(station.GLENROY, station.JACANA, [
     routeGraph.glenroyToJacana,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToBroadmeadows.part(11, 12),
+  ]),
   new LineShapeEdge(station.JACANA, station.BROADMEADOWS, [
     routeGraph.jacanaToBroadmeadows,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToBroadmeadows.part(12, 12),
+  ]),
   new LineShapeEdge(station.BROADMEADOWS, station.COOLAROO, [
     routeGraph.broadmeadowsToCoolaroo,
-  ], []),
+  ], [
+    mapSegment.broadmeadowsToCraigieburn.part(1, 3),
+  ]),
   new LineShapeEdge(station.COOLAROO, station.ROXBURGH_PARK, [
     routeGraph.coolarooToRoxburghPark,
-  ], []),
+  ], [
+    mapSegment.broadmeadowsToCraigieburn.part(2, 3),
+  ]),
   new LineShapeEdge(station.ROXBURGH_PARK, station.CRAIGIEBURN, [
     routeGraph.roxburghParkToCraigieburn,
-  ], []),
+  ], [
+    mapSegment.broadmeadowsToCraigieburn.part(3, 3),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/cranbourne.ts
+++ b/server/entry-point/data/lines/cranbourne.ts
@@ -44,58 +44,58 @@ const lineShapeEdges = [
     routeGraph.flagstaffToMelbourneCentral,
     routeGraph.melbourneCentralToParliament,
     routeGraph.parliamentToRichmond,
-  ]),
+  ], []),
   new LineShapeEdge(station.RICHMOND, station.SOUTH_YARRA, [
     routeGraph.richmondToSouthYarra,
-  ]),
+  ], []),
   new LineShapeEdge(station.SOUTH_YARRA, station.CAULFIELD, [
     routeGraph.southYarraToCaulfield,
-  ]),
+  ], []),
   new LineShapeEdge(station.CAULFIELD, station.CARNEGIE, [
     routeGraph.caulfieldToCarnegie,
-  ]),
+  ], []),
   new LineShapeEdge(station.CARNEGIE, station.MURRUMBEENA, [
     routeGraph.carnegieToMurrumbeena,
-  ]),
+  ], []),
   new LineShapeEdge(station.MURRUMBEENA, station.HUGHESDALE, [
     routeGraph.murrumbeenaToHughesdale,
-  ]),
+  ], []),
   new LineShapeEdge(station.HUGHESDALE, station.OAKLEIGH, [
     routeGraph.hughesdaleToOakleigh,
-  ]),
+  ], []),
   new LineShapeEdge(station.OAKLEIGH, station.HUNTINGDALE, [
     routeGraph.oakleighToHuntingdale,
-  ]),
+  ], []),
   new LineShapeEdge(station.HUNTINGDALE, station.CLAYTON, [
     routeGraph.huntingdaleToClayton,
-  ]),
+  ], []),
   new LineShapeEdge(station.CLAYTON, station.WESTALL, [
     routeGraph.claytonToWestall,
-  ]),
+  ], []),
   new LineShapeEdge(station.WESTALL, station.SPRINGVALE, [
     routeGraph.westallToSpringvale,
-  ]),
+  ], []),
   new LineShapeEdge(station.SPRINGVALE, station.SANDOWN_PARK, [
     routeGraph.springvaleToSandownPark,
-  ]),
+  ], []),
   new LineShapeEdge(station.SANDOWN_PARK, station.NOBLE_PARK, [
     routeGraph.sandownParkToNoblePark,
-  ]),
+  ], []),
   new LineShapeEdge(station.NOBLE_PARK, station.YARRAMAN, [
     routeGraph.nobleParkToYarraman,
-  ]),
+  ], []),
   new LineShapeEdge(station.YARRAMAN, station.DANDENONG, [
     routeGraph.yarramanToDandenong,
-  ]),
+  ], []),
   new LineShapeEdge(station.DANDENONG, station.LYNBROOK, [
     routeGraph.dandenongToLynbrook,
-  ]),
+  ], []),
   new LineShapeEdge(station.LYNBROOK, station.MERINDA_PARK, [
     routeGraph.lynbrookToMerindaPark,
-  ]),
+  ], []),
   new LineShapeEdge(station.MERINDA_PARK, station.CRANBOURNE, [
     routeGraph.merindaParkToCranbourne,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/cranbourne.ts
+++ b/server/entry-point/data/lines/cranbourne.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -33,6 +35,21 @@ const routeGraph = {
   dandenongToLynbrook: new StationPair(station.DANDENONG, station.LYNBROOK),
   lynbrookToMerindaPark: new StationPair(station.LYNBROOK, station.MERINDA_PARK),
   merindaParkToCranbourne: new StationPair(station.MERINDA_PARK, station.CRANBOURNE),
+};
+
+// prettier-ignore
+const mapSegment = {
+  flindersStreetToRichmond: MapSegment.full(map.DANDENONG.FLINDERS_STREET_DIRECT, map.DANDENONG.RICHMOND),
+  flindersStreetToSouthernCross: MapSegment.full(map.DANDENONG.FLINDERS_STREET_LOOP, map.DANDENONG.SOUTHERN_CROSS),
+  southernCrossToFlagstaff: MapSegment.full(map.DANDENONG.SOUTHERN_CROSS, map.DANDENONG.FLAGSTAFF),
+  flagstaffToMelbourneCentral: MapSegment.full(map.DANDENONG.FLAGSTAFF, map.DANDENONG.MELBOURNE_CENTRAL),
+  melbourneCentralToParliament: MapSegment.full(map.DANDENONG.MELBOURNE_CENTRAL, map.DANDENONG.PARLIAMENT),
+  parliamentToRichmond: MapSegment.full(map.DANDENONG.PARLIAMENT, map.DANDENONG.RICHMOND),
+  richmondToSouthYarra: MapSegment.full(map.DANDENONG.RICHMOND, map.DANDENONG.SOUTH_YARRA),
+  southYarraToCaulfield: MapSegment.full(map.DANDENONG.SOUTH_YARRA, map.DANDENONG.CAULFIELD),
+  caulfieldToClayton: MapSegment.full(map.DANDENONG.CAULFIELD, map.DANDENONG.CLAYTON),
+  claytonToDandenong: MapSegment.full(map.DANDENONG.CLAYTON, map.DANDENONG.DANDENONG),
+  dandenongToCranbourne: MapSegment.full(map.DANDENONG.DANDENONG, map.DANDENONG.CRANBOURNE),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/cranbourne.ts
+++ b/server/entry-point/data/lines/cranbourne.ts
@@ -61,58 +61,99 @@ const lineShapeEdges = [
     routeGraph.flagstaffToMelbourneCentral,
     routeGraph.melbourneCentralToParliament,
     routeGraph.parliamentToRichmond,
-  ], []),
+  ], [
+    mapSegment.flindersStreetToRichmond,
+    mapSegment.flindersStreetToSouthernCross,
+    mapSegment.southernCrossToFlagstaff,
+    mapSegment.flagstaffToMelbourneCentral,
+    mapSegment.melbourneCentralToParliament,
+    mapSegment.parliamentToRichmond,
+  ]),
   new LineShapeEdge(station.RICHMOND, station.SOUTH_YARRA, [
     routeGraph.richmondToSouthYarra,
-  ], []),
+  ], [
+    mapSegment.richmondToSouthYarra,
+  ]),
   new LineShapeEdge(station.SOUTH_YARRA, station.CAULFIELD, [
     routeGraph.southYarraToCaulfield,
-  ], []),
+  ], [
+    mapSegment.southYarraToCaulfield,
+  ]),
   new LineShapeEdge(station.CAULFIELD, station.CARNEGIE, [
     routeGraph.caulfieldToCarnegie,
-  ], []),
+  ], [
+    mapSegment.caulfieldToClayton.part(1, 6),
+  ]),
   new LineShapeEdge(station.CARNEGIE, station.MURRUMBEENA, [
     routeGraph.carnegieToMurrumbeena,
-  ], []),
+  ], [
+    mapSegment.caulfieldToClayton.part(2, 6),
+  ]),
   new LineShapeEdge(station.MURRUMBEENA, station.HUGHESDALE, [
     routeGraph.murrumbeenaToHughesdale,
-  ], []),
+  ], [
+    mapSegment.caulfieldToClayton.part(3, 6),
+  ]),
   new LineShapeEdge(station.HUGHESDALE, station.OAKLEIGH, [
     routeGraph.hughesdaleToOakleigh,
-  ], []),
+  ], [
+    mapSegment.caulfieldToClayton.part(4, 6),
+  ]),
   new LineShapeEdge(station.OAKLEIGH, station.HUNTINGDALE, [
     routeGraph.oakleighToHuntingdale,
-  ], []),
+  ], [
+    mapSegment.caulfieldToClayton.part(5, 6),
+  ]),
   new LineShapeEdge(station.HUNTINGDALE, station.CLAYTON, [
     routeGraph.huntingdaleToClayton,
-  ], []),
+  ], [
+    mapSegment.caulfieldToClayton.part(6, 6),
+  ]),
   new LineShapeEdge(station.CLAYTON, station.WESTALL, [
     routeGraph.claytonToWestall,
-  ], []),
+  ], [
+    mapSegment.claytonToDandenong.part(1, 6),
+  ]),
   new LineShapeEdge(station.WESTALL, station.SPRINGVALE, [
     routeGraph.westallToSpringvale,
-  ], []),
+  ], [
+    mapSegment.claytonToDandenong.part(2, 6),
+  ]),
   new LineShapeEdge(station.SPRINGVALE, station.SANDOWN_PARK, [
     routeGraph.springvaleToSandownPark,
-  ], []),
+  ], [
+    mapSegment.claytonToDandenong.part(3, 6),
+  ]),
   new LineShapeEdge(station.SANDOWN_PARK, station.NOBLE_PARK, [
     routeGraph.sandownParkToNoblePark,
-  ], []),
+  ], [
+    mapSegment.claytonToDandenong.part(4, 6),
+  ]),
   new LineShapeEdge(station.NOBLE_PARK, station.YARRAMAN, [
     routeGraph.nobleParkToYarraman,
-  ], []),
+  ], [
+    mapSegment.claytonToDandenong.part(5, 6),
+  ]),
   new LineShapeEdge(station.YARRAMAN, station.DANDENONG, [
     routeGraph.yarramanToDandenong,
-  ], []),
+  ], [
+    mapSegment.claytonToDandenong.part(6, 6),
+  ]),
   new LineShapeEdge(station.DANDENONG, station.LYNBROOK, [
     routeGraph.dandenongToLynbrook,
-  ], []),
+  ], [
+    mapSegment.dandenongToCranbourne.part(1, 3),
+  ]),
   new LineShapeEdge(station.LYNBROOK, station.MERINDA_PARK, [
     routeGraph.lynbrookToMerindaPark,
-  ], []),
+  ], [
+    mapSegment.dandenongToCranbourne.part(2, 3),
+  ]),
   new LineShapeEdge(station.MERINDA_PARK, station.CRANBOURNE, [
     routeGraph.merindaParkToCranbourne,
-  ], []),
+  ], [
+    mapSegment.dandenongToCranbourne.part(3, 3),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/flemington-racecourse.ts
+++ b/server/entry-point/data/lines/flemington-racecourse.ts
@@ -16,6 +16,8 @@ const routeGraph = {
   showgroundsToFlemingtonRacecourse: new StationPair(station.SHOWGROUNDS, station.FLEMINGTON_RACECOURSE),
 };
 
+// NODE: The Flemington Racecourse line is currently not represented on the map.
+
 // prettier-ignore
 const lineShapeEdges = [
   new LineShapeEdge(station.FLINDERS_STREET, station.SOUTHERN_CROSS, [

--- a/server/entry-point/data/lines/flemington-racecourse.ts
+++ b/server/entry-point/data/lines/flemington-racecourse.ts
@@ -20,16 +20,16 @@ const routeGraph = {
 const lineShapeEdges = [
   new LineShapeEdge(station.FLINDERS_STREET, station.SOUTHERN_CROSS, [
     routeGraph.flindersStreetToSouthernCross,
-  ]),
+  ], []),
   new LineShapeEdge(station.SOUTHERN_CROSS, station.NORTH_MELBOURNE, [
     routeGraph.southernCrossToNorthMelbourne,
-  ]),
+  ], []),
   new LineShapeEdge(station.NORTH_MELBOURNE, station.SHOWGROUNDS, [
     routeGraph.northMelbourneToShowgrounds,
-  ]),
+  ], []),
   new LineShapeEdge(station.SHOWGROUNDS, station.FLEMINGTON_RACECOURSE, [
     routeGraph.showgroundsToFlemingtonRacecourse,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/frankston.ts
+++ b/server/entry-point/data/lines/frankston.ts
@@ -43,85 +43,85 @@ const routeGraph = {
 const lineShapeEdges = [
   new LineShapeEdge(station.FLINDERS_STREET, station.RICHMOND, [
     routeGraph.flindersStreetToRichmond,
-  ]),
+  ], []),
   new LineShapeEdge(station.RICHMOND, station.SOUTH_YARRA, [
     routeGraph.richmondToSouthYarra,
-  ]),
+  ], []),
   new LineShapeEdge(station.SOUTH_YARRA, station.HAWKSBURN, [
     routeGraph.southYarraToHawksburn,
-  ]),
+  ], []),
   new LineShapeEdge(station.HAWKSBURN, station.TOORAK, [
     routeGraph.hawksburnToToorak,
-  ]),
+  ], []),
   new LineShapeEdge(station.TOORAK, station.ARMADALE, [
     routeGraph.toorakToArmadale,
-  ]),
+  ], []),
   new LineShapeEdge(station.ARMADALE, station.MALVERN, [
     routeGraph.armadaleToMalvern,
-  ]),
+  ], []),
   new LineShapeEdge(station.MALVERN, station.CAULFIELD, [
     routeGraph.malvernToCaulfield,
-  ]),
+  ], []),
   new LineShapeEdge(station.CAULFIELD, station.GLEN_HUNTLY, [
     routeGraph.caulfieldToGlenHuntly,
-  ]),
+  ], []),
   new LineShapeEdge(station.GLEN_HUNTLY, station.ORMOND, [
     routeGraph.glenHuntlyToOrmond,
-  ]),
+  ], []),
   new LineShapeEdge(station.ORMOND, station.MCKINNON, [
     routeGraph.ormondToMcKinnon,
-  ]),
+  ], []),
   new LineShapeEdge(station.MCKINNON, station.BENTLEIGH, [
     routeGraph.mcKinnonToBentleigh,
-  ]),
+  ], []),
   new LineShapeEdge(station.BENTLEIGH, station.PATTERSON, [
     routeGraph.bentleighToPatterson,
-  ]),
+  ], []),
   new LineShapeEdge(station.PATTERSON, station.MOORABBIN, [
     routeGraph.pattersonToMoorabbin,
-  ]),
+  ], []),
   new LineShapeEdge(station.MOORABBIN, station.HIGHETT, [
     routeGraph.moorabbinToHighett,
-  ]),
+  ], []),
   new LineShapeEdge(station.HIGHETT, station.SOUTHLAND, [
     routeGraph.highettToSouthland,
-  ]),
+  ], []),
   new LineShapeEdge(station.SOUTHLAND, station.CHELTENHAM, [
     routeGraph.southlandToCheltenham,
-  ]),
+  ], []),
   new LineShapeEdge(station.CHELTENHAM, station.MENTONE, [
     routeGraph.cheltenhamToMentone,
-  ]),
+  ], []),
   new LineShapeEdge(station.MENTONE, station.PARKDALE, [
     routeGraph.mentoneToParkdale,
-  ]),
+  ], []),
   new LineShapeEdge(station.PARKDALE, station.MORDIALLOC, [
     routeGraph.parkdaleToMordialloc,
-  ]),
+  ], []),
   new LineShapeEdge(station.MORDIALLOC, station.ASPENDALE, [
     routeGraph.mordiallocToAspendale,
-  ]),
+  ], []),
   new LineShapeEdge(station.ASPENDALE, station.EDITHVALE, [
     routeGraph.aspendaleToEdithvale,
-  ]),
+  ], []),
   new LineShapeEdge(station.EDITHVALE, station.CHELSEA, [
     routeGraph.edithvaleToChelsea,
-  ]),
+  ], []),
   new LineShapeEdge(station.CHELSEA, station.BONBEACH, [
     routeGraph.chelseaToBonbeach,
-  ]),
+  ], []),
   new LineShapeEdge(station.BONBEACH, station.CARRUM, [
     routeGraph.bonbeachToCarrum,
-  ]),
+  ], []),
   new LineShapeEdge(station.CARRUM, station.SEAFORD, [
     routeGraph.carrumToSeaford,
-  ]),
+  ], []),
   new LineShapeEdge(station.SEAFORD, station.KANANOOK, [
     routeGraph.seafordToKananook,
-  ]),
+  ], []),
   new LineShapeEdge(station.KANANOOK, station.FRANKSTON, [
     routeGraph.kananookToFrankston,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/frankston.ts
+++ b/server/entry-point/data/lines/frankston.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -37,6 +39,14 @@ const routeGraph = {
   carrumToSeaford: new StationPair(station.CARRUM, station.SEAFORD),
   seafordToKananook: new StationPair(station.SEAFORD, station.KANANOOK),
   kananookToFrankston: new StationPair(station.KANANOOK, station.FRANKSTON),
+};
+
+// prettier-ignore
+const mapSegment = {
+  flindersStreetToRichmond: MapSegment.full(map.FRANKSTON.FLINDERS_STREET, map.FRANKSTON.RICHMOND),
+  richmondToSouthYarra: MapSegment.full(map.FRANKSTON.RICHMOND, map.FRANKSTON.SOUTH_YARRA),
+  southYarraToCaulfield: MapSegment.full(map.FRANKSTON.SOUTH_YARRA, map.FRANKSTON.CAULFIELD),
+  caulfieldToFrankston: MapSegment.full(map.FRANKSTON.CAULFIELD, map.FRANKSTON.FRANKSTON),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/frankston.ts
+++ b/server/entry-point/data/lines/frankston.ts
@@ -53,85 +53,139 @@ const mapSegment = {
 const lineShapeEdges = [
   new LineShapeEdge(station.FLINDERS_STREET, station.RICHMOND, [
     routeGraph.flindersStreetToRichmond,
-  ], []),
+  ], [
+    mapSegment.flindersStreetToRichmond,
+  ]),
   new LineShapeEdge(station.RICHMOND, station.SOUTH_YARRA, [
     routeGraph.richmondToSouthYarra,
-  ], []),
+  ], [
+    mapSegment.richmondToSouthYarra,
+  ]),
   new LineShapeEdge(station.SOUTH_YARRA, station.HAWKSBURN, [
     routeGraph.southYarraToHawksburn,
-  ], []),
+  ], [
+    mapSegment.southYarraToCaulfield.part(1, 5),
+  ]),
   new LineShapeEdge(station.HAWKSBURN, station.TOORAK, [
     routeGraph.hawksburnToToorak,
-  ], []),
+  ], [
+    mapSegment.southYarraToCaulfield.part(2, 5),
+  ]),
   new LineShapeEdge(station.TOORAK, station.ARMADALE, [
     routeGraph.toorakToArmadale,
-  ], []),
+  ], [
+    mapSegment.southYarraToCaulfield.part(3, 5),
+  ]),
   new LineShapeEdge(station.ARMADALE, station.MALVERN, [
     routeGraph.armadaleToMalvern,
-  ], []),
+  ], [
+    mapSegment.southYarraToCaulfield.part(4, 5),
+  ]),
   new LineShapeEdge(station.MALVERN, station.CAULFIELD, [
     routeGraph.malvernToCaulfield,
-  ], []),
+  ], [
+    mapSegment.southYarraToCaulfield.part(5, 5),
+  ]),
   new LineShapeEdge(station.CAULFIELD, station.GLEN_HUNTLY, [
     routeGraph.caulfieldToGlenHuntly,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(1, 20),
+  ]),
   new LineShapeEdge(station.GLEN_HUNTLY, station.ORMOND, [
     routeGraph.glenHuntlyToOrmond,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(2, 20),
+  ]),
   new LineShapeEdge(station.ORMOND, station.MCKINNON, [
     routeGraph.ormondToMcKinnon,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(3, 20),
+  ]),
   new LineShapeEdge(station.MCKINNON, station.BENTLEIGH, [
     routeGraph.mcKinnonToBentleigh,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(4, 20),
+  ]),
   new LineShapeEdge(station.BENTLEIGH, station.PATTERSON, [
     routeGraph.bentleighToPatterson,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(5, 20),
+  ]),
   new LineShapeEdge(station.PATTERSON, station.MOORABBIN, [
     routeGraph.pattersonToMoorabbin,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(6, 20),
+  ]),
   new LineShapeEdge(station.MOORABBIN, station.HIGHETT, [
     routeGraph.moorabbinToHighett,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(7, 20),
+  ]),
   new LineShapeEdge(station.HIGHETT, station.SOUTHLAND, [
     routeGraph.highettToSouthland,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(8, 20),
+  ]),
   new LineShapeEdge(station.SOUTHLAND, station.CHELTENHAM, [
     routeGraph.southlandToCheltenham,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(9, 20),
+  ]),
   new LineShapeEdge(station.CHELTENHAM, station.MENTONE, [
     routeGraph.cheltenhamToMentone,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(10, 20),
+  ]),
   new LineShapeEdge(station.MENTONE, station.PARKDALE, [
     routeGraph.mentoneToParkdale,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(11, 20),
+  ]),
   new LineShapeEdge(station.PARKDALE, station.MORDIALLOC, [
     routeGraph.parkdaleToMordialloc,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(12, 20),
+  ]),
   new LineShapeEdge(station.MORDIALLOC, station.ASPENDALE, [
     routeGraph.mordiallocToAspendale,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(13, 20),
+  ]),
   new LineShapeEdge(station.ASPENDALE, station.EDITHVALE, [
     routeGraph.aspendaleToEdithvale,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(14, 20),
+  ]),
   new LineShapeEdge(station.EDITHVALE, station.CHELSEA, [
     routeGraph.edithvaleToChelsea,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(15, 20),
+  ]),
   new LineShapeEdge(station.CHELSEA, station.BONBEACH, [
     routeGraph.chelseaToBonbeach,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(16, 20),
+  ]),
   new LineShapeEdge(station.BONBEACH, station.CARRUM, [
     routeGraph.bonbeachToCarrum,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(17, 20),
+  ]),
   new LineShapeEdge(station.CARRUM, station.SEAFORD, [
     routeGraph.carrumToSeaford,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(18, 20),
+  ]),
   new LineShapeEdge(station.SEAFORD, station.KANANOOK, [
     routeGraph.seafordToKananook,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(19, 20),
+  ]),
   new LineShapeEdge(station.KANANOOK, station.FRANKSTON, [
     routeGraph.kananookToFrankston,
-  ], []),
+  ], [
+    mapSegment.caulfieldToFrankston.part(20, 20),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/geelong.ts
+++ b/server/entry-point/data/lines/geelong.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -31,6 +33,17 @@ const routeGraph = {
   camperdownToTerang: new StationPair(station.CAMPERDOWN, station.TERANG),
   terangToSherwoodPark: new StationPair(station.TERANG, station.SHERWOOD_PARK),
   sherwoodParkToWarrnambool: new StationPair(station.SHERWOOD_PARK, station.WARRNAMBOOL),
+};
+
+// prettier-ignore
+const mapSegment = {
+  southernCrossToNorthMelbourneJunction: MapSegment.full(map.REGIONAL_WESTERN.SOUTHERN_CROSS, map.REGIONAL_WESTERN.NORTH_MELBOURNE_JUNCTION),
+  northMelbourneJunctionToNorthMelbourne: MapSegment.full(map.REGIONAL_WESTERN.NORTH_MELBOURNE_JUNCTION, map.REGIONAL_WESTERN.NORTH_MELBOURNE_RRL),
+  northMelbourneToFootscray: MapSegment.full(map.REGIONAL_WESTERN.NORTH_MELBOURNE_RRL, map.REGIONAL_WESTERN.FOOTSCRAY),
+  footscrayToSunshineJunction: MapSegment.full(map.REGIONAL_WESTERN.FOOTSCRAY, map.REGIONAL_WESTERN.SUNSHINE_JUNCTION),
+  sunshineJunctionToSunshine: MapSegment.full(map.REGIONAL_WESTERN.SUNSHINE_JUNCTION, map.REGIONAL_WESTERN.SUNSHINE_DEER_PARK),
+  sunshineToDeerPark: MapSegment.full(map.REGIONAL_WESTERN.SUNSHINE_DEER_PARK, map.REGIONAL_WESTERN.DEER_PARK),
+  deerParkToWarrnambool: MapSegment.full(map.REGIONAL_WESTERN.DEER_PARK, map.REGIONAL_WESTERN.WARRNAMBOOL),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/geelong.ts
+++ b/server/entry-point/data/lines/geelong.ts
@@ -50,70 +50,115 @@ const mapSegment = {
 const lineShapeEdges = [
   new LineShapeEdge(station.SOUTHERN_CROSS, station.FOOTSCRAY, [
     routeGraph.southernCrossToDeerPark,
-  ], []),
+  ], [
+    mapSegment.southernCrossToNorthMelbourneJunction,
+    mapSegment.northMelbourneJunctionToNorthMelbourne,
+    mapSegment.northMelbourneToFootscray,
+  ]),
   new LineShapeEdge(station.FOOTSCRAY, station.SUNSHINE, [
     routeGraph.southernCrossToDeerPark,
     routeGraph.footscrayToDeerPark,
-  ], []),
+  ], [
+    mapSegment.footscrayToSunshineJunction,
+    mapSegment.sunshineJunctionToSunshine,
+  ]),
   new LineShapeEdge(station.SUNSHINE, station.DEER_PARK, [
     routeGraph.southernCrossToDeerPark,
     routeGraph.footscrayToDeerPark,
     routeGraph.sunshineToDeerPark,
-  ], []),
+  ], [
+    mapSegment.sunshineToDeerPark,
+  ]),
   new LineShapeEdge(station.DEER_PARK, station.TARNEIT, [
     routeGraph.deerParkToTarneit,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(1, 18),
+  ]),
   new LineShapeEdge(station.TARNEIT, station.WYNDHAM_VALE, [
     routeGraph.tarneitToWyndhamVale,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(2, 18),
+  ]),
   new LineShapeEdge(station.WYNDHAM_VALE, station.LITTLE_RIVER, [
     routeGraph.wyndhamValeToLittleRiver,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(3, 18),
+  ]),
   new LineShapeEdge(station.LITTLE_RIVER, station.LARA, [
     routeGraph.littleRiverToLara,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(4, 18),
+  ]),
   new LineShapeEdge(station.LARA, station.CORIO, [
     routeGraph.laraToCorio,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(5, 18),
+  ]),
   new LineShapeEdge(station.CORIO, station.NORTH_SHORE, [
     routeGraph.corioToNorthShore,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(6, 18),
+  ]),
   new LineShapeEdge(station.NORTH_SHORE, station.NORTH_GEELONG, [
     routeGraph.northShoreToNorthGeelong,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(7, 18),
+  ]),
   new LineShapeEdge(station.NORTH_GEELONG, station.GEELONG, [
     routeGraph.northGeelongToGeelong,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(8, 18),
+  ]),
   new LineShapeEdge(station.GEELONG, station.SOUTH_GEELONG, [
     routeGraph.geelongToSouthGeelong,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(9, 18),
+  ]),
   new LineShapeEdge(station.SOUTH_GEELONG, station.MARSHALL, [
     routeGraph.southGeelongToMarshall,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(10, 18),
+  ]),
   new LineShapeEdge(station.MARSHALL, station.WAURN_PONDS, [
     routeGraph.marshallToWaurnPonds,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(11, 18),
+  ]),
   new LineShapeEdge(station.WAURN_PONDS, station.WINCHELSEA, [
     routeGraph.waurnPondsToWinchelsea,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(12, 18),
+  ]),
   new LineShapeEdge(station.WINCHELSEA, station.BIRREGURRA, [
     routeGraph.winchelseaToBirregurra,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(13, 18),
+  ]),
   new LineShapeEdge(station.BIRREGURRA, station.COLAC, [
     routeGraph.birregurraToColac,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(14, 18),
+  ]),
   new LineShapeEdge(station.COLAC, station.CAMPERDOWN, [
     routeGraph.colacToCamperdown,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(15, 18),
+  ]),
   new LineShapeEdge(station.CAMPERDOWN, station.TERANG, [
     routeGraph.camperdownToTerang,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(16, 18),
+  ]),
   new LineShapeEdge(station.TERANG, station.SHERWOOD_PARK, [
     routeGraph.terangToSherwoodPark,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(17, 18),
+  ]),
   new LineShapeEdge(station.SHERWOOD_PARK, station.WARRNAMBOOL, [
     routeGraph.sherwoodParkToWarrnambool,
-  ], []),
+  ], [
+    mapSegment.deerParkToWarrnambool.part(18, 18),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/geelong.ts
+++ b/server/entry-point/data/lines/geelong.ts
@@ -37,70 +37,70 @@ const routeGraph = {
 const lineShapeEdges = [
   new LineShapeEdge(station.SOUTHERN_CROSS, station.FOOTSCRAY, [
     routeGraph.southernCrossToDeerPark,
-  ]),
+  ], []),
   new LineShapeEdge(station.FOOTSCRAY, station.SUNSHINE, [
     routeGraph.southernCrossToDeerPark,
     routeGraph.footscrayToDeerPark,
-  ]),
+  ], []),
   new LineShapeEdge(station.SUNSHINE, station.DEER_PARK, [
     routeGraph.southernCrossToDeerPark,
     routeGraph.footscrayToDeerPark,
     routeGraph.sunshineToDeerPark,
-  ]),
+  ], []),
   new LineShapeEdge(station.DEER_PARK, station.TARNEIT, [
     routeGraph.deerParkToTarneit,
-  ]),
+  ], []),
   new LineShapeEdge(station.TARNEIT, station.WYNDHAM_VALE, [
     routeGraph.tarneitToWyndhamVale,
-  ]),
+  ], []),
   new LineShapeEdge(station.WYNDHAM_VALE, station.LITTLE_RIVER, [
     routeGraph.wyndhamValeToLittleRiver,
-  ]),
+  ], []),
   new LineShapeEdge(station.LITTLE_RIVER, station.LARA, [
     routeGraph.littleRiverToLara,
-  ]),
+  ], []),
   new LineShapeEdge(station.LARA, station.CORIO, [
     routeGraph.laraToCorio,
-  ]),
+  ], []),
   new LineShapeEdge(station.CORIO, station.NORTH_SHORE, [
     routeGraph.corioToNorthShore,
-  ]),
+  ], []),
   new LineShapeEdge(station.NORTH_SHORE, station.NORTH_GEELONG, [
     routeGraph.northShoreToNorthGeelong,
-  ]),
+  ], []),
   new LineShapeEdge(station.NORTH_GEELONG, station.GEELONG, [
     routeGraph.northGeelongToGeelong,
-  ]),
+  ], []),
   new LineShapeEdge(station.GEELONG, station.SOUTH_GEELONG, [
     routeGraph.geelongToSouthGeelong,
-  ]),
+  ], []),
   new LineShapeEdge(station.SOUTH_GEELONG, station.MARSHALL, [
     routeGraph.southGeelongToMarshall,
-  ]),
+  ], []),
   new LineShapeEdge(station.MARSHALL, station.WAURN_PONDS, [
     routeGraph.marshallToWaurnPonds,
-  ]),
+  ], []),
   new LineShapeEdge(station.WAURN_PONDS, station.WINCHELSEA, [
     routeGraph.waurnPondsToWinchelsea,
-  ]),
+  ], []),
   new LineShapeEdge(station.WINCHELSEA, station.BIRREGURRA, [
     routeGraph.winchelseaToBirregurra,
-  ]),
+  ], []),
   new LineShapeEdge(station.BIRREGURRA, station.COLAC, [
     routeGraph.birregurraToColac,
-  ]),
+  ], []),
   new LineShapeEdge(station.COLAC, station.CAMPERDOWN, [
     routeGraph.colacToCamperdown,
-  ]),
+  ], []),
   new LineShapeEdge(station.CAMPERDOWN, station.TERANG, [
     routeGraph.camperdownToTerang,
-  ]),
+  ], []),
   new LineShapeEdge(station.TERANG, station.SHERWOOD_PARK, [
     routeGraph.terangToSherwoodPark,
-  ]),
+  ], []),
   new LineShapeEdge(station.SHERWOOD_PARK, station.WARRNAMBOOL, [
     routeGraph.sherwoodParkToWarrnambool,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/gippsland.ts
+++ b/server/entry-point/data/lines/gippsland.ts
@@ -38,29 +38,29 @@ const routeGraph = {
 const lineShapeEdges = [
   new LineShapeEdge(station.SOUTHERN_CROSS, station.FLINDERS_STREET, [
     routeGraph.southernCrossToPakenham,
-  ]),
+  ], []),
   new LineShapeEdge(station.FLINDERS_STREET, station.RICHMOND, [
     routeGraph.southernCrossToPakenham,
     routeGraph.flindersStreetToPakenham,
-  ]),
+  ], []),
   new LineShapeEdge(station.RICHMOND, station.CAULFIELD, [
     routeGraph.southernCrossToPakenham,
     routeGraph.flindersStreetToPakenham,
     routeGraph.richmondToPakenham,
-  ]),
+  ], []),
   new LineShapeEdge(station.CAULFIELD, station.CLAYTON, [
     routeGraph.southernCrossToPakenham,
     routeGraph.flindersStreetToPakenham,
     routeGraph.richmondToPakenham,
     routeGraph.caulfieldToPakenham,
-  ]),
+  ], []),
   new LineShapeEdge(station.CLAYTON, station.DANDENONG, [
     routeGraph.southernCrossToPakenham,
     routeGraph.flindersStreetToPakenham,
     routeGraph.richmondToPakenham,
     routeGraph.caulfieldToPakenham,
     routeGraph.claytonToPakenham,
-  ]),
+  ], []),
   new LineShapeEdge(station.DANDENONG, station.PAKENHAM, [
     routeGraph.southernCrossToPakenham,
     routeGraph.flindersStreetToPakenham,
@@ -68,55 +68,55 @@ const lineShapeEdges = [
     routeGraph.caulfieldToPakenham,
     routeGraph.claytonToPakenham,
     routeGraph.dandenongToPakenham,
-  ]),
+  ], []),
   new LineShapeEdge(station.PAKENHAM, station.NAR_NAR_GOON, [
     routeGraph.pakenhamToNarNarGoon,
-  ]),
+  ], []),
   new LineShapeEdge(station.NAR_NAR_GOON, station.TYNONG, [
     routeGraph.narNarGoonToTynong,
-  ]),
+  ], []),
   new LineShapeEdge(station.TYNONG, station.GARFIELD, [
     routeGraph.tynongToGarfield,
-  ]),
+  ], []),
   new LineShapeEdge(station.GARFIELD, station.BUNYIP, [
     routeGraph.garfieldToBunyip,
-  ]),
+  ], []),
   new LineShapeEdge(station.BUNYIP, station.LONGWARRY, [
     routeGraph.bunyipToLongwarry,
-  ]),
+  ], []),
   new LineShapeEdge(station.LONGWARRY, station.DROUIN, [
     routeGraph.longwarryToDrouin,
-  ]),
+  ], []),
   new LineShapeEdge(station.DROUIN, station.WARRAGUL, [
     routeGraph.drouinToWarragul,
-  ]),
+  ], []),
   new LineShapeEdge(station.WARRAGUL, station.YARRAGON, [
     routeGraph.warragulToYarragon,
-  ]),
+  ], []),
   new LineShapeEdge(station.YARRAGON, station.TRAFALGAR, [
     routeGraph.yarragonToTrafalgar,
-  ]),
+  ], []),
   new LineShapeEdge(station.TRAFALGAR, station.MOE, [
     routeGraph.trafalgarToMoe,
-  ]),
+  ], []),
   new LineShapeEdge(station.MOE, station.MORWELL, [
     routeGraph.moeToMorwell,
-  ]),
+  ], []),
   new LineShapeEdge(station.MORWELL, station.TRARALGON, [
     routeGraph.morwellToTraralgon,
-  ]),
+  ], []),
   new LineShapeEdge(station.TRARALGON, station.ROSEDALE, [
     routeGraph.traralgonToRosedale,
-  ]),
+  ], []),
   new LineShapeEdge(station.ROSEDALE, station.SALE, [
     routeGraph.rosedaleToSale,
-  ]),
+  ], []),
   new LineShapeEdge(station.SALE, station.STRATFORD, [
     routeGraph.saleToStratford,
-  ]),
+  ], []),
   new LineShapeEdge(station.STRATFORD, station.BAIRNSDALE, [
     routeGraph.stratfordToBairnsdale,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/gippsland.ts
+++ b/server/entry-point/data/lines/gippsland.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -32,6 +34,19 @@ const routeGraph = {
   rosedaleToSale: new StationPair(station.ROSEDALE, station.SALE),
   saleToStratford: new StationPair(station.SALE, station.STRATFORD),
   stratfordToBairnsdale: new StationPair(station.STRATFORD, station.BAIRNSDALE),
+};
+
+// prettier-ignore
+const mapSegment = {
+  southernCrossToFlindersStreet: MapSegment.full(map.GIPPSLAND.SOUTHERN_CROSS, map.GIPPSLAND.FLINDERS_STREET),
+  flindersStreetToRichmond: MapSegment.full(map.GIPPSLAND.FLINDERS_STREET, map.GIPPSLAND.RICHMOND),
+  richmondToSouthYarra: MapSegment.full(map.GIPPSLAND.RICHMOND, map.GIPPSLAND.SOUTH_YARRA),
+  southYarraToCaulfield: MapSegment.full(map.GIPPSLAND.SOUTH_YARRA, map.GIPPSLAND.CAULFIELD),
+  caulfieldToClayton: MapSegment.full(map.GIPPSLAND.CAULFIELD, map.GIPPSLAND.CLAYTON),
+  claytonToDandenong: MapSegment.full(map.GIPPSLAND.CLAYTON, map.GIPPSLAND.DANDENONG),
+  dandenongToPakenham: MapSegment.full(map.GIPPSLAND.DANDENONG, map.GIPPSLAND.PAKENHAM),
+  pakenhamToEastPakenham: MapSegment.full(map.GIPPSLAND.PAKENHAM, map.GIPPSLAND.EAST_PAKENHAM),
+  eastPakenhamToBairnsdale: MapSegment.full(map.GIPPSLAND.EAST_PAKENHAM, map.GIPPSLAND.BAIRNSDALE),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/gippsland.ts
+++ b/server/entry-point/data/lines/gippsland.ts
@@ -53,29 +53,40 @@ const mapSegment = {
 const lineShapeEdges = [
   new LineShapeEdge(station.SOUTHERN_CROSS, station.FLINDERS_STREET, [
     routeGraph.southernCrossToPakenham,
-  ], []),
+  ], [
+    mapSegment.southernCrossToFlindersStreet,
+  ]),
   new LineShapeEdge(station.FLINDERS_STREET, station.RICHMOND, [
     routeGraph.southernCrossToPakenham,
     routeGraph.flindersStreetToPakenham,
-  ], []),
+  ], [
+    mapSegment.flindersStreetToRichmond,
+  ]),
   new LineShapeEdge(station.RICHMOND, station.CAULFIELD, [
     routeGraph.southernCrossToPakenham,
     routeGraph.flindersStreetToPakenham,
     routeGraph.richmondToPakenham,
-  ], []),
+  ], [
+    mapSegment.richmondToSouthYarra,
+    mapSegment.southYarraToCaulfield,
+  ]),
   new LineShapeEdge(station.CAULFIELD, station.CLAYTON, [
     routeGraph.southernCrossToPakenham,
     routeGraph.flindersStreetToPakenham,
     routeGraph.richmondToPakenham,
     routeGraph.caulfieldToPakenham,
-  ], []),
+  ], [
+    mapSegment.caulfieldToClayton,
+  ]),
   new LineShapeEdge(station.CLAYTON, station.DANDENONG, [
     routeGraph.southernCrossToPakenham,
     routeGraph.flindersStreetToPakenham,
     routeGraph.richmondToPakenham,
     routeGraph.caulfieldToPakenham,
     routeGraph.claytonToPakenham,
-  ], []),
+  ], [
+    mapSegment.claytonToDandenong,
+  ]),
   new LineShapeEdge(station.DANDENONG, station.PAKENHAM, [
     routeGraph.southernCrossToPakenham,
     routeGraph.flindersStreetToPakenham,
@@ -83,55 +94,90 @@ const lineShapeEdges = [
     routeGraph.caulfieldToPakenham,
     routeGraph.claytonToPakenham,
     routeGraph.dandenongToPakenham,
-  ], []),
+  ], [
+    mapSegment.dandenongToPakenham,
+  ]),
   new LineShapeEdge(station.PAKENHAM, station.NAR_NAR_GOON, [
     routeGraph.pakenhamToNarNarGoon,
-  ], []),
+  ], [
+    mapSegment.pakenhamToEastPakenham,
+    mapSegment.eastPakenhamToBairnsdale.part(1, 16),
+  ]),
   new LineShapeEdge(station.NAR_NAR_GOON, station.TYNONG, [
     routeGraph.narNarGoonToTynong,
-  ], []),
+  ], [
+    mapSegment.eastPakenhamToBairnsdale.part(2, 16),
+  ]),
   new LineShapeEdge(station.TYNONG, station.GARFIELD, [
     routeGraph.tynongToGarfield,
-  ], []),
+  ], [
+    mapSegment.eastPakenhamToBairnsdale.part(3, 16),
+  ]),
   new LineShapeEdge(station.GARFIELD, station.BUNYIP, [
     routeGraph.garfieldToBunyip,
-  ], []),
+  ], [
+    mapSegment.eastPakenhamToBairnsdale.part(4, 16),
+  ]),
   new LineShapeEdge(station.BUNYIP, station.LONGWARRY, [
     routeGraph.bunyipToLongwarry,
-  ], []),
+  ], [
+    mapSegment.eastPakenhamToBairnsdale.part(5, 16),
+  ]),
   new LineShapeEdge(station.LONGWARRY, station.DROUIN, [
     routeGraph.longwarryToDrouin,
-  ], []),
+  ], [
+    mapSegment.eastPakenhamToBairnsdale.part(6, 16),
+  ]),
   new LineShapeEdge(station.DROUIN, station.WARRAGUL, [
     routeGraph.drouinToWarragul,
-  ], []),
+  ], [
+    mapSegment.eastPakenhamToBairnsdale.part(7, 16),
+  ]),
   new LineShapeEdge(station.WARRAGUL, station.YARRAGON, [
     routeGraph.warragulToYarragon,
-  ], []),
+  ], [
+    mapSegment.eastPakenhamToBairnsdale.part(8, 16),
+  ]),
   new LineShapeEdge(station.YARRAGON, station.TRAFALGAR, [
     routeGraph.yarragonToTrafalgar,
-  ], []),
+  ], [
+    mapSegment.eastPakenhamToBairnsdale.part(9, 16),
+  ]),
   new LineShapeEdge(station.TRAFALGAR, station.MOE, [
     routeGraph.trafalgarToMoe,
-  ], []),
+  ], [
+    mapSegment.eastPakenhamToBairnsdale.part(10, 16),
+  ]),
   new LineShapeEdge(station.MOE, station.MORWELL, [
     routeGraph.moeToMorwell,
-  ], []),
+  ], [
+    mapSegment.eastPakenhamToBairnsdale.part(11, 16),
+  ]),
   new LineShapeEdge(station.MORWELL, station.TRARALGON, [
     routeGraph.morwellToTraralgon,
-  ], []),
+  ], [
+    mapSegment.eastPakenhamToBairnsdale.part(12, 16),
+  ]),
   new LineShapeEdge(station.TRARALGON, station.ROSEDALE, [
     routeGraph.traralgonToRosedale,
-  ], []),
+  ], [
+    mapSegment.eastPakenhamToBairnsdale.part(13, 16),
+  ]),
   new LineShapeEdge(station.ROSEDALE, station.SALE, [
     routeGraph.rosedaleToSale,
-  ], []),
+  ], [
+    mapSegment.eastPakenhamToBairnsdale.part(14, 16),
+  ]),
   new LineShapeEdge(station.SALE, station.STRATFORD, [
     routeGraph.saleToStratford,
-  ], []),
+  ], [
+    mapSegment.eastPakenhamToBairnsdale.part(15, 16),
+  ]),
   new LineShapeEdge(station.STRATFORD, station.BAIRNSDALE, [
     routeGraph.stratfordToBairnsdale,
-  ], []),
+  ], [
+    mapSegment.eastPakenhamToBairnsdale.part(16, 16),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/glen-waverley.ts
+++ b/server/entry-point/data/lines/glen-waverley.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -30,6 +32,18 @@ const routeGraph = {
   jordanvilleToMountWaverley: new StationPair(station.JORDANVILLE, station.MOUNT_WAVERLEY),
   mountWaverleyToSyndal: new StationPair(station.MOUNT_WAVERLEY, station.SYNDAL),
   syndalToGlenWaverley: new StationPair(station.SYNDAL, station.GLEN_WAVERLEY),
+};
+
+// prettier-ignore
+const mapSegment = {
+  flindersStreetToRichmond: MapSegment.full(map.BURNLEY.FLINDERS_STREET_DIRECT, map.BURNLEY.RICHMOND),
+  flindersStreetToSouthernCross: MapSegment.full(map.BURNLEY.FLINDERS_STREET_LOOP, map.BURNLEY.SOUTHERN_CROSS),
+  southernCrossToFlagstaff: MapSegment.full(map.BURNLEY.SOUTHERN_CROSS, map.BURNLEY.FLAGSTAFF),
+  flagstaffToMelbourneCentral: MapSegment.full(map.BURNLEY.FLAGSTAFF, map.BURNLEY.MELBOURNE_CENTRAL),
+  melbourneCentralToParliament: MapSegment.full(map.BURNLEY.MELBOURNE_CENTRAL, map.BURNLEY.PARLIAMENT),
+  parliamentToRichmond: MapSegment.full(map.BURNLEY.PARLIAMENT, map.BURNLEY.RICHMOND),
+  richmondToBurnley: MapSegment.full(map.BURNLEY.RICHMOND, map.BURNLEY.BURNLEY),
+  burnleyToGlenWaverley: MapSegment.full(map.BURNLEY.BURNLEY, map.BURNLEY.GLEN_WAVERLEY),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/glen-waverley.ts
+++ b/server/entry-point/data/lines/glen-waverley.ts
@@ -55,49 +55,84 @@ const lineShapeEdges = [
     routeGraph.flagstaffToMelbourneCentral,
     routeGraph.melbourneCentralToParliament,
     routeGraph.parliamentToRichmond,
-  ], []),
+  ], [
+    mapSegment.flindersStreetToRichmond,
+    mapSegment.flindersStreetToSouthernCross,
+    mapSegment.southernCrossToFlagstaff,
+    mapSegment.flagstaffToMelbourneCentral,
+    mapSegment.melbourneCentralToParliament,
+    mapSegment.parliamentToRichmond,
+  ]),
   new LineShapeEdge(station.RICHMOND, station.EAST_RICHMOND, [
     routeGraph.richmondToEastRichmond,
-  ], []),
+  ], [
+    mapSegment.richmondToBurnley.part(1, 2),
+  ]),
   new LineShapeEdge(station.EAST_RICHMOND, station.BURNLEY, [
     routeGraph.eastRichmondToBurnley,
-  ], []),
+  ], [
+    mapSegment.richmondToBurnley.part(2, 2),
+  ]),
   new LineShapeEdge(station.BURNLEY, station.HEYINGTON, [
     routeGraph.burnleyToHeyington,
-  ], []),
+  ], [
+    mapSegment.burnleyToGlenWaverley.part(1, 12),
+  ]),
   new LineShapeEdge(station.HEYINGTON, station.KOOYONG, [
     routeGraph.heyingtonToKooyong,
-  ], []),
+  ], [
+    mapSegment.burnleyToGlenWaverley.part(2, 12),
+  ]),
   new LineShapeEdge(station.KOOYONG, station.TOORONGA, [
     routeGraph.kooyongToTooronga,
-  ], []),
+  ], [
+    mapSegment.burnleyToGlenWaverley.part(3, 12),
+  ]),
   new LineShapeEdge(station.TOORONGA, station.GARDINER, [
     routeGraph.toorongaToGardiner,
-  ], []),
+  ], [
+    mapSegment.burnleyToGlenWaverley.part(4, 12),
+  ]),
   new LineShapeEdge(station.GARDINER, station.GLEN_IRIS, [
     routeGraph.gardinerToGlenIris,
-  ], []),
+  ], [
+    mapSegment.burnleyToGlenWaverley.part(5, 12),
+  ]),
   new LineShapeEdge(station.GLEN_IRIS, station.DARLING, [
     routeGraph.glenIrisToDarling,
-  ], []),
+  ], [
+    mapSegment.burnleyToGlenWaverley.part(6, 12),
+  ]),
   new LineShapeEdge(station.DARLING, station.EAST_MALVERN, [
     routeGraph.darlingToEastMalvern,
-  ], []),
+  ], [
+    mapSegment.burnleyToGlenWaverley.part(7, 12),
+  ]),
   new LineShapeEdge(station.EAST_MALVERN, station.HOLMESGLEN, [
     routeGraph.eastMalvernToHolmesglen,
-  ], []),
+  ], [
+    mapSegment.burnleyToGlenWaverley.part(8, 12),
+  ]),
   new LineShapeEdge(station.HOLMESGLEN, station.JORDANVILLE, [
     routeGraph.holmesglenToJordanville,
-  ], []),
+  ], [
+    mapSegment.burnleyToGlenWaverley.part(9, 12),
+  ]),
   new LineShapeEdge(station.JORDANVILLE, station.MOUNT_WAVERLEY, [
     routeGraph.jordanvilleToMountWaverley,
-  ], []),
+  ], [
+    mapSegment.burnleyToGlenWaverley.part(10, 12),
+  ]),
   new LineShapeEdge(station.MOUNT_WAVERLEY, station.SYNDAL, [
     routeGraph.mountWaverleyToSyndal,
-  ], []),
+  ], [
+    mapSegment.burnleyToGlenWaverley.part(11, 12),
+  ]),
   new LineShapeEdge(station.SYNDAL, station.GLEN_WAVERLEY, [
     routeGraph.syndalToGlenWaverley,
-  ], []),
+  ], [
+    mapSegment.burnleyToGlenWaverley.part(12, 12),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/glen-waverley.ts
+++ b/server/entry-point/data/lines/glen-waverley.ts
@@ -41,49 +41,49 @@ const lineShapeEdges = [
     routeGraph.flagstaffToMelbourneCentral,
     routeGraph.melbourneCentralToParliament,
     routeGraph.parliamentToRichmond,
-  ]),
+  ], []),
   new LineShapeEdge(station.RICHMOND, station.EAST_RICHMOND, [
     routeGraph.richmondToEastRichmond,
-  ]),
+  ], []),
   new LineShapeEdge(station.EAST_RICHMOND, station.BURNLEY, [
     routeGraph.eastRichmondToBurnley,
-  ]),
+  ], []),
   new LineShapeEdge(station.BURNLEY, station.HEYINGTON, [
     routeGraph.burnleyToHeyington,
-  ]),
+  ], []),
   new LineShapeEdge(station.HEYINGTON, station.KOOYONG, [
     routeGraph.heyingtonToKooyong,
-  ]),
+  ], []),
   new LineShapeEdge(station.KOOYONG, station.TOORONGA, [
     routeGraph.kooyongToTooronga,
-  ]),
+  ], []),
   new LineShapeEdge(station.TOORONGA, station.GARDINER, [
     routeGraph.toorongaToGardiner,
-  ]),
+  ], []),
   new LineShapeEdge(station.GARDINER, station.GLEN_IRIS, [
     routeGraph.gardinerToGlenIris,
-  ]),
+  ], []),
   new LineShapeEdge(station.GLEN_IRIS, station.DARLING, [
     routeGraph.glenIrisToDarling,
-  ]),
+  ], []),
   new LineShapeEdge(station.DARLING, station.EAST_MALVERN, [
     routeGraph.darlingToEastMalvern,
-  ]),
+  ], []),
   new LineShapeEdge(station.EAST_MALVERN, station.HOLMESGLEN, [
     routeGraph.eastMalvernToHolmesglen,
-  ]),
+  ], []),
   new LineShapeEdge(station.HOLMESGLEN, station.JORDANVILLE, [
     routeGraph.holmesglenToJordanville,
-  ]),
+  ], []),
   new LineShapeEdge(station.JORDANVILLE, station.MOUNT_WAVERLEY, [
     routeGraph.jordanvilleToMountWaverley,
-  ]),
+  ], []),
   new LineShapeEdge(station.MOUNT_WAVERLEY, station.SYNDAL, [
     routeGraph.mountWaverleyToSyndal,
-  ]),
+  ], []),
   new LineShapeEdge(station.SYNDAL, station.GLEN_WAVERLEY, [
     routeGraph.syndalToGlenWaverley,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/hurstbridge.ts
+++ b/server/entry-point/data/lines/hurstbridge.ts
@@ -63,73 +63,124 @@ const lineShapeEdges = [
     routeGraph.flagstaffToMelbourneCentral,
     routeGraph.melbourneCentralToParliament,
     routeGraph.parliamentToJolimont,
-  ], []),
+  ], [
+    mapSegment.flindersStreetToJolimont,
+    mapSegment.flindersStreetToSouthernCross,
+    mapSegment.southernCrossToFlagstaff,
+    mapSegment.flagstaffToMelbourneCentral,
+    mapSegment.melbourneCentralToParliament,
+    mapSegment.parliamentToJolimont,
+  ]),
   new LineShapeEdge(station.JOLIMONT, station.WEST_RICHMOND, [
     routeGraph.jolimontToWestRichmond,
-  ], []),
+  ], [
+    mapSegment.jolimontToCliftonHill.part(1, 5),
+  ]),
   new LineShapeEdge(station.WEST_RICHMOND, station.NORTH_RICHMOND, [
     routeGraph.westRichmondToNorthRichmond,
-  ], []),
+  ], [
+    mapSegment.jolimontToCliftonHill.part(2, 5),
+  ]),
   new LineShapeEdge(station.NORTH_RICHMOND, station.COLLINGWOOD, [
     routeGraph.northRichmondToCollingwood,
-  ], []),
+  ], [
+    mapSegment.jolimontToCliftonHill.part(3, 5),
+  ]),
   new LineShapeEdge(station.COLLINGWOOD, station.VICTORIA_PARK, [
     routeGraph.collingwoodToVictoriaPark,
-  ], []),
+  ], [
+    mapSegment.jolimontToCliftonHill.part(4, 5),
+  ]),
   new LineShapeEdge(station.VICTORIA_PARK, station.CLIFTON_HILL, [
     routeGraph.victoriaParkToCliftonHill,
-  ], []),
+  ], [
+    mapSegment.jolimontToCliftonHill.part(5, 5),
+  ]),
   new LineShapeEdge(station.CLIFTON_HILL, station.WESTGARTH, [
     routeGraph.cliftonHillToWestgarth,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToHurstbridge.part(1, 17),
+  ]),
   new LineShapeEdge(station.WESTGARTH, station.DENNIS, [
     routeGraph.westgarthToDennis,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToHurstbridge.part(2, 17),
+  ]),
   new LineShapeEdge(station.DENNIS, station.FAIRFIELD, [
     routeGraph.dennisToFairfield,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToHurstbridge.part(3, 17),
+  ]),
   new LineShapeEdge(station.FAIRFIELD, station.ALPHINGTON, [
     routeGraph.fairfieldToAlphington,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToHurstbridge.part(4, 17),
+  ]),
   new LineShapeEdge(station.ALPHINGTON, station.DAREBIN, [
     routeGraph.alphingtonToDarebin,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToHurstbridge.part(5, 17),
+  ]),
   new LineShapeEdge(station.DAREBIN, station.IVANHOE, [
     routeGraph.darebinToIvanhoe,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToHurstbridge.part(6, 17),
+  ]),
   new LineShapeEdge(station.IVANHOE, station.EAGLEMONT, [
     routeGraph.ivanhoeToEaglemont,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToHurstbridge.part(7, 17),
+  ]),
   new LineShapeEdge(station.EAGLEMONT, station.HEIDELBERG, [
     routeGraph.eaglemontToHeidelberg,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToHurstbridge.part(8, 17),
+  ]),
   new LineShapeEdge(station.HEIDELBERG, station.ROSANNA, [
     routeGraph.heidelbergToRosanna,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToHurstbridge.part(9, 17),
+  ]),
   new LineShapeEdge(station.ROSANNA, station.MACLEOD, [
     routeGraph.rosannaToMacleod,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToHurstbridge.part(10, 17),
+  ]),
   new LineShapeEdge(station.MACLEOD, station.WATSONIA, [
     routeGraph.macleodToWatsonia,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToHurstbridge.part(11, 17),
+  ]),
   new LineShapeEdge(station.WATSONIA, station.GREENSBOROUGH, [
     routeGraph.watsoniaToGreensborough,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToHurstbridge.part(12, 17),
+  ]),
   new LineShapeEdge(station.GREENSBOROUGH, station.MONTMORENCY, [
     routeGraph.greensboroughToMontmorency,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToHurstbridge.part(13, 17),
+  ]),
   new LineShapeEdge(station.MONTMORENCY, station.ELTHAM, [
     routeGraph.montmorencyToEltham,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToHurstbridge.part(14, 17),
+  ]),
   new LineShapeEdge(station.ELTHAM, station.DIAMOND_CREEK, [
     routeGraph.elthamToDiamondCreek,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToHurstbridge.part(15, 17),
+  ]),
   new LineShapeEdge(station.DIAMOND_CREEK, station.WATTLE_GLEN, [
     routeGraph.diamondCreekToWattleGlen,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToHurstbridge.part(16, 17),
+  ]),
   new LineShapeEdge(station.WATTLE_GLEN, station.HURSTBRIDGE, [
     routeGraph.wattleGlenToHurstbridge,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToHurstbridge.part(17, 17),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/hurstbridge.ts
+++ b/server/entry-point/data/lines/hurstbridge.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -38,6 +40,18 @@ const routeGraph = {
   elthamToDiamondCreek: new StationPair(station.ELTHAM, station.DIAMOND_CREEK),
   diamondCreekToWattleGlen: new StationPair(station.DIAMOND_CREEK, station.WATTLE_GLEN),
   wattleGlenToHurstbridge: new StationPair(station.WATTLE_GLEN, station.HURSTBRIDGE),
+};
+
+// prettier-ignore
+const mapSegment = {
+  flindersStreetToJolimont: MapSegment.full(map.CLIFTON_HILL.FLINDERS_STREET_DIRECT, map.CLIFTON_HILL.JOLIMONT),
+  flindersStreetToSouthernCross: MapSegment.full(map.CLIFTON_HILL.FLINDERS_STREET_LOOP, map.CLIFTON_HILL.SOUTHERN_CROSS),
+  southernCrossToFlagstaff: MapSegment.full(map.CLIFTON_HILL.SOUTHERN_CROSS, map.CLIFTON_HILL.FLAGSTAFF),
+  flagstaffToMelbourneCentral: MapSegment.full(map.CLIFTON_HILL.FLAGSTAFF, map.CLIFTON_HILL.MELBOURNE_CENTRAL),
+  melbourneCentralToParliament: MapSegment.full(map.CLIFTON_HILL.MELBOURNE_CENTRAL, map.CLIFTON_HILL.PARLIAMENT),
+  parliamentToJolimont: MapSegment.full(map.CLIFTON_HILL.PARLIAMENT, map.CLIFTON_HILL.JOLIMONT),
+  jolimontToCliftonHill: MapSegment.full(map.CLIFTON_HILL.JOLIMONT, map.CLIFTON_HILL.CLIFTON_HILL),
+  cliftonHillToHurstbridge: MapSegment.full(map.CLIFTON_HILL.CLIFTON_HILL, map.CLIFTON_HILL.HURSTBRIDGE),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/hurstbridge.ts
+++ b/server/entry-point/data/lines/hurstbridge.ts
@@ -49,73 +49,73 @@ const lineShapeEdges = [
     routeGraph.flagstaffToMelbourneCentral,
     routeGraph.melbourneCentralToParliament,
     routeGraph.parliamentToJolimont,
-  ]),
+  ], []),
   new LineShapeEdge(station.JOLIMONT, station.WEST_RICHMOND, [
     routeGraph.jolimontToWestRichmond,
-  ]),
+  ], []),
   new LineShapeEdge(station.WEST_RICHMOND, station.NORTH_RICHMOND, [
     routeGraph.westRichmondToNorthRichmond,
-  ]),
+  ], []),
   new LineShapeEdge(station.NORTH_RICHMOND, station.COLLINGWOOD, [
     routeGraph.northRichmondToCollingwood,
-  ]),
+  ], []),
   new LineShapeEdge(station.COLLINGWOOD, station.VICTORIA_PARK, [
     routeGraph.collingwoodToVictoriaPark,
-  ]),
+  ], []),
   new LineShapeEdge(station.VICTORIA_PARK, station.CLIFTON_HILL, [
     routeGraph.victoriaParkToCliftonHill,
-  ]),
+  ], []),
   new LineShapeEdge(station.CLIFTON_HILL, station.WESTGARTH, [
     routeGraph.cliftonHillToWestgarth,
-  ]),
+  ], []),
   new LineShapeEdge(station.WESTGARTH, station.DENNIS, [
     routeGraph.westgarthToDennis,
-  ]),
+  ], []),
   new LineShapeEdge(station.DENNIS, station.FAIRFIELD, [
     routeGraph.dennisToFairfield,
-  ]),
+  ], []),
   new LineShapeEdge(station.FAIRFIELD, station.ALPHINGTON, [
     routeGraph.fairfieldToAlphington,
-  ]),
+  ], []),
   new LineShapeEdge(station.ALPHINGTON, station.DAREBIN, [
     routeGraph.alphingtonToDarebin,
-  ]),
+  ], []),
   new LineShapeEdge(station.DAREBIN, station.IVANHOE, [
     routeGraph.darebinToIvanhoe,
-  ]),
+  ], []),
   new LineShapeEdge(station.IVANHOE, station.EAGLEMONT, [
     routeGraph.ivanhoeToEaglemont,
-  ]),
+  ], []),
   new LineShapeEdge(station.EAGLEMONT, station.HEIDELBERG, [
     routeGraph.eaglemontToHeidelberg,
-  ]),
+  ], []),
   new LineShapeEdge(station.HEIDELBERG, station.ROSANNA, [
     routeGraph.heidelbergToRosanna,
-  ]),
+  ], []),
   new LineShapeEdge(station.ROSANNA, station.MACLEOD, [
     routeGraph.rosannaToMacleod,
-  ]),
+  ], []),
   new LineShapeEdge(station.MACLEOD, station.WATSONIA, [
     routeGraph.macleodToWatsonia,
-  ]),
+  ], []),
   new LineShapeEdge(station.WATSONIA, station.GREENSBOROUGH, [
     routeGraph.watsoniaToGreensborough,
-  ]),
+  ], []),
   new LineShapeEdge(station.GREENSBOROUGH, station.MONTMORENCY, [
     routeGraph.greensboroughToMontmorency,
-  ]),
+  ], []),
   new LineShapeEdge(station.MONTMORENCY, station.ELTHAM, [
     routeGraph.montmorencyToEltham,
-  ]),
+  ], []),
   new LineShapeEdge(station.ELTHAM, station.DIAMOND_CREEK, [
     routeGraph.elthamToDiamondCreek,
-  ]),
+  ], []),
   new LineShapeEdge(station.DIAMOND_CREEK, station.WATTLE_GLEN, [
     routeGraph.diamondCreekToWattleGlen,
-  ]),
+  ], []),
   new LineShapeEdge(station.WATTLE_GLEN, station.HURSTBRIDGE, [
     routeGraph.wattleGlenToHurstbridge,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/lilydale.ts
+++ b/server/entry-point/data/lines/lilydale.ts
@@ -64,70 +64,119 @@ const lineShapeEdges = [
     routeGraph.flagstaffToMelbourneCentral,
     routeGraph.melbourneCentralToParliament,
     routeGraph.parliamentToRichmond,
-  ], []),
+  ], [
+    mapSegment.flindersStreetToRichmond,
+    mapSegment.flindersStreetToSouthernCross,
+    mapSegment.southernCrossToFlagstaff,
+    mapSegment.flagstaffToMelbourneCentral,
+    mapSegment.melbourneCentralToParliament,
+    mapSegment.parliamentToRichmond,
+  ]),
   new LineShapeEdge(station.RICHMOND, station.EAST_RICHMOND, [
     routeGraph.richmondToEastRichmond,
-  ], []),
+  ], [
+    mapSegment.richmondToBurnley.part(1, 2),
+  ]),
   new LineShapeEdge(station.EAST_RICHMOND, station.BURNLEY, [
     routeGraph.eastRichmondToBurnley,
-  ], []),
+  ], [
+    mapSegment.richmondToBurnley.part(2, 2),
+  ]),
   new LineShapeEdge(station.BURNLEY, station.HAWTHORN, [
     routeGraph.burnleyToHawthorn,
-  ], []),
+  ], [
+    mapSegment.burnleyToCamberwell.part(1, 4),
+  ]),
   new LineShapeEdge(station.HAWTHORN, station.GLENFERRIE, [
     routeGraph.hawthornToGlenferrie,
-  ], []),
+  ], [
+    mapSegment.burnleyToCamberwell.part(2, 4),
+  ]),
   new LineShapeEdge(station.GLENFERRIE, station.AUBURN, [
     routeGraph.glenferrieToAuburn,
-  ], []),
+  ], [
+    mapSegment.burnleyToCamberwell.part(3, 4),
+  ]),
   new LineShapeEdge(station.AUBURN, station.CAMBERWELL, [
     routeGraph.auburnToCamberwell,
-  ], []),
+  ], [
+    mapSegment.burnleyToCamberwell.part(4, 4),
+  ]),
   new LineShapeEdge(station.CAMBERWELL, station.EAST_CAMBERWELL, [
     routeGraph.camberwellToEastCamberwell,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(1, 11),
+  ]),
   new LineShapeEdge(station.EAST_CAMBERWELL, station.CANTERBURY, [
     routeGraph.eastCamberwellToCanterbury,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(2, 11),
+  ]),
   new LineShapeEdge(station.CANTERBURY, station.CHATHAM, [
     routeGraph.canterburyToChatham,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(3, 11),
+  ]),
   new LineShapeEdge(station.CHATHAM, station.UNION, [
     routeGraph.chathamToUnion,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(4, 11),
+  ]),
   new LineShapeEdge(station.UNION, station.BOX_HILL, [
     routeGraph.unionToBoxHill,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(5, 11),
+  ]),
   new LineShapeEdge(station.BOX_HILL, station.LABURNUM, [
     routeGraph.boxHillToLaburnum,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(6, 11),
+  ]),
   new LineShapeEdge(station.LABURNUM, station.BLACKBURN, [
     routeGraph.laburnumToBlackburn,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(7, 11),
+  ]),
   new LineShapeEdge(station.BLACKBURN, station.NUNAWADING, [
     routeGraph.blackburnToNunawading,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(8, 11),
+  ]),
   new LineShapeEdge(station.NUNAWADING, station.MITCHAM, [
     routeGraph.nunawadingToMitcham,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(9, 11),
+  ]),
   new LineShapeEdge(station.MITCHAM, station.HEATHERDALE, [
     routeGraph.mitchamToHeatherdale,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(10, 11),
+  ]),
   new LineShapeEdge(station.HEATHERDALE, station.RINGWOOD, [
     routeGraph.heatherdaleToRingwood,
-  ], []),
+  ], [
+    mapSegment.camberwellToRingwood.part(11, 11),
+  ]),
   new LineShapeEdge(station.RINGWOOD, station.RINGWOOD_EAST, [
     routeGraph.ringwoodToRingwoodEast,
-  ], []),
+  ], [
+    mapSegment.ringwoodToLilydale.part(1, 4),
+  ]),
   new LineShapeEdge(station.RINGWOOD_EAST, station.CROYDON, [
     routeGraph.ringwoodEastToCroydon,
-  ], []),
+  ], [
+    mapSegment.ringwoodToLilydale.part(2, 4),
+  ]),
   new LineShapeEdge(station.CROYDON, station.MOOROOLBARK, [
     routeGraph.croydonToMooroolbark,
-  ], []),
+  ], [
+    mapSegment.ringwoodToLilydale.part(3, 4),
+  ]),
   new LineShapeEdge(station.MOOROOLBARK, station.LILYDALE, [
     routeGraph.mooroolbarkToLilydale,
-  ], []),
+  ], [
+    mapSegment.ringwoodToLilydale.part(4, 4),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/lilydale.ts
+++ b/server/entry-point/data/lines/lilydale.ts
@@ -48,70 +48,70 @@ const lineShapeEdges = [
     routeGraph.flagstaffToMelbourneCentral,
     routeGraph.melbourneCentralToParliament,
     routeGraph.parliamentToRichmond,
-  ]),
+  ], []),
   new LineShapeEdge(station.RICHMOND, station.EAST_RICHMOND, [
     routeGraph.richmondToEastRichmond,
-  ]),
+  ], []),
   new LineShapeEdge(station.EAST_RICHMOND, station.BURNLEY, [
     routeGraph.eastRichmondToBurnley,
-  ]),
+  ], []),
   new LineShapeEdge(station.BURNLEY, station.HAWTHORN, [
     routeGraph.burnleyToHawthorn,
-  ]),
+  ], []),
   new LineShapeEdge(station.HAWTHORN, station.GLENFERRIE, [
     routeGraph.hawthornToGlenferrie,
-  ]),
+  ], []),
   new LineShapeEdge(station.GLENFERRIE, station.AUBURN, [
     routeGraph.glenferrieToAuburn,
-  ]),
+  ], []),
   new LineShapeEdge(station.AUBURN, station.CAMBERWELL, [
     routeGraph.auburnToCamberwell,
-  ]),
+  ], []),
   new LineShapeEdge(station.CAMBERWELL, station.EAST_CAMBERWELL, [
     routeGraph.camberwellToEastCamberwell,
-  ]),
+  ], []),
   new LineShapeEdge(station.EAST_CAMBERWELL, station.CANTERBURY, [
     routeGraph.eastCamberwellToCanterbury,
-  ]),
+  ], []),
   new LineShapeEdge(station.CANTERBURY, station.CHATHAM, [
     routeGraph.canterburyToChatham,
-  ]),
+  ], []),
   new LineShapeEdge(station.CHATHAM, station.UNION, [
     routeGraph.chathamToUnion,
-  ]),
+  ], []),
   new LineShapeEdge(station.UNION, station.BOX_HILL, [
     routeGraph.unionToBoxHill,
-  ]),
+  ], []),
   new LineShapeEdge(station.BOX_HILL, station.LABURNUM, [
     routeGraph.boxHillToLaburnum,
-  ]),
+  ], []),
   new LineShapeEdge(station.LABURNUM, station.BLACKBURN, [
     routeGraph.laburnumToBlackburn,
-  ]),
+  ], []),
   new LineShapeEdge(station.BLACKBURN, station.NUNAWADING, [
     routeGraph.blackburnToNunawading,
-  ]),
+  ], []),
   new LineShapeEdge(station.NUNAWADING, station.MITCHAM, [
     routeGraph.nunawadingToMitcham,
-  ]),
+  ], []),
   new LineShapeEdge(station.MITCHAM, station.HEATHERDALE, [
     routeGraph.mitchamToHeatherdale,
-  ]),
+  ], []),
   new LineShapeEdge(station.HEATHERDALE, station.RINGWOOD, [
     routeGraph.heatherdaleToRingwood,
-  ]),
+  ], []),
   new LineShapeEdge(station.RINGWOOD, station.RINGWOOD_EAST, [
     routeGraph.ringwoodToRingwoodEast,
-  ]),
+  ], []),
   new LineShapeEdge(station.RINGWOOD_EAST, station.CROYDON, [
     routeGraph.ringwoodEastToCroydon,
-  ]),
+  ], []),
   new LineShapeEdge(station.CROYDON, station.MOOROOLBARK, [
     routeGraph.croydonToMooroolbark,
-  ]),
+  ], []),
   new LineShapeEdge(station.MOOROOLBARK, station.LILYDALE, [
     routeGraph.mooroolbarkToLilydale,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/lilydale.ts
+++ b/server/entry-point/data/lines/lilydale.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -37,6 +39,20 @@ const routeGraph = {
   ringwoodEastToCroydon: new StationPair(station.RINGWOOD_EAST, station.CROYDON),
   croydonToMooroolbark: new StationPair(station.CROYDON, station.MOOROOLBARK),
   mooroolbarkToLilydale: new StationPair(station.MOOROOLBARK, station.LILYDALE),
+};
+
+// prettier-ignore
+const mapSegment = {
+  flindersStreetToRichmond: MapSegment.full(map.BURNLEY.FLINDERS_STREET_DIRECT, map.BURNLEY.RICHMOND),
+  flindersStreetToSouthernCross: MapSegment.full(map.BURNLEY.FLINDERS_STREET_LOOP, map.BURNLEY.SOUTHERN_CROSS),
+  southernCrossToFlagstaff: MapSegment.full(map.BURNLEY.SOUTHERN_CROSS, map.BURNLEY.FLAGSTAFF),
+  flagstaffToMelbourneCentral: MapSegment.full(map.BURNLEY.FLAGSTAFF, map.BURNLEY.MELBOURNE_CENTRAL),
+  melbourneCentralToParliament: MapSegment.full(map.BURNLEY.MELBOURNE_CENTRAL, map.BURNLEY.PARLIAMENT),
+  parliamentToRichmond: MapSegment.full(map.BURNLEY.PARLIAMENT, map.BURNLEY.RICHMOND),
+  richmondToBurnley: MapSegment.full(map.BURNLEY.RICHMOND, map.BURNLEY.BURNLEY),
+  burnleyToCamberwell: MapSegment.full(map.BURNLEY.BURNLEY, map.BURNLEY.CAMBERWELL),
+  camberwellToRingwood: MapSegment.full(map.BURNLEY.CAMBERWELL, map.BURNLEY.RINGWOOD),
+  ringwoodToLilydale: MapSegment.full(map.BURNLEY.RINGWOOD, map.BURNLEY.LILYDALE),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/mernda.ts
+++ b/server/entry-point/data/lines/mernda.ts
@@ -64,76 +64,129 @@ const lineShapeEdges = [
     routeGraph.flagstaffToMelbourneCentral,
     routeGraph.melbourneCentralToParliament,
     routeGraph.parliamentToJolimont,
-  ], []),
+  ], [
+    mapSegment.flindersStreetToJolimont,
+    mapSegment.flindersStreetToSouthernCross,
+    mapSegment.southernCrossToFlagstaff,
+    mapSegment.flagstaffToMelbourneCentral,
+    mapSegment.melbourneCentralToParliament,
+    mapSegment.parliamentToJolimont,
+  ]),
   new LineShapeEdge(station.JOLIMONT, station.WEST_RICHMOND, [
     routeGraph.jolimontToWestRichmond,
-  ], []),
+  ], [
+    mapSegment.jolimontToCliftonHill.part(1, 5),
+  ]),
   new LineShapeEdge(station.WEST_RICHMOND, station.NORTH_RICHMOND, [
     routeGraph.westRichmondToNorthRichmond,
-  ], []),
+  ], [
+    mapSegment.jolimontToCliftonHill.part(2, 5),
+  ]),
   new LineShapeEdge(station.NORTH_RICHMOND, station.COLLINGWOOD, [
     routeGraph.northRichmondToCollingwood,
-  ], []),
+  ], [
+    mapSegment.jolimontToCliftonHill.part(3, 5),
+  ]),
   new LineShapeEdge(station.COLLINGWOOD, station.VICTORIA_PARK, [
     routeGraph.collingwoodToVictoriaPark,
-  ], []),
+  ], [
+    mapSegment.jolimontToCliftonHill.part(4, 5),
+  ]),
   new LineShapeEdge(station.VICTORIA_PARK, station.CLIFTON_HILL, [
     routeGraph.victoriaParkToCliftonHill,
-  ], []),
+  ], [
+    mapSegment.jolimontToCliftonHill.part(5, 5),
+  ]),
   new LineShapeEdge(station.CLIFTON_HILL, station.RUSHALL, [
     routeGraph.cliftonHillToRushall,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(1, 18),
+  ]),
   new LineShapeEdge(station.RUSHALL, station.MERRI, [
     routeGraph.rushallToMerri,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(2, 18),
+  ]),
   new LineShapeEdge(station.MERRI, station.NORTHCOTE, [
     routeGraph.merriToNorthcote,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(3, 18),
+  ]),
   new LineShapeEdge(station.NORTHCOTE, station.CROXTON, [
     routeGraph.northcoteToCroxton,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(4, 18),
+  ]),
   new LineShapeEdge(station.CROXTON, station.THORNBURY, [
     routeGraph.croxtonToThornbury,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(5, 18),
+  ]),
   new LineShapeEdge(station.THORNBURY, station.BELL, [
     routeGraph.thornburyToBell,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(6, 18),
+  ]),
   new LineShapeEdge(station.BELL, station.PRESTON, [
     routeGraph.bellToPreston,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(7, 18),
+  ]),
   new LineShapeEdge(station.PRESTON, station.REGENT, [
     routeGraph.prestonToRegent,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(8, 18),
+  ]),
   new LineShapeEdge(station.REGENT, station.RESERVOIR, [
     routeGraph.regentToReservoir,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(9, 18),
+  ]),
   new LineShapeEdge(station.RESERVOIR, station.RUTHVEN, [
     routeGraph.reservoirToRuthven,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(10, 18),
+  ]),
   new LineShapeEdge(station.RUTHVEN, station.KEON_PARK, [
     routeGraph.ruthvenToKeonPark,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(11, 18),
+  ]),
   new LineShapeEdge(station.KEON_PARK, station.THOMASTOWN, [
     routeGraph.keonParkToThomastown,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(12, 18),
+  ]),
   new LineShapeEdge(station.THOMASTOWN, station.LALOR, [
     routeGraph.thomastownToLalor,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(13, 18),
+  ]),
   new LineShapeEdge(station.LALOR, station.EPPING, [
     routeGraph.lalorToEpping,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(14, 18),
+  ]),
   new LineShapeEdge(station.EPPING, station.SOUTH_MORANG, [
     routeGraph.eppingToSouthMorang,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(15, 18),
+  ]),
   new LineShapeEdge(station.SOUTH_MORANG, station.MIDDLE_GORGE, [
     routeGraph.southMorangToMiddleGorge,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(16, 18),
+  ]),
   new LineShapeEdge(station.MIDDLE_GORGE, station.HAWKSTOWE, [
     routeGraph.middleGorgeToHawkstowe,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(17, 18),
+  ]),
   new LineShapeEdge(station.HAWKSTOWE, station.MERNDA, [
     routeGraph.hawkstoweToMernda,
-  ], []),
+  ], [
+    mapSegment.cliftonHillToMernda.part(18, 18),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/mernda.ts
+++ b/server/entry-point/data/lines/mernda.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -39,6 +41,18 @@ const routeGraph = {
   southMorangToMiddleGorge: new StationPair(station.SOUTH_MORANG, station.MIDDLE_GORGE),
   middleGorgeToHawkstowe: new StationPair(station.MIDDLE_GORGE, station.HAWKSTOWE),
   hawkstoweToMernda: new StationPair(station.HAWKSTOWE, station.MERNDA),
+};
+
+// prettier-ignore
+const mapSegment = {
+  flindersStreetToJolimont: MapSegment.full(map.CLIFTON_HILL.FLINDERS_STREET_DIRECT, map.CLIFTON_HILL.JOLIMONT),
+  flindersStreetToSouthernCross: MapSegment.full(map.CLIFTON_HILL.FLINDERS_STREET_LOOP, map.CLIFTON_HILL.SOUTHERN_CROSS),
+  southernCrossToFlagstaff: MapSegment.full(map.CLIFTON_HILL.SOUTHERN_CROSS, map.CLIFTON_HILL.FLAGSTAFF),
+  flagstaffToMelbourneCentral: MapSegment.full(map.CLIFTON_HILL.FLAGSTAFF, map.CLIFTON_HILL.MELBOURNE_CENTRAL),
+  melbourneCentralToParliament: MapSegment.full(map.CLIFTON_HILL.MELBOURNE_CENTRAL, map.CLIFTON_HILL.PARLIAMENT),
+  parliamentToJolimont: MapSegment.full(map.CLIFTON_HILL.PARLIAMENT, map.CLIFTON_HILL.JOLIMONT),
+  jolimontToCliftonHill: MapSegment.full(map.CLIFTON_HILL.JOLIMONT, map.CLIFTON_HILL.CLIFTON_HILL),
+  cliftonHillToMernda: MapSegment.full(map.CLIFTON_HILL.CLIFTON_HILL, map.CLIFTON_HILL.MERNDA),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/mernda.ts
+++ b/server/entry-point/data/lines/mernda.ts
@@ -50,76 +50,76 @@ const lineShapeEdges = [
     routeGraph.flagstaffToMelbourneCentral,
     routeGraph.melbourneCentralToParliament,
     routeGraph.parliamentToJolimont,
-  ]),
+  ], []),
   new LineShapeEdge(station.JOLIMONT, station.WEST_RICHMOND, [
     routeGraph.jolimontToWestRichmond,
-  ]),
+  ], []),
   new LineShapeEdge(station.WEST_RICHMOND, station.NORTH_RICHMOND, [
     routeGraph.westRichmondToNorthRichmond,
-  ]),
+  ], []),
   new LineShapeEdge(station.NORTH_RICHMOND, station.COLLINGWOOD, [
     routeGraph.northRichmondToCollingwood,
-  ]),
+  ], []),
   new LineShapeEdge(station.COLLINGWOOD, station.VICTORIA_PARK, [
     routeGraph.collingwoodToVictoriaPark,
-  ]),
+  ], []),
   new LineShapeEdge(station.VICTORIA_PARK, station.CLIFTON_HILL, [
     routeGraph.victoriaParkToCliftonHill,
-  ]),
+  ], []),
   new LineShapeEdge(station.CLIFTON_HILL, station.RUSHALL, [
     routeGraph.cliftonHillToRushall,
-  ]),
+  ], []),
   new LineShapeEdge(station.RUSHALL, station.MERRI, [
     routeGraph.rushallToMerri,
-  ]),
+  ], []),
   new LineShapeEdge(station.MERRI, station.NORTHCOTE, [
     routeGraph.merriToNorthcote,
-  ]),
+  ], []),
   new LineShapeEdge(station.NORTHCOTE, station.CROXTON, [
     routeGraph.northcoteToCroxton,
-  ]),
+  ], []),
   new LineShapeEdge(station.CROXTON, station.THORNBURY, [
     routeGraph.croxtonToThornbury,
-  ]),
+  ], []),
   new LineShapeEdge(station.THORNBURY, station.BELL, [
     routeGraph.thornburyToBell,
-  ]),
+  ], []),
   new LineShapeEdge(station.BELL, station.PRESTON, [
     routeGraph.bellToPreston,
-  ]),
+  ], []),
   new LineShapeEdge(station.PRESTON, station.REGENT, [
     routeGraph.prestonToRegent,
-  ]),
+  ], []),
   new LineShapeEdge(station.REGENT, station.RESERVOIR, [
     routeGraph.regentToReservoir,
-  ]),
+  ], []),
   new LineShapeEdge(station.RESERVOIR, station.RUTHVEN, [
     routeGraph.reservoirToRuthven,
-  ]),
+  ], []),
   new LineShapeEdge(station.RUTHVEN, station.KEON_PARK, [
     routeGraph.ruthvenToKeonPark,
-  ]),
+  ], []),
   new LineShapeEdge(station.KEON_PARK, station.THOMASTOWN, [
     routeGraph.keonParkToThomastown,
-  ]),
+  ], []),
   new LineShapeEdge(station.THOMASTOWN, station.LALOR, [
     routeGraph.thomastownToLalor,
-  ]),
+  ], []),
   new LineShapeEdge(station.LALOR, station.EPPING, [
     routeGraph.lalorToEpping,
-  ]),
+  ], []),
   new LineShapeEdge(station.EPPING, station.SOUTH_MORANG, [
     routeGraph.eppingToSouthMorang,
-  ]),
+  ], []),
   new LineShapeEdge(station.SOUTH_MORANG, station.MIDDLE_GORGE, [
     routeGraph.southMorangToMiddleGorge,
-  ]),
+  ], []),
   new LineShapeEdge(station.MIDDLE_GORGE, station.HAWKSTOWE, [
     routeGraph.middleGorgeToHawkstowe,
-  ]),
+  ], []),
   new LineShapeEdge(station.HAWKSTOWE, station.MERNDA, [
     routeGraph.hawkstoweToMernda,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/pakenham.ts
+++ b/server/entry-point/data/lines/pakenham.ts
@@ -67,73 +67,124 @@ const lineShapeEdges = [
     routeGraph.flagstaffToMelbourneCentral,
     routeGraph.melbourneCentralToParliament,
     routeGraph.parliamentToRichmond,
-  ], []),
+  ], [
+    mapSegment.flindersStreetToRichmond,
+    mapSegment.flindersStreetToSouthernCross,
+    mapSegment.southernCrossToFlagstaff,
+    mapSegment.flagstaffToMelbourneCentral,
+    mapSegment.melbourneCentralToParliament,
+    mapSegment.parliamentToRichmond,
+  ]),
   new LineShapeEdge(station.RICHMOND, station.SOUTH_YARRA, [
     routeGraph.richmondToSouthYarra,
-  ], []),
+  ], [
+    mapSegment.richmondToSouthYarra,
+  ]),
   new LineShapeEdge(station.SOUTH_YARRA, station.CAULFIELD, [
     routeGraph.southYarraToCaulfield,
-  ], []),
+  ], [
+    mapSegment.southYarraToCaulfield,
+  ]),
   new LineShapeEdge(station.CAULFIELD, station.CARNEGIE, [
     routeGraph.caulfieldToCarnegie,
-  ], []),
+  ], [
+    mapSegment.caulfieldToClayton.part(1, 6),
+  ]),
   new LineShapeEdge(station.CARNEGIE, station.MURRUMBEENA, [
     routeGraph.carnegieToMurrumbeena,
-  ], []),
+  ], [
+    mapSegment.caulfieldToClayton.part(2, 6),
+  ]),
   new LineShapeEdge(station.MURRUMBEENA, station.HUGHESDALE, [
     routeGraph.murrumbeenaToHughesdale,
-  ], []),
+  ], [
+    mapSegment.caulfieldToClayton.part(3, 6),
+  ]),
   new LineShapeEdge(station.HUGHESDALE, station.OAKLEIGH, [
     routeGraph.hughesdaleToOakleigh,
-  ], []),
+  ], [
+    mapSegment.caulfieldToClayton.part(4, 6),
+  ]),
   new LineShapeEdge(station.OAKLEIGH, station.HUNTINGDALE, [
     routeGraph.oakleighToHuntingdale,
-  ], []),
+  ], [
+    mapSegment.caulfieldToClayton.part(5, 6),
+  ]),
   new LineShapeEdge(station.HUNTINGDALE, station.CLAYTON, [
     routeGraph.huntingdaleToClayton,
-  ], []),
+  ], [
+    mapSegment.caulfieldToClayton.part(6, 6),
+  ]),
   new LineShapeEdge(station.CLAYTON, station.WESTALL, [
     routeGraph.claytonToWestall,
-  ], []),
+  ], [
+    mapSegment.claytonToDandenong.part(1, 6),
+  ]),
   new LineShapeEdge(station.WESTALL, station.SPRINGVALE, [
     routeGraph.westallToSpringvale,
-  ], []),
+  ], [
+    mapSegment.claytonToDandenong.part(2, 6),
+  ]),
   new LineShapeEdge(station.SPRINGVALE, station.SANDOWN_PARK, [
     routeGraph.springvaleToSandownPark,
-  ], []),
+  ], [
+    mapSegment.claytonToDandenong.part(3, 6),
+  ]),
   new LineShapeEdge(station.SANDOWN_PARK, station.NOBLE_PARK, [
     routeGraph.sandownParkToNoblePark,
-  ], []),
+  ], [
+    mapSegment.claytonToDandenong.part(4, 6),
+  ]),
   new LineShapeEdge(station.NOBLE_PARK, station.YARRAMAN, [
     routeGraph.nobleParkToYarraman,
-  ], []),
+  ], [
+    mapSegment.claytonToDandenong.part(5, 6),
+  ]),
   new LineShapeEdge(station.YARRAMAN, station.DANDENONG, [
     routeGraph.yarramanToDandenong,
-  ], []),
+  ], [
+    mapSegment.claytonToDandenong.part(6, 6),
+  ]),
   new LineShapeEdge(station.DANDENONG, station.HALLAM, [
     routeGraph.dandenongToHallam,
-  ], []),
+  ], [
+    mapSegment.dandenongToPakenham.part(1, 7),
+  ]),
   new LineShapeEdge(station.HALLAM, station.NARRE_WARREN, [
     routeGraph.hallamToNarreWarren,
-  ], []),
+  ], [
+    mapSegment.dandenongToPakenham.part(2, 7),
+  ]),
   new LineShapeEdge(station.NARRE_WARREN, station.BERWICK, [
     routeGraph.narreWarrenToBerwick,
-  ], []),
+  ], [
+    mapSegment.dandenongToPakenham.part(3, 7),
+  ]),
   new LineShapeEdge(station.BERWICK, station.BEACONSFIELD, [
     routeGraph.berwickToBeaconsfield,
-  ], []),
+  ], [
+    mapSegment.dandenongToPakenham.part(4, 7),
+  ]),
   new LineShapeEdge(station.BEACONSFIELD, station.OFFICER, [
     routeGraph.beaconsfieldToOfficer,
-  ], []),
+  ], [
+    mapSegment.dandenongToPakenham.part(5, 7),
+  ]),
   new LineShapeEdge(station.OFFICER, station.CARDINIA_ROAD, [
     routeGraph.officerToCardiniaRoad,
-  ], []),
+  ], [
+    mapSegment.dandenongToPakenham.part(6, 7),
+  ]),
   new LineShapeEdge(station.CARDINIA_ROAD, station.PAKENHAM, [
     routeGraph.cardiniaRoadToPakenham,
-  ], []),
+  ], [
+    mapSegment.dandenongToPakenham.part(7, 7),
+  ]),
   new LineShapeEdge(station.PAKENHAM, station.EAST_PAKENHAM, [
     routeGraph.pakenhamToEastPakenham,
-  ], []),
+  ], [
+    mapSegment.pakenhamToEastPakenham,
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/pakenham.ts
+++ b/server/entry-point/data/lines/pakenham.ts
@@ -49,73 +49,73 @@ const lineShapeEdges = [
     routeGraph.flagstaffToMelbourneCentral,
     routeGraph.melbourneCentralToParliament,
     routeGraph.parliamentToRichmond,
-  ]),
+  ], []),
   new LineShapeEdge(station.RICHMOND, station.SOUTH_YARRA, [
     routeGraph.richmondToSouthYarra,
-  ]),
+  ], []),
   new LineShapeEdge(station.SOUTH_YARRA, station.CAULFIELD, [
     routeGraph.southYarraToCaulfield,
-  ]),
+  ], []),
   new LineShapeEdge(station.CAULFIELD, station.CARNEGIE, [
     routeGraph.caulfieldToCarnegie,
-  ]),
+  ], []),
   new LineShapeEdge(station.CARNEGIE, station.MURRUMBEENA, [
     routeGraph.carnegieToMurrumbeena,
-  ]),
+  ], []),
   new LineShapeEdge(station.MURRUMBEENA, station.HUGHESDALE, [
     routeGraph.murrumbeenaToHughesdale,
-  ]),
+  ], []),
   new LineShapeEdge(station.HUGHESDALE, station.OAKLEIGH, [
     routeGraph.hughesdaleToOakleigh,
-  ]),
+  ], []),
   new LineShapeEdge(station.OAKLEIGH, station.HUNTINGDALE, [
     routeGraph.oakleighToHuntingdale,
-  ]),
+  ], []),
   new LineShapeEdge(station.HUNTINGDALE, station.CLAYTON, [
     routeGraph.huntingdaleToClayton,
-  ]),
+  ], []),
   new LineShapeEdge(station.CLAYTON, station.WESTALL, [
     routeGraph.claytonToWestall,
-  ]),
+  ], []),
   new LineShapeEdge(station.WESTALL, station.SPRINGVALE, [
     routeGraph.westallToSpringvale,
-  ]),
+  ], []),
   new LineShapeEdge(station.SPRINGVALE, station.SANDOWN_PARK, [
     routeGraph.springvaleToSandownPark,
-  ]),
+  ], []),
   new LineShapeEdge(station.SANDOWN_PARK, station.NOBLE_PARK, [
     routeGraph.sandownParkToNoblePark,
-  ]),
+  ], []),
   new LineShapeEdge(station.NOBLE_PARK, station.YARRAMAN, [
     routeGraph.nobleParkToYarraman,
-  ]),
+  ], []),
   new LineShapeEdge(station.YARRAMAN, station.DANDENONG, [
     routeGraph.yarramanToDandenong,
-  ]),
+  ], []),
   new LineShapeEdge(station.DANDENONG, station.HALLAM, [
     routeGraph.dandenongToHallam,
-  ]),
+  ], []),
   new LineShapeEdge(station.HALLAM, station.NARRE_WARREN, [
     routeGraph.hallamToNarreWarren,
-  ]),
+  ], []),
   new LineShapeEdge(station.NARRE_WARREN, station.BERWICK, [
     routeGraph.narreWarrenToBerwick,
-  ]),
+  ], []),
   new LineShapeEdge(station.BERWICK, station.BEACONSFIELD, [
     routeGraph.berwickToBeaconsfield,
-  ]),
+  ], []),
   new LineShapeEdge(station.BEACONSFIELD, station.OFFICER, [
     routeGraph.beaconsfieldToOfficer,
-  ]),
+  ], []),
   new LineShapeEdge(station.OFFICER, station.CARDINIA_ROAD, [
     routeGraph.officerToCardiniaRoad,
-  ]),
+  ], []),
   new LineShapeEdge(station.CARDINIA_ROAD, station.PAKENHAM, [
     routeGraph.cardiniaRoadToPakenham,
-  ]),
+  ], []),
   new LineShapeEdge(station.PAKENHAM, station.EAST_PAKENHAM, [
     routeGraph.pakenhamToEastPakenham,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/pakenham.ts
+++ b/server/entry-point/data/lines/pakenham.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -38,6 +40,22 @@ const routeGraph = {
   officerToCardiniaRoad: new StationPair(station.OFFICER, station.CARDINIA_ROAD),
   cardiniaRoadToPakenham: new StationPair(station.CARDINIA_ROAD, station.PAKENHAM),
   pakenhamToEastPakenham: new StationPair(station.PAKENHAM, station.EAST_PAKENHAM),
+};
+
+// prettier-ignore
+const mapSegment = {
+  flindersStreetToRichmond: MapSegment.full(map.DANDENONG.FLINDERS_STREET_DIRECT, map.DANDENONG.RICHMOND),
+  flindersStreetToSouthernCross: MapSegment.full(map.DANDENONG.FLINDERS_STREET_LOOP, map.DANDENONG.SOUTHERN_CROSS),
+  southernCrossToFlagstaff: MapSegment.full(map.DANDENONG.SOUTHERN_CROSS, map.DANDENONG.FLAGSTAFF),
+  flagstaffToMelbourneCentral: MapSegment.full(map.DANDENONG.FLAGSTAFF, map.DANDENONG.MELBOURNE_CENTRAL),
+  melbourneCentralToParliament: MapSegment.full(map.DANDENONG.MELBOURNE_CENTRAL, map.DANDENONG.PARLIAMENT),
+  parliamentToRichmond: MapSegment.full(map.DANDENONG.PARLIAMENT, map.DANDENONG.RICHMOND),
+  richmondToSouthYarra: MapSegment.full(map.DANDENONG.RICHMOND, map.DANDENONG.SOUTH_YARRA),
+  southYarraToCaulfield: MapSegment.full(map.DANDENONG.SOUTH_YARRA, map.DANDENONG.CAULFIELD),
+  caulfieldToClayton: MapSegment.full(map.DANDENONG.CAULFIELD, map.DANDENONG.CLAYTON),
+  claytonToDandenong: MapSegment.full(map.DANDENONG.CLAYTON, map.DANDENONG.DANDENONG),
+  dandenongToPakenham: MapSegment.full(map.DANDENONG.DANDENONG, map.DANDENONG.PAKENHAM),
+  pakenhamToEastPakenham: MapSegment.full(map.DANDENONG.PAKENHAM, map.DANDENONG.EAST_PAKENHAM),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/sandringham.ts
+++ b/server/entry-point/data/lines/sandringham.ts
@@ -29,43 +29,43 @@ const routeGraph = {
 const lineShapeEdges = [
   new LineShapeEdge(station.FLINDERS_STREET, station.RICHMOND, [
     routeGraph.flindersStreetToRichmond,
-  ]),
+  ], []),
   new LineShapeEdge(station.RICHMOND, station.SOUTH_YARRA, [
     routeGraph.richmondToSouthYarra,
-  ]),
+  ], []),
   new LineShapeEdge(station.SOUTH_YARRA, station.PRAHRAN, [
     routeGraph.southYarraToPrahran,
-  ]),
+  ], []),
   new LineShapeEdge(station.PRAHRAN, station.WINDSOR, [
     routeGraph.prahranToWindsor,
-  ]),
+  ], []),
   new LineShapeEdge(station.WINDSOR, station.BALACLAVA, [
     routeGraph.windsorToBalaclava,
-  ]),
+  ], []),
   new LineShapeEdge(station.BALACLAVA, station.RIPPONLEA, [
     routeGraph.balaclavaToRipponlea,
-  ]),
+  ], []),
   new LineShapeEdge(station.RIPPONLEA, station.ELSTERNWICK, [
     routeGraph.ripponleaToElsternwick,
-  ]),
+  ], []),
   new LineShapeEdge(station.ELSTERNWICK, station.GARDENVALE, [
     routeGraph.elsternwickToGardenvale,
-  ]),
+  ], []),
   new LineShapeEdge(station.GARDENVALE, station.NORTH_BRIGHTON, [
     routeGraph.gardenvaleToNorthBrighton,
-  ]),
+  ], []),
   new LineShapeEdge(station.NORTH_BRIGHTON, station.MIDDLE_BRIGHTON, [
     routeGraph.northBrightonToMiddleBrighton,
-  ]),
+  ], []),
   new LineShapeEdge(station.MIDDLE_BRIGHTON, station.BRIGHTON_BEACH, [
     routeGraph.middleBrightonToBrightonBeach,
-  ]),
+  ], []),
   new LineShapeEdge(station.BRIGHTON_BEACH, station.HAMPTON, [
     routeGraph.brightonBeachToHampton,
-  ]),
+  ], []),
   new LineShapeEdge(station.HAMPTON, station.SANDRINGHAM, [
     routeGraph.hamptonToSandringham,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/sandringham.ts
+++ b/server/entry-point/data/lines/sandringham.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -23,6 +25,13 @@ const routeGraph = {
   middleBrightonToBrightonBeach: new StationPair(station.MIDDLE_BRIGHTON, station.BRIGHTON_BEACH),
   brightonBeachToHampton: new StationPair(station.BRIGHTON_BEACH, station.HAMPTON),
   hamptonToSandringham: new StationPair(station.HAMPTON, station.SANDRINGHAM),
+};
+
+// prettier-ignore
+const mapSegment = {
+  flindersStreetToRichmond: MapSegment.full(map.SANDRINGHAM.FLINDERS_STREET, map.SANDRINGHAM.RICHMOND),
+  richmondToSouthYarra: MapSegment.full(map.SANDRINGHAM.RICHMOND, map.SANDRINGHAM.SOUTH_YARRA),
+  southYarraToSandringham: MapSegment.full(map.SANDRINGHAM.SOUTH_YARRA, map.SANDRINGHAM.SANDRINGHAM),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/sandringham.ts
+++ b/server/entry-point/data/lines/sandringham.ts
@@ -38,43 +38,69 @@ const mapSegment = {
 const lineShapeEdges = [
   new LineShapeEdge(station.FLINDERS_STREET, station.RICHMOND, [
     routeGraph.flindersStreetToRichmond,
-  ], []),
+  ], [
+    mapSegment.flindersStreetToRichmond,
+  ]),
   new LineShapeEdge(station.RICHMOND, station.SOUTH_YARRA, [
     routeGraph.richmondToSouthYarra,
-  ], []),
+  ], [
+    mapSegment.richmondToSouthYarra,
+  ]),
   new LineShapeEdge(station.SOUTH_YARRA, station.PRAHRAN, [
     routeGraph.southYarraToPrahran,
-  ], []),
+  ], [
+    mapSegment.southYarraToSandringham.part(1, 11),
+  ]),
   new LineShapeEdge(station.PRAHRAN, station.WINDSOR, [
     routeGraph.prahranToWindsor,
-  ], []),
+  ], [
+    mapSegment.southYarraToSandringham.part(2, 11),
+  ]),
   new LineShapeEdge(station.WINDSOR, station.BALACLAVA, [
     routeGraph.windsorToBalaclava,
-  ], []),
+  ], [
+    mapSegment.southYarraToSandringham.part(3, 11),
+  ]),
   new LineShapeEdge(station.BALACLAVA, station.RIPPONLEA, [
     routeGraph.balaclavaToRipponlea,
-  ], []),
+  ], [
+    mapSegment.southYarraToSandringham.part(4, 11),
+  ]),
   new LineShapeEdge(station.RIPPONLEA, station.ELSTERNWICK, [
     routeGraph.ripponleaToElsternwick,
-  ], []),
+  ], [
+    mapSegment.southYarraToSandringham.part(5, 11),
+  ]),
   new LineShapeEdge(station.ELSTERNWICK, station.GARDENVALE, [
     routeGraph.elsternwickToGardenvale,
-  ], []),
+  ], [
+    mapSegment.southYarraToSandringham.part(6, 11),
+  ]),
   new LineShapeEdge(station.GARDENVALE, station.NORTH_BRIGHTON, [
     routeGraph.gardenvaleToNorthBrighton,
-  ], []),
+  ], [
+    mapSegment.southYarraToSandringham.part(7, 11),
+  ]),
   new LineShapeEdge(station.NORTH_BRIGHTON, station.MIDDLE_BRIGHTON, [
     routeGraph.northBrightonToMiddleBrighton,
-  ], []),
+  ], [
+    mapSegment.southYarraToSandringham.part(8, 11),
+  ]),
   new LineShapeEdge(station.MIDDLE_BRIGHTON, station.BRIGHTON_BEACH, [
     routeGraph.middleBrightonToBrightonBeach,
-  ], []),
+  ], [
+    mapSegment.southYarraToSandringham.part(9, 11),
+  ]),
   new LineShapeEdge(station.BRIGHTON_BEACH, station.HAMPTON, [
     routeGraph.brightonBeachToHampton,
-  ], []),
+  ], [
+    mapSegment.southYarraToSandringham.part(10, 11),
+  ]),
   new LineShapeEdge(station.HAMPTON, station.SANDRINGHAM, [
     routeGraph.hamptonToSandringham,
-  ], []),
+  ], [
+    mapSegment.southYarraToSandringham.part(11, 11),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/seymour.ts
+++ b/server/entry-point/data/lines/seymour.ts
@@ -53,82 +53,131 @@ const mapSegment = {
 const lineShapeEdges = [
   new LineShapeEdge(station.SOUTHERN_CROSS, station.NORTH_MELBOURNE, [
     routeGraph.southernCrossToDonnybrook,
-  ], []),
+  ], [
+    mapSegment.southernCrossToNorthMelbourneJunction,
+    mapSegment.northMelbourneJunctionToNorthMelbourne,
+  ]),
   new LineShapeEdge(station.NORTH_MELBOURNE, station.BROADMEADOWS, [
     routeGraph.southernCrossToDonnybrook,
     routeGraph.northMelbourneToDonnybrook,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToBroadmeadows,
+  ]),
   new LineShapeEdge(station.BROADMEADOWS, station.CRAIGIEBURN, [
     routeGraph.southernCrossToDonnybrook,
     routeGraph.northMelbourneToDonnybrook,
     routeGraph.broadmeadowsToDonnybrook,
-  ], []),
+  ], [
+    mapSegment.broadmeadowsToCraigieburn,
+  ]),
   new LineShapeEdge(station.CRAIGIEBURN, station.DONNYBROOK, [
     routeGraph.southernCrossToDonnybrook,
     routeGraph.northMelbourneToDonnybrook,
     routeGraph.broadmeadowsToDonnybrook,
     routeGraph.craigieburnToDonnybrook,
-  ], []),
+  ], [
+    mapSegment.craigieburnToSeymour.part(1, 8),
+  ]),
   new LineShapeEdge(station.DONNYBROOK, station.WALLAN, [
     routeGraph.donnybrookToWallan,
-  ], []),
+  ], [
+    mapSegment.craigieburnToSeymour.part(2, 8),
+  ]),
   new LineShapeEdge(station.WALLAN, station.HEATHCOTE_JUNCTION, [
     routeGraph.wallanToHeathcoteJunction,
-  ], []),
+  ], [
+    mapSegment.craigieburnToSeymour.part(3, 8),
+  ]),
   new LineShapeEdge(station.HEATHCOTE_JUNCTION, station.WANDONG, [
     routeGraph.heathcoteJunctionToWandong,
-  ], []),
+  ], [
+    mapSegment.craigieburnToSeymour.part(4, 8),
+  ]),
   new LineShapeEdge(station.WANDONG, station.KILMORE_EAST, [
     routeGraph.wandongToKilmoreEast,
-  ], []),
+  ], [
+    mapSegment.craigieburnToSeymour.part(5, 8),
+  ]),
   new LineShapeEdge(station.KILMORE_EAST, station.BROADFORD, [
     routeGraph.kilmoreEastToBroadford,
-  ], []),
+  ], [
+    mapSegment.craigieburnToSeymour.part(6, 8),
+  ]),
   new LineShapeEdge(station.BROADFORD, station.TALLAROOK, [
     routeGraph.broadfordToTallarook,
-  ], []),
+  ], [
+    mapSegment.craigieburnToSeymour.part(7, 8),
+  ]),
   new LineShapeEdge(station.TALLAROOK, station.SEYMOUR, [
     routeGraph.tallarookToSeymour,
-  ], []),
+  ], [
+    mapSegment.craigieburnToSeymour.part(8, 8),
+  ]),
   new LineShapeEdge(station.SEYMOUR, station.AVENEL, [
     routeGraph.seymourToAvenel,
-  ], []),
+  ], [
+    mapSegment.seymourToAlbury.part(1, 9),
+  ]),
   new LineShapeEdge(station.AVENEL, station.EUROA, [
     routeGraph.avenelToEuroa,
-  ], []),
+  ], [
+    mapSegment.seymourToAlbury.part(2, 9),
+  ]),
   new LineShapeEdge(station.EUROA, station.VIOLET_TOWN, [
     routeGraph.euroaToVioletTown,
-  ], []),
+  ], [
+    mapSegment.seymourToAlbury.part(3, 9),
+  ]),
   new LineShapeEdge(station.VIOLET_TOWN, station.BENALLA, [
     routeGraph.violetTownToBenalla,
-  ], []),
+  ], [
+    mapSegment.seymourToAlbury.part(4, 9),
+  ]),
   new LineShapeEdge(station.BENALLA, station.WANGARATTA, [
     routeGraph.benallaToWangaratta,
-  ], []),
+  ], [
+    mapSegment.seymourToAlbury.part(5, 9),
+  ]),
   new LineShapeEdge(station.WANGARATTA, station.SPRINGHURST, [
     routeGraph.wangarattaToSpringhurst,
-  ], []),
+  ], [
+    mapSegment.seymourToAlbury.part(6, 9),
+  ]),
   new LineShapeEdge(station.SPRINGHURST, station.CHILTERN, [
     routeGraph.springhurstToChiltern,
-  ], []),
+  ], [
+    mapSegment.seymourToAlbury.part(7, 9),
+  ]),
   new LineShapeEdge(station.CHILTERN, station.WODONGA, [
     routeGraph.chilternToWodonga,
-  ], []),
+  ], [
+    mapSegment.seymourToAlbury.part(8, 9),
+  ]),
   new LineShapeEdge(station.WODONGA, station.ALBURY, [
     routeGraph.wodongaToAlbury,
-  ], []),
+  ], [
+    mapSegment.seymourToAlbury.part(9, 9),
+  ]),
   new LineShapeEdge(station.SEYMOUR, station.NAGAMBIE, [
     routeGraph.seymourToNagambie,
-  ], []),
+  ], [
+    mapSegment.seymourToShepparton.part(1, 4),
+  ]),
   new LineShapeEdge(station.NAGAMBIE, station.MURCHISON_EAST, [
     routeGraph.nagambieToMurchisonEast,
-  ], []),
+  ], [
+    mapSegment.seymourToShepparton.part(2, 4),
+  ]),
   new LineShapeEdge(station.MURCHISON_EAST, station.MOOROOPNA, [
     routeGraph.murchisonEastToMooroopna,
-  ], []),
+  ], [
+    mapSegment.seymourToShepparton.part(3, 4),
+  ]),
   new LineShapeEdge(station.MOOROOPNA, station.SHEPPARTON, [
     routeGraph.mooroopnaToShepparton,
-  ], []),
+  ], [
+    mapSegment.seymourToShepparton.part(4, 4),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/seymour.ts
+++ b/server/entry-point/data/lines/seymour.ts
@@ -40,82 +40,82 @@ const routeGraph = {
 const lineShapeEdges = [
   new LineShapeEdge(station.SOUTHERN_CROSS, station.NORTH_MELBOURNE, [
     routeGraph.southernCrossToDonnybrook,
-  ]),
+  ], []),
   new LineShapeEdge(station.NORTH_MELBOURNE, station.BROADMEADOWS, [
     routeGraph.southernCrossToDonnybrook,
     routeGraph.northMelbourneToDonnybrook,
-  ]),
+  ], []),
   new LineShapeEdge(station.BROADMEADOWS, station.CRAIGIEBURN, [
     routeGraph.southernCrossToDonnybrook,
     routeGraph.northMelbourneToDonnybrook,
     routeGraph.broadmeadowsToDonnybrook,
-  ]),
+  ], []),
   new LineShapeEdge(station.CRAIGIEBURN, station.DONNYBROOK, [
     routeGraph.southernCrossToDonnybrook,
     routeGraph.northMelbourneToDonnybrook,
     routeGraph.broadmeadowsToDonnybrook,
     routeGraph.craigieburnToDonnybrook,
-  ]),
+  ], []),
   new LineShapeEdge(station.DONNYBROOK, station.WALLAN, [
     routeGraph.donnybrookToWallan,
-  ]),
+  ], []),
   new LineShapeEdge(station.WALLAN, station.HEATHCOTE_JUNCTION, [
     routeGraph.wallanToHeathcoteJunction,
-  ]),
+  ], []),
   new LineShapeEdge(station.HEATHCOTE_JUNCTION, station.WANDONG, [
     routeGraph.heathcoteJunctionToWandong,
-  ]),
+  ], []),
   new LineShapeEdge(station.WANDONG, station.KILMORE_EAST, [
     routeGraph.wandongToKilmoreEast,
-  ]),
+  ], []),
   new LineShapeEdge(station.KILMORE_EAST, station.BROADFORD, [
     routeGraph.kilmoreEastToBroadford,
-  ]),
+  ], []),
   new LineShapeEdge(station.BROADFORD, station.TALLAROOK, [
     routeGraph.broadfordToTallarook,
-  ]),
+  ], []),
   new LineShapeEdge(station.TALLAROOK, station.SEYMOUR, [
     routeGraph.tallarookToSeymour,
-  ]),
+  ], []),
   new LineShapeEdge(station.SEYMOUR, station.AVENEL, [
     routeGraph.seymourToAvenel,
-  ]),
+  ], []),
   new LineShapeEdge(station.AVENEL, station.EUROA, [
     routeGraph.avenelToEuroa,
-  ]),
+  ], []),
   new LineShapeEdge(station.EUROA, station.VIOLET_TOWN, [
     routeGraph.euroaToVioletTown,
-  ]),
+  ], []),
   new LineShapeEdge(station.VIOLET_TOWN, station.BENALLA, [
     routeGraph.violetTownToBenalla,
-  ]),
+  ], []),
   new LineShapeEdge(station.BENALLA, station.WANGARATTA, [
     routeGraph.benallaToWangaratta,
-  ]),
+  ], []),
   new LineShapeEdge(station.WANGARATTA, station.SPRINGHURST, [
     routeGraph.wangarattaToSpringhurst,
-  ]),
+  ], []),
   new LineShapeEdge(station.SPRINGHURST, station.CHILTERN, [
     routeGraph.springhurstToChiltern,
-  ]),
+  ], []),
   new LineShapeEdge(station.CHILTERN, station.WODONGA, [
     routeGraph.chilternToWodonga,
-  ]),
+  ], []),
   new LineShapeEdge(station.WODONGA, station.ALBURY, [
     routeGraph.wodongaToAlbury,
-  ]),
+  ], []),
   new LineShapeEdge(station.SEYMOUR, station.NAGAMBIE, [
     routeGraph.seymourToNagambie,
-  ]),
+  ], []),
   new LineShapeEdge(station.NAGAMBIE, station.MURCHISON_EAST, [
     routeGraph.nagambieToMurchisonEast,
-  ]),
+  ], []),
   new LineShapeEdge(station.MURCHISON_EAST, station.MOOROOPNA, [
     routeGraph.murchisonEastToMooroopna,
-  ]),
+  ], []),
   new LineShapeEdge(station.MOOROOPNA, station.SHEPPARTON, [
     routeGraph.mooroopnaToShepparton,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/seymour.ts
+++ b/server/entry-point/data/lines/seymour.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -34,6 +36,17 @@ const routeGraph = {
   nagambieToMurchisonEast: new StationPair(station.NAGAMBIE, station.MURCHISON_EAST),
   murchisonEastToMooroopna: new StationPair(station.MURCHISON_EAST, station.MOOROOPNA),
   mooroopnaToShepparton: new StationPair(station.MOOROOPNA, station.SHEPPARTON),
+};
+
+// prettier-ignore
+const mapSegment = {
+  southernCrossToNorthMelbourneJunction: MapSegment.full(map.REGIONAL_WESTERN.SOUTHERN_CROSS, map.REGIONAL_WESTERN.NORTH_MELBOURNE_JUNCTION),
+  northMelbourneJunctionToNorthMelbourne: MapSegment.full(map.REGIONAL_WESTERN.NORTH_MELBOURNE_JUNCTION, map.REGIONAL_WESTERN.NORTH_MELBOURNE_SEYMOUR),
+  northMelbourneToBroadmeadows: MapSegment.full(map.REGIONAL_WESTERN.NORTH_MELBOURNE_SEYMOUR, map.REGIONAL_WESTERN.BROADMEADOWS),
+  broadmeadowsToCraigieburn: MapSegment.full(map.REGIONAL_WESTERN.BROADMEADOWS, map.REGIONAL_WESTERN.CRAIGIEBURN),
+  craigieburnToSeymour: MapSegment.full(map.REGIONAL_WESTERN.CRAIGIEBURN, map.REGIONAL_WESTERN.SEYMOUR),
+  seymourToAlbury: MapSegment.full(map.REGIONAL_WESTERN.SEYMOUR, map.REGIONAL_WESTERN.ALBURY),
+  seymourToShepparton: MapSegment.full(map.REGIONAL_WESTERN.SEYMOUR, map.REGIONAL_WESTERN.SHEPPARTON),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/stony-point.ts
+++ b/server/entry-point/data/lines/stony-point.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -19,6 +21,11 @@ const routeGraph = {
   bitternToMorradoo: new StationPair(station.BITTERN, station.MORRADOO),
   morradooToCribPoint: new StationPair(station.MORRADOO, station.CRIB_POINT),
   cribPointToStonyPoint: new StationPair(station.CRIB_POINT, station.STONY_POINT),
+};
+
+// prettier-ignore
+const mapSegment = {
+  frankstonToStonyPoint: MapSegment.full(map.STONY_POINT.FRANKSTON, map.STONY_POINT.STONY_POINT),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/stony-point.ts
+++ b/server/entry-point/data/lines/stony-point.ts
@@ -25,31 +25,31 @@ const routeGraph = {
 const lineShapeEdges = [
   new LineShapeEdge(station.FRANKSTON, station.LEAWARRA, [
     routeGraph.frankstonToLeawarra,
-  ]),
+  ], []),
   new LineShapeEdge(station.LEAWARRA, station.BAXTER, [
     routeGraph.leawarraToBaxter,
-  ]),
+  ], []),
   new LineShapeEdge(station.BAXTER, station.SOMERVILLE, [
     routeGraph.baxterToSomerville,
-  ]),
+  ], []),
   new LineShapeEdge(station.SOMERVILLE, station.TYABB, [
     routeGraph.somervilleToTyabb,
-  ]),
+  ], []),
   new LineShapeEdge(station.TYABB, station.HASTINGS, [
     routeGraph.tyabbToHastings,
-  ]),
+  ], []),
   new LineShapeEdge(station.HASTINGS, station.BITTERN, [
     routeGraph.hastingsToBittern,
-  ]),
+  ], []),
   new LineShapeEdge(station.BITTERN, station.MORRADOO, [
     routeGraph.bitternToMorradoo,
-  ]),
+  ], []),
   new LineShapeEdge(station.MORRADOO, station.CRIB_POINT, [
     routeGraph.morradooToCribPoint,
-  ]),
+  ], []),
   new LineShapeEdge(station.CRIB_POINT, station.STONY_POINT, [
     routeGraph.cribPointToStonyPoint,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/stony-point.ts
+++ b/server/entry-point/data/lines/stony-point.ts
@@ -32,31 +32,49 @@ const mapSegment = {
 const lineShapeEdges = [
   new LineShapeEdge(station.FRANKSTON, station.LEAWARRA, [
     routeGraph.frankstonToLeawarra,
-  ], []),
+  ], [
+    mapSegment.frankstonToStonyPoint.part(1, 9),
+  ]),
   new LineShapeEdge(station.LEAWARRA, station.BAXTER, [
     routeGraph.leawarraToBaxter,
-  ], []),
+  ], [
+    mapSegment.frankstonToStonyPoint.part(2, 9),
+  ]),
   new LineShapeEdge(station.BAXTER, station.SOMERVILLE, [
     routeGraph.baxterToSomerville,
-  ], []),
+  ], [
+    mapSegment.frankstonToStonyPoint.part(3, 9),
+  ]),
   new LineShapeEdge(station.SOMERVILLE, station.TYABB, [
     routeGraph.somervilleToTyabb,
-  ], []),
+  ], [
+    mapSegment.frankstonToStonyPoint.part(4, 9),
+  ]),
   new LineShapeEdge(station.TYABB, station.HASTINGS, [
     routeGraph.tyabbToHastings,
-  ], []),
+  ], [
+    mapSegment.frankstonToStonyPoint.part(5, 9),
+  ]),
   new LineShapeEdge(station.HASTINGS, station.BITTERN, [
     routeGraph.hastingsToBittern,
-  ], []),
+  ], [
+    mapSegment.frankstonToStonyPoint.part(6, 9),
+  ]),
   new LineShapeEdge(station.BITTERN, station.MORRADOO, [
     routeGraph.bitternToMorradoo,
-  ], []),
+  ], [
+    mapSegment.frankstonToStonyPoint.part(7, 9),
+  ]),
   new LineShapeEdge(station.MORRADOO, station.CRIB_POINT, [
     routeGraph.morradooToCribPoint,
-  ], []),
+  ], [
+    mapSegment.frankstonToStonyPoint.part(8, 9),
+  ]),
   new LineShapeEdge(station.CRIB_POINT, station.STONY_POINT, [
     routeGraph.cribPointToStonyPoint,
-  ], []),
+  ], [
+    mapSegment.frankstonToStonyPoint.part(9, 9),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/sunbury.ts
+++ b/server/entry-point/data/lines/sunbury.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -28,6 +30,21 @@ const routeGraph = {
   keilorPlainsToWatergardens: new StationPair(station.KEILOR_PLAINS, station.WATERGARDENS),
   watergardensToDiggersRest: new StationPair(station.WATERGARDENS, station.DIGGERS_REST),
   diggersRestToSunbury: new StationPair(station.DIGGERS_REST, station.SUNBURY),
+};
+
+// prettier-ignore
+const mapSegment = {
+  flindersStreetToSouthernCross: MapSegment.full(map.NORTHERN.FLINDERS_STREET_DIRECT, map.NORTHERN.SOUTHERN_CROSS),
+  southernCrossToNorthMelbourne: MapSegment.full(map.NORTHERN.SOUTHERN_CROSS, map.NORTHERN.NORTH_MELBOURNE),
+  northMelbourneToFlagstaff: MapSegment.full(map.NORTHERN.NORTH_MELBOURNE, map.NORTHERN.FLAGSTAFF),
+  flagstaffToMelbourneCentral: MapSegment.full(map.NORTHERN.FLAGSTAFF, map.NORTHERN.MELBOURNE_CENTRAL),
+  melbourneCentralToParliament: MapSegment.full(map.NORTHERN.MELBOURNE_CENTRAL, map.NORTHERN.PARLIAMENT),
+  parliamentToFlindersStreet: MapSegment.full(map.NORTHERN.PARLIAMENT, map.NORTHERN.FLINDERS_STREET_LOOP),
+  northMelbourneToFootscray: MapSegment.full(map.NORTHERN.NORTH_MELBOURNE, map.NORTHERN.FOOTSCRAY),
+  footscrayToSunshineJunction: MapSegment.full(map.NORTHERN.FOOTSCRAY, map.NORTHERN.SUNSHINE_JUNCTION),
+  sunshineJunctionToSunshine: MapSegment.full(map.NORTHERN.SUNSHINE_JUNCTION, map.NORTHERN.SUNSHINE),
+  sunshineToWatergardens: MapSegment.full(map.NORTHERN.SUNSHINE, map.NORTHERN.WATERGARDENS),
+  watergardensToSunbury: MapSegment.full(map.NORTHERN.WATERGARDENS, map.NORTHERN.SUNBURY),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/sunbury.ts
+++ b/server/entry-point/data/lines/sunbury.ts
@@ -56,43 +56,75 @@ const lineShapeEdges = [
     routeGraph.parliamentToMelbourneCentral,
     routeGraph.melbourneCentralToFlagstaff,
     routeGraph.flagstaffToNorthMelbourne,
-  ], []),
+  ], [
+    mapSegment.flindersStreetToSouthernCross,
+    mapSegment.southernCrossToNorthMelbourne,
+    mapSegment.northMelbourneToFlagstaff,
+    mapSegment.flagstaffToMelbourneCentral,
+    mapSegment.melbourneCentralToParliament,
+    mapSegment.parliamentToFlindersStreet,
+  ]),
   new LineShapeEdge(station.NORTH_MELBOURNE, station.FOOTSCRAY, [
     routeGraph.northMelbourneToFootscray,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToFootscray,
+  ]),
   new LineShapeEdge(station.FOOTSCRAY, station.MIDDLE_FOOTSCRAY, [
     routeGraph.footscrayToMiddleFootscray,
-  ], []),
+  ], [
+    mapSegment.footscrayToSunshineJunction.part(1, 4),
+  ]),
   new LineShapeEdge(station.MIDDLE_FOOTSCRAY, station.WEST_FOOTSCRAY, [
     routeGraph.middleFootscrayToWestFootscray,
-  ], []),
+  ], [
+    mapSegment.footscrayToSunshineJunction.part(2, 4),
+  ]),
   new LineShapeEdge(station.WEST_FOOTSCRAY, station.TOTTENHAM, [
     routeGraph.westFootscrayToTottenham,
-  ], []),
+  ], [
+    mapSegment.footscrayToSunshineJunction.part(3, 4),
+  ]),
   new LineShapeEdge(station.TOTTENHAM, station.SUNSHINE, [
     routeGraph.tottenhamToSunshine,
-  ], []),
+  ], [
+    mapSegment.footscrayToSunshineJunction.part(4, 4),
+    mapSegment.sunshineJunctionToSunshine,
+  ]),
   new LineShapeEdge(station.SUNSHINE, station.ALBION, [
     routeGraph.sunshineToAlbion,
-  ], []),
+  ], [
+    mapSegment.sunshineToWatergardens.part(1, 5),
+  ]),
   new LineShapeEdge(station.ALBION, station.GINIFER, [
     routeGraph.albionToGinifer,
-  ], []),
+  ], [
+    mapSegment.sunshineToWatergardens.part(2, 5),
+  ]),
   new LineShapeEdge(station.GINIFER, station.ST_ALBANS, [
     routeGraph.giniferToStAlbans,
-  ], []),
+  ], [
+    mapSegment.sunshineToWatergardens.part(3, 5),
+  ]),
   new LineShapeEdge(station.ST_ALBANS, station.KEILOR_PLAINS, [
     routeGraph.stAlbansToKeilorPlains,
-  ], []),
+  ], [
+    mapSegment.sunshineToWatergardens.part(4, 5),
+  ]),
   new LineShapeEdge(station.KEILOR_PLAINS, station.WATERGARDENS, [
     routeGraph.keilorPlainsToWatergardens,
-  ], []),
+  ], [
+    mapSegment.sunshineToWatergardens.part(5, 5),
+  ]),
   new LineShapeEdge(station.WATERGARDENS, station.DIGGERS_REST, [
     routeGraph.watergardensToDiggersRest,
-  ], []),
+  ], [
+    mapSegment.watergardensToSunbury.part(1, 2),
+  ]),
   new LineShapeEdge(station.DIGGERS_REST, station.SUNBURY, [
     routeGraph.diggersRestToSunbury,
-  ], []),
+  ], [
+    mapSegment.watergardensToSunbury.part(2, 2),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/sunbury.ts
+++ b/server/entry-point/data/lines/sunbury.ts
@@ -39,43 +39,43 @@ const lineShapeEdges = [
     routeGraph.parliamentToMelbourneCentral,
     routeGraph.melbourneCentralToFlagstaff,
     routeGraph.flagstaffToNorthMelbourne,
-  ]),
+  ], []),
   new LineShapeEdge(station.NORTH_MELBOURNE, station.FOOTSCRAY, [
     routeGraph.northMelbourneToFootscray,
-  ]),
+  ], []),
   new LineShapeEdge(station.FOOTSCRAY, station.MIDDLE_FOOTSCRAY, [
     routeGraph.footscrayToMiddleFootscray,
-  ]),
+  ], []),
   new LineShapeEdge(station.MIDDLE_FOOTSCRAY, station.WEST_FOOTSCRAY, [
     routeGraph.middleFootscrayToWestFootscray,
-  ]),
+  ], []),
   new LineShapeEdge(station.WEST_FOOTSCRAY, station.TOTTENHAM, [
     routeGraph.westFootscrayToTottenham,
-  ]),
+  ], []),
   new LineShapeEdge(station.TOTTENHAM, station.SUNSHINE, [
     routeGraph.tottenhamToSunshine,
-  ]),
+  ], []),
   new LineShapeEdge(station.SUNSHINE, station.ALBION, [
     routeGraph.sunshineToAlbion,
-  ]),
+  ], []),
   new LineShapeEdge(station.ALBION, station.GINIFER, [
     routeGraph.albionToGinifer,
-  ]),
+  ], []),
   new LineShapeEdge(station.GINIFER, station.ST_ALBANS, [
     routeGraph.giniferToStAlbans,
-  ]),
+  ], []),
   new LineShapeEdge(station.ST_ALBANS, station.KEILOR_PLAINS, [
     routeGraph.stAlbansToKeilorPlains,
-  ]),
+  ], []),
   new LineShapeEdge(station.KEILOR_PLAINS, station.WATERGARDENS, [
     routeGraph.keilorPlainsToWatergardens,
-  ]),
+  ], []),
   new LineShapeEdge(station.WATERGARDENS, station.DIGGERS_REST, [
     routeGraph.watergardensToDiggersRest,
-  ]),
+  ], []),
   new LineShapeEdge(station.DIGGERS_REST, station.SUNBURY, [
     routeGraph.diggersRestToSunbury,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/upfield.ts
+++ b/server/entry-point/data/lines/upfield.ts
@@ -40,46 +40,46 @@ const lineShapeEdges = [
     routeGraph.parliamentToMelbourneCentral,
     routeGraph.melbourneCentralToFlagstaff,
     routeGraph.flagstaffToNorthMelbourne,
-  ]),
+  ], []),
   new LineShapeEdge(station.NORTH_MELBOURNE, station.MACAULAY, [
     routeGraph.northMelbourneToMacaulay,
-  ]),
+  ], []),
   new LineShapeEdge(station.MACAULAY, station.FLEMINGTON_BRIDGE, [
     routeGraph.macaulayToFlemingtonBridge,
-  ]),
+  ], []),
   new LineShapeEdge(station.FLEMINGTON_BRIDGE, station.ROYAL_PARK, [
     routeGraph.flemingtonBridgeToRoyalPark,
-  ]),
+  ], []),
   new LineShapeEdge(station.ROYAL_PARK, station.JEWELL, [
     routeGraph.royalParkToJewell,
-  ]),
+  ], []),
   new LineShapeEdge(station.JEWELL, station.BRUNSWICK, [
     routeGraph.jewellToBrunswick,
-  ]),
+  ], []),
   new LineShapeEdge(station.BRUNSWICK, station.ANSTEY, [
     routeGraph.brunswickToAnstey,
-  ]),
+  ], []),
   new LineShapeEdge(station.ANSTEY, station.MORELAND, [
     routeGraph.ansteyToMoreland,
-  ]),
+  ], []),
   new LineShapeEdge(station.MORELAND, station.COBURG, [
     routeGraph.morelandToCoburg,
-  ]),
+  ], []),
   new LineShapeEdge(station.COBURG, station.BATMAN, [
     routeGraph.coburgToBatman,
-  ]),
+  ], []),
   new LineShapeEdge(station.BATMAN, station.MERLYNSTON, [
     routeGraph.batmanToMerlynston,
-  ]),
+  ], []),
   new LineShapeEdge(station.MERLYNSTON, station.FAWKNER, [
     routeGraph.merlynstonToFawkner,
-  ]),
+  ], []),
   new LineShapeEdge(station.FAWKNER, station.GOWRIE, [
     routeGraph.fawknerToGowrie,
-  ]),
+  ], []),
   new LineShapeEdge(station.GOWRIE, station.UPFIELD, [
     routeGraph.gowrieToUpfield,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/upfield.ts
+++ b/server/entry-point/data/lines/upfield.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -29,6 +31,17 @@ const routeGraph = {
   merlynstonToFawkner: new StationPair(station.MERLYNSTON, station.FAWKNER),
   fawknerToGowrie: new StationPair(station.FAWKNER, station.GOWRIE),
   gowrieToUpfield: new StationPair(station.GOWRIE, station.UPFIELD),
+};
+
+// prettier-ignore
+const mapSegment = {
+  flindersStreetToSouthernCross: MapSegment.full(map.NORTHERN.FLINDERS_STREET_DIRECT, map.NORTHERN.SOUTHERN_CROSS),
+  southernCrossToNorthMelbourne: MapSegment.full(map.NORTHERN.SOUTHERN_CROSS, map.NORTHERN.NORTH_MELBOURNE),
+  northMelbourneToFlagstaff: MapSegment.full(map.NORTHERN.NORTH_MELBOURNE, map.NORTHERN.FLAGSTAFF),
+  flagstaffToMelbourneCentral: MapSegment.full(map.NORTHERN.FLAGSTAFF, map.NORTHERN.MELBOURNE_CENTRAL),
+  melbourneCentralToParliament: MapSegment.full(map.NORTHERN.MELBOURNE_CENTRAL, map.NORTHERN.PARLIAMENT),
+  parliamentToFlindersStreet: MapSegment.full(map.NORTHERN.PARLIAMENT, map.NORTHERN.FLINDERS_STREET_LOOP),
+  northMelbourneToUpfield: MapSegment.full(map.NORTHERN.NORTH_MELBOURNE, map.NORTHERN.UPFIELD),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/upfield.ts
+++ b/server/entry-point/data/lines/upfield.ts
@@ -53,46 +53,79 @@ const lineShapeEdges = [
     routeGraph.parliamentToMelbourneCentral,
     routeGraph.melbourneCentralToFlagstaff,
     routeGraph.flagstaffToNorthMelbourne,
-  ], []),
+  ], [
+    mapSegment.flindersStreetToSouthernCross,
+    mapSegment.southernCrossToNorthMelbourne,
+    mapSegment.northMelbourneToFlagstaff,
+    mapSegment.flagstaffToMelbourneCentral,
+    mapSegment.melbourneCentralToParliament,
+    mapSegment.parliamentToFlindersStreet,
+  ]),
   new LineShapeEdge(station.NORTH_MELBOURNE, station.MACAULAY, [
     routeGraph.northMelbourneToMacaulay,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToUpfield.part(1, 13),
+  ]),
   new LineShapeEdge(station.MACAULAY, station.FLEMINGTON_BRIDGE, [
     routeGraph.macaulayToFlemingtonBridge,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToUpfield.part(2, 13),
+  ]),
   new LineShapeEdge(station.FLEMINGTON_BRIDGE, station.ROYAL_PARK, [
     routeGraph.flemingtonBridgeToRoyalPark,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToUpfield.part(3, 13),
+  ]),
   new LineShapeEdge(station.ROYAL_PARK, station.JEWELL, [
     routeGraph.royalParkToJewell,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToUpfield.part(4, 13),
+  ]),
   new LineShapeEdge(station.JEWELL, station.BRUNSWICK, [
     routeGraph.jewellToBrunswick,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToUpfield.part(5, 13),
+  ]),
   new LineShapeEdge(station.BRUNSWICK, station.ANSTEY, [
     routeGraph.brunswickToAnstey,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToUpfield.part(6, 13),
+  ]),
   new LineShapeEdge(station.ANSTEY, station.MORELAND, [
     routeGraph.ansteyToMoreland,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToUpfield.part(7, 13),
+  ]),
   new LineShapeEdge(station.MORELAND, station.COBURG, [
     routeGraph.morelandToCoburg,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToUpfield.part(8, 13),
+  ]),
   new LineShapeEdge(station.COBURG, station.BATMAN, [
     routeGraph.coburgToBatman,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToUpfield.part(9, 13),
+  ]),
   new LineShapeEdge(station.BATMAN, station.MERLYNSTON, [
     routeGraph.batmanToMerlynston,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToUpfield.part(10, 13),
+  ]),
   new LineShapeEdge(station.MERLYNSTON, station.FAWKNER, [
     routeGraph.merlynstonToFawkner,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToUpfield.part(11, 13),
+  ]),
   new LineShapeEdge(station.FAWKNER, station.GOWRIE, [
     routeGraph.fawknerToGowrie,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToUpfield.part(12, 13),
+  ]),
   new LineShapeEdge(station.GOWRIE, station.UPFIELD, [
     routeGraph.gowrieToUpfield,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToUpfield.part(13, 13),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/werribee.ts
+++ b/server/entry-point/data/lines/werribee.ts
@@ -33,47 +33,47 @@ const routeGraph = {
 const lineShapeEdges = [
   new LineShapeEdge(station.FLINDERS_STREET, station.SOUTHERN_CROSS, [
     routeGraph.flindersStreetToSouthernCross,
-  ]),
+  ], []),
   new LineShapeEdge(station.SOUTHERN_CROSS, station.NORTH_MELBOURNE, [
     routeGraph.southernCrossToNorthMelbourne,
-  ]),
+  ], []),
   new LineShapeEdge(station.NORTH_MELBOURNE, station.SOUTH_KENSINGTON, [
     routeGraph.northMelbourneToSouthKensington,
-  ]),
+  ], []),
   new LineShapeEdge(station.SOUTH_KENSINGTON, station.FOOTSCRAY, [
     routeGraph.southKensingtonToFootscray,
-  ]),
+  ], []),
   new LineShapeEdge(station.FOOTSCRAY, station.SEDDON, [
     routeGraph.footscrayToSeddon,
-  ]),
+  ], []),
   new LineShapeEdge(station.SEDDON, station.YARRAVILLE, [
     routeGraph.seddonToYarraville,
-  ]),
+  ], []),
   new LineShapeEdge(station.YARRAVILLE, station.SPOTSWOOD, [
     routeGraph.yarravilleToSpotswood,
-  ]),
+  ], []),
   new LineShapeEdge(station.SPOTSWOOD, station.NEWPORT, [
     routeGraph.spotswoodToNewport,
-  ]),
+  ], []),
   new LineShapeEdge(station.NEWPORT, station.LAVERTON, [
     routeGraph.newportToSeaholme,
     routeGraph.seaholmeToAltona,
     routeGraph.altonaToWestona,
     routeGraph.westonaToLaverton,
     routeGraph.newportToLaverton,
-  ]),
+  ], []),
   new LineShapeEdge(station.LAVERTON, station.AIRCRAFT, [
     routeGraph.lavertonToAircraft,
-  ]),
+  ], []),
   new LineShapeEdge(station.AIRCRAFT, station.WILLIAMS_LANDING, [
     routeGraph.aircraftToWilliamsLanding,
-  ]),
+  ], []),
   new LineShapeEdge(station.WILLIAMS_LANDING, station.HOPPERS_CROSSING, [
     routeGraph.williamsLandingToHoppersCrossing,
-  ]),
+  ], []),
   new LineShapeEdge(station.HOPPERS_CROSSING, station.WERRIBEE, [
     routeGraph.hoppersCrossingToWerribee,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/werribee.ts
+++ b/server/entry-point/data/lines/werribee.ts
@@ -46,47 +46,74 @@ const mapSegment = {
 const lineShapeEdges = [
   new LineShapeEdge(station.FLINDERS_STREET, station.SOUTHERN_CROSS, [
     routeGraph.flindersStreetToSouthernCross,
-  ], []),
+  ], [
+    mapSegment.flindersStreetToSouthernCross,
+  ]),
   new LineShapeEdge(station.SOUTHERN_CROSS, station.NORTH_MELBOURNE, [
     routeGraph.southernCrossToNorthMelbourne,
-  ], []),
+  ], [
+    mapSegment.southernCrossToNorthMelbourne,
+  ]),
   new LineShapeEdge(station.NORTH_MELBOURNE, station.SOUTH_KENSINGTON, [
     routeGraph.northMelbourneToSouthKensington,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToFootscray.part(1, 2),
+  ]),
   new LineShapeEdge(station.SOUTH_KENSINGTON, station.FOOTSCRAY, [
     routeGraph.southKensingtonToFootscray,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToFootscray.part(2, 2),
+  ]),
   new LineShapeEdge(station.FOOTSCRAY, station.SEDDON, [
     routeGraph.footscrayToSeddon,
-  ], []),
+  ], [
+    mapSegment.footscrayToNewport.part(1, 4),
+  ]),
   new LineShapeEdge(station.SEDDON, station.YARRAVILLE, [
     routeGraph.seddonToYarraville,
-  ], []),
+  ], [
+    mapSegment.footscrayToNewport.part(2, 4),
+  ]),
   new LineShapeEdge(station.YARRAVILLE, station.SPOTSWOOD, [
     routeGraph.yarravilleToSpotswood,
-  ], []),
+  ], [
+    mapSegment.footscrayToNewport.part(3, 4),
+  ]),
   new LineShapeEdge(station.SPOTSWOOD, station.NEWPORT, [
     routeGraph.spotswoodToNewport,
-  ], []),
+  ], [
+    mapSegment.footscrayToNewport.part(4, 4),
+  ]),
   new LineShapeEdge(station.NEWPORT, station.LAVERTON, [
     routeGraph.newportToSeaholme,
     routeGraph.seaholmeToAltona,
     routeGraph.altonaToWestona,
     routeGraph.westonaToLaverton,
     routeGraph.newportToLaverton,
-  ], []),
+  ], [
+    mapSegment.newportToLavertonLoop,
+    mapSegment.newportToLavertonExpress,
+  ]),
   new LineShapeEdge(station.LAVERTON, station.AIRCRAFT, [
     routeGraph.lavertonToAircraft,
-  ], []),
+  ], [
+    mapSegment.lavertonToWerribee.part(1, 4),
+  ]),
   new LineShapeEdge(station.AIRCRAFT, station.WILLIAMS_LANDING, [
     routeGraph.aircraftToWilliamsLanding,
-  ], []),
+  ], [
+    mapSegment.lavertonToWerribee.part(2, 4),
+  ]),
   new LineShapeEdge(station.WILLIAMS_LANDING, station.HOPPERS_CROSSING, [
     routeGraph.williamsLandingToHoppersCrossing,
-  ], []),
+  ], [
+    mapSegment.lavertonToWerribee.part(3, 4),
+  ]),
   new LineShapeEdge(station.HOPPERS_CROSSING, station.WERRIBEE, [
     routeGraph.hoppersCrossingToWerribee,
-  ], []),
+  ], [
+    mapSegment.lavertonToWerribee.part(4, 4),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/werribee.ts
+++ b/server/entry-point/data/lines/werribee.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -27,6 +29,17 @@ const routeGraph = {
   aircraftToWilliamsLanding: new StationPair(station.AIRCRAFT, station.WILLIAMS_LANDING),
   williamsLandingToHoppersCrossing: new StationPair(station.WILLIAMS_LANDING, station.HOPPERS_CROSSING),
   hoppersCrossingToWerribee: new StationPair(station.HOPPERS_CROSSING, station.WERRIBEE),
+};
+
+// prettier-ignore
+const mapSegment = {
+  flindersStreetToSouthernCross: MapSegment.full(map.NEWPORT.FLINDERS_STREET, map.NEWPORT.SOUTHERN_CROSS),
+  southernCrossToNorthMelbourne: MapSegment.full(map.NEWPORT.SOUTHERN_CROSS, map.NEWPORT.NORTH_MELBOURNE),
+  northMelbourneToFootscray: MapSegment.full(map.NEWPORT.NORTH_MELBOURNE, map.NEWPORT.FOOTSCRAY),
+  footscrayToNewport: MapSegment.full(map.NEWPORT.FOOTSCRAY, map.NEWPORT.NEWPORT),
+  newportToLavertonLoop: MapSegment.full(map.NEWPORT.NEWPORT, map.NEWPORT.LAVERTON_LOOP),
+  newportToLavertonExpress: MapSegment.full(map.NEWPORT.NEWPORT, map.NEWPORT.LAVERTON_EXPRESS),
+  lavertonToWerribee: MapSegment.full(map.NEWPORT.LAVERTON_LOOP, map.NEWPORT.WERRIBEE),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/williamstown.ts
+++ b/server/entry-point/data/lines/williamstown.ts
@@ -27,37 +27,37 @@ const routeGraph = {
 const lineShapeEdges = [
   new LineShapeEdge(station.FLINDERS_STREET, station.SOUTHERN_CROSS, [
     routeGraph.flindersStreetToSouthernCross,
-  ]),
+  ], []),
   new LineShapeEdge(station.SOUTHERN_CROSS, station.NORTH_MELBOURNE, [
     routeGraph.southernCrossToNorthMelbourne,
-  ]),
+  ], []),
   new LineShapeEdge(station.NORTH_MELBOURNE, station.SOUTH_KENSINGTON, [
     routeGraph.northMelbourneToSouthKensington,
-  ]),
+  ], []),
   new LineShapeEdge(station.SOUTH_KENSINGTON, station.FOOTSCRAY, [
     routeGraph.southKensingtonToFootscray,
-  ]),
+  ], []),
   new LineShapeEdge(station.FOOTSCRAY, station.SEDDON, [
     routeGraph.footscrayToSeddon,
-  ]),
+  ], []),
   new LineShapeEdge(station.SEDDON, station.YARRAVILLE, [
     routeGraph.seddonToYarraville,
-  ]),
+  ], []),
   new LineShapeEdge(station.YARRAVILLE, station.SPOTSWOOD, [
     routeGraph.yarravilleToSpotswood,
-  ]),
+  ], []),
   new LineShapeEdge(station.SPOTSWOOD, station.NEWPORT, [
     routeGraph.spotswoodToNewport,
-  ]),
+  ], []),
   new LineShapeEdge(station.NEWPORT, station.NORTH_WILLIAMSTOWN, [
     routeGraph.newportToNorthWilliamstown,
-  ]),
+  ], []),
   new LineShapeEdge(station.NORTH_WILLIAMSTOWN, station.WILLIAMSTOWN_BEACH, [
     routeGraph.northWilliamstownToWilliamstownBeach,
-  ]),
+  ], []),
   new LineShapeEdge(station.WILLIAMSTOWN_BEACH, station.WILLIAMSTOWN, [
     routeGraph.williamstownBeachToWilliamstown,
-  ]),
+  ], []),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/server/entry-point/data/lines/williamstown.ts
+++ b/server/entry-point/data/lines/williamstown.ts
@@ -1,5 +1,6 @@
 import * as id from "@/shared/line-ids";
 import * as station from "@/shared/station-ids";
+import * as map from "@/shared/map-node-ids";
 import { Line } from "@/server/data/line/line";
 import { StationPair } from "@/server/data/line/line-routes/station-pair";
 import {
@@ -7,6 +8,7 @@ import {
   LineShapeEdge,
 } from "@/server/data/line/line-routes/line-shape";
 import { LineRoute } from "@/server/data/line/line-routes/line-route";
+import { MapSegment } from "@/server/data/map-segment";
 
 // prettier-ignore
 const routeGraph = {
@@ -21,6 +23,15 @@ const routeGraph = {
   newportToNorthWilliamstown: new StationPair(station.NEWPORT, station.NORTH_WILLIAMSTOWN),
   northWilliamstownToWilliamstownBeach: new StationPair(station.NORTH_WILLIAMSTOWN, station.WILLIAMSTOWN_BEACH),
   williamstownBeachToWilliamstown: new StationPair(station.WILLIAMSTOWN_BEACH, station.WILLIAMSTOWN),
+};
+
+// prettier-ignore
+const mapSegment = {
+  flindersStreetToSouthernCross: MapSegment.full(map.NEWPORT.FLINDERS_STREET, map.NEWPORT.SOUTHERN_CROSS),
+  southernCrossToNorthMelbourne: MapSegment.full(map.NEWPORT.SOUTHERN_CROSS, map.NEWPORT.NORTH_MELBOURNE),
+  northMelbourneToFootscray: MapSegment.full(map.NEWPORT.NORTH_MELBOURNE, map.NEWPORT.FOOTSCRAY),
+  footscrayToNewport: MapSegment.full(map.NEWPORT.FOOTSCRAY, map.NEWPORT.NEWPORT),
+  newportToWilliamstown: MapSegment.full(map.NEWPORT.NEWPORT, map.NEWPORT.WILLIAMSTOWN),
 };
 
 // prettier-ignore

--- a/server/entry-point/data/lines/williamstown.ts
+++ b/server/entry-point/data/lines/williamstown.ts
@@ -38,37 +38,59 @@ const mapSegment = {
 const lineShapeEdges = [
   new LineShapeEdge(station.FLINDERS_STREET, station.SOUTHERN_CROSS, [
     routeGraph.flindersStreetToSouthernCross,
-  ], []),
+  ], [
+    mapSegment.flindersStreetToSouthernCross,
+  ]),
   new LineShapeEdge(station.SOUTHERN_CROSS, station.NORTH_MELBOURNE, [
     routeGraph.southernCrossToNorthMelbourne,
-  ], []),
+  ], [
+    mapSegment.southernCrossToNorthMelbourne,
+  ]),
   new LineShapeEdge(station.NORTH_MELBOURNE, station.SOUTH_KENSINGTON, [
     routeGraph.northMelbourneToSouthKensington,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToFootscray.part(1, 2),
+  ]),
   new LineShapeEdge(station.SOUTH_KENSINGTON, station.FOOTSCRAY, [
     routeGraph.southKensingtonToFootscray,
-  ], []),
+  ], [
+    mapSegment.northMelbourneToFootscray.part(2, 2),
+  ]),
   new LineShapeEdge(station.FOOTSCRAY, station.SEDDON, [
     routeGraph.footscrayToSeddon,
-  ], []),
+  ], [
+    mapSegment.footscrayToNewport.part(1, 4),
+  ]),
   new LineShapeEdge(station.SEDDON, station.YARRAVILLE, [
     routeGraph.seddonToYarraville,
-  ], []),
+  ], [
+    mapSegment.footscrayToNewport.part(2, 4),
+  ]),
   new LineShapeEdge(station.YARRAVILLE, station.SPOTSWOOD, [
     routeGraph.yarravilleToSpotswood,
-  ], []),
+  ], [
+    mapSegment.footscrayToNewport.part(3, 4),
+  ]),
   new LineShapeEdge(station.SPOTSWOOD, station.NEWPORT, [
     routeGraph.spotswoodToNewport,
-  ], []),
+  ], [
+    mapSegment.footscrayToNewport.part(4, 4),
+  ]),
   new LineShapeEdge(station.NEWPORT, station.NORTH_WILLIAMSTOWN, [
     routeGraph.newportToNorthWilliamstown,
-  ], []),
+  ], [
+    mapSegment.newportToWilliamstown.part(1, 3),
+  ]),
   new LineShapeEdge(station.NORTH_WILLIAMSTOWN, station.WILLIAMSTOWN_BEACH, [
     routeGraph.northWilliamstownToWilliamstownBeach,
-  ], []),
+  ], [
+    mapSegment.newportToWilliamstown.part(2, 3),
+  ]),
   new LineShapeEdge(station.WILLIAMSTOWN_BEACH, station.WILLIAMSTOWN, [
     routeGraph.williamstownBeachToWilliamstown,
-  ], []),
+  ], [
+    mapSegment.newportToWilliamstown.part(3, 3),
+  ]),
 ];
 
 const routeGraphPairs = Object.values(routeGraph);

--- a/tests/server/data/line/line-routes/line-shape.test.ts
+++ b/tests/server/data/line/line-routes/line-shape.test.ts
@@ -7,24 +7,25 @@ import { StationPair } from "@/server/data/line/line-routes/station-pair";
 
 describe("LineShape", () => {
   const lineShape = new LineShape("the-city", [
-    new LineShapeEdge("the-city", 1, [
-      new StationPair(20, 1),
-      new StationPair(21, 1),
-      new StationPair(22, 1),
-    ]),
-    new LineShapeEdge(1, 2, [new StationPair(1, 2)]),
-    new LineShapeEdge(2, 3, [new StationPair(2, 3)]),
-    new LineShapeEdge(3, 4, [new StationPair(3, 4)]),
-    new LineShapeEdge(4, 5, [new StationPair(4, 5)]),
-    new LineShapeEdge(3, 6, [new StationPair(3, 6)]),
-    new LineShapeEdge(6, 7, [new StationPair(6, 7)]),
+    new LineShapeEdge(
+      "the-city",
+      1,
+      [new StationPair(20, 1), new StationPair(21, 1), new StationPair(22, 1)],
+      [],
+    ),
+    new LineShapeEdge(1, 2, [new StationPair(1, 2)], []),
+    new LineShapeEdge(2, 3, [new StationPair(2, 3)], []),
+    new LineShapeEdge(3, 4, [new StationPair(3, 4)], []),
+    new LineShapeEdge(4, 5, [new StationPair(4, 5)], []),
+    new LineShapeEdge(3, 6, [new StationPair(3, 6)], []),
+    new LineShapeEdge(6, 7, [new StationPair(6, 7)], []),
   ]);
 
   it("disallows construction of invalid shapes", () => {
     expect(
       () =>
         new LineShape("the-city", [
-          new LineShapeEdge(1, 2, [new StationPair(1, 2)]),
+          new LineShapeEdge(1, 2, [new StationPair(1, 2)], []),
         ]),
     ).toThrow();
   });
@@ -116,10 +117,13 @@ describe("LineShape", () => {
 
 describe("LineShapeEdge", () => {
   it("disallows construction of invalid edges", () => {
-    expect(() => new LineShapeEdge(1, 2, [])).toThrow();
-    expect(() => new LineShapeEdge(1, 1, [new StationPair(1, 2)])).toThrow();
+    expect(() => new LineShapeEdge(1, 2, [], [])).toThrow();
     expect(
-      () => new LineShapeEdge("the-city", "the-city", [new StationPair(1, 2)]),
+      () => new LineShapeEdge(1, 1, [new StationPair(1, 2)], []),
+    ).toThrow();
+    expect(
+      () =>
+        new LineShapeEdge("the-city", "the-city", [new StationPair(1, 2)], []),
     ).toThrow();
   });
 });

--- a/tests/server/entry-point/data/__snapshots__/line-routes.test.ts.snap
+++ b/tests/server/entry-point/data/__snapshots__/line-routes.test.ts.snap
@@ -2,1025 +2,589 @@
 
 exports[`Melbourne default line route edges > should match the snapshot 1`] = `
 "
-[ALAMEIN LINE]
 
-All route graph pairs:
-  Flinders Street -> Richmond
-  Flinders Street -> Southern Cross
-  Southern Cross -> Flagstaff
-  Flagstaff -> Melbourne Central
-  Melbourne Central -> Parliament
-  Parliament -> Richmond
-  Richmond -> East Richmond
-  East Richmond -> Burnley
-  Burnley -> Hawthorn
-  Hawthorn -> Glenferrie
-  Glenferrie -> Auburn
-  Auburn -> Camberwell
-  Camberwell -> Riversdale
-  Riversdale -> Willison
-  Willison -> Hartwell
-  Hartwell -> Burwood
-  Burwood -> Ashburton
-  Ashburton -> Alamein
 
-Line shape edges:
-  "The city" -> Richmond: [Flinders Street -> Richmond, Flinders Street -> Southern Cross, Southern Cross -> Flagstaff, Flagstaff -> Melbourne Central, Melbourne Central -> Parliament, Parliament -> Richmond]
-  Richmond -> East Richmond: [Richmond -> East Richmond]
-  East Richmond -> Burnley: [East Richmond -> Burnley]
-  Burnley -> Hawthorn: [Burnley -> Hawthorn]
-  Hawthorn -> Glenferrie: [Hawthorn -> Glenferrie]
-  Glenferrie -> Auburn: [Glenferrie -> Auburn]
-  Auburn -> Camberwell: [Auburn -> Camberwell]
-  Camberwell -> Riversdale: [Camberwell -> Riversdale]
-  Riversdale -> Willison: [Riversdale -> Willison]
-  Willison -> Hartwell: [Willison -> Hartwell]
-  Hartwell -> Burwood: [Hartwell -> Burwood]
-  Burwood -> Ashburton: [Burwood -> Ashburton]
-  Ashburton -> Alamein: [Ashburton -> Alamein]
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ALAMEIN
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+"The city" -> Richmond                    Flinders Street -> Richmond               BURNLEY.FLINDERS_STREET_DIRECT -> BURNLEY.RICHMOND (0.00 -> 1.00)                                   
+                                          Flinders Street -> Southern Cross         BURNLEY.FLINDERS_STREET_LOOP -> BURNLEY.SOUTHERN_CROSS (0.00 -> 1.00)                               
+                                          Southern Cross -> Flagstaff               BURNLEY.SOUTHERN_CROSS -> BURNLEY.FLAGSTAFF (0.00 -> 1.00)                                          
+                                          Flagstaff -> Melbourne Central            BURNLEY.FLAGSTAFF -> BURNLEY.MELBOURNE_CENTRAL (0.00 -> 1.00)                                       
+                                          Melbourne Central -> Parliament           BURNLEY.MELBOURNE_CENTRAL -> BURNLEY.PARLIAMENT (0.00 -> 1.00)                                      
+                                          Parliament -> Richmond                    BURNLEY.PARLIAMENT -> BURNLEY.RICHMOND (0.00 -> 1.00)                                               
+Richmond -> East Richmond                 Richmond -> East Richmond                 BURNLEY.RICHMOND -> BURNLEY.BURNLEY (0.00 -> 0.50)                                                  
+East Richmond -> Burnley                  East Richmond -> Burnley                  BURNLEY.RICHMOND -> BURNLEY.BURNLEY (0.50 -> 1.00)                                                  
+Burnley -> Hawthorn                       Burnley -> Hawthorn                       BURNLEY.BURNLEY -> BURNLEY.CAMBERWELL (0.00 -> 0.25)                                                
+Hawthorn -> Glenferrie                    Hawthorn -> Glenferrie                    BURNLEY.BURNLEY -> BURNLEY.CAMBERWELL (0.25 -> 0.50)                                                
+Glenferrie -> Auburn                      Glenferrie -> Auburn                      BURNLEY.BURNLEY -> BURNLEY.CAMBERWELL (0.50 -> 0.75)                                                
+Auburn -> Camberwell                      Auburn -> Camberwell                      BURNLEY.BURNLEY -> BURNLEY.CAMBERWELL (0.75 -> 1.00)                                                
+Camberwell -> Riversdale                  Camberwell -> Riversdale                  BURNLEY.CAMBERWELL -> BURNLEY.ALAMEIN (0.00 -> 0.17)                                                
+Riversdale -> Willison                    Riversdale -> Willison                    BURNLEY.CAMBERWELL -> BURNLEY.ALAMEIN (0.17 -> 0.33)                                                
+Willison -> Hartwell                      Willison -> Hartwell                      BURNLEY.CAMBERWELL -> BURNLEY.ALAMEIN (0.33 -> 0.50)                                                
+Hartwell -> Burwood                       Hartwell -> Burwood                       BURNLEY.CAMBERWELL -> BURNLEY.ALAMEIN (0.50 -> 0.67)                                                
+Burwood -> Ashburton                      Burwood -> Ashburton                      BURNLEY.CAMBERWELL -> BURNLEY.ALAMEIN (0.67 -> 0.83)                                                
+Ashburton -> Alamein                      Ashburton -> Alamein                      BURNLEY.CAMBERWELL -> BURNLEY.ALAMEIN (0.83 -> 1.00)                                                
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+BALLARAT
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Southern Cross -> Footscray               Southern Cross -> Ardeer                  REGIONAL_WESTERN.SOUTHERN_CROSS -> REGIONAL_WESTERN.NORTH_MELBOURNE_JUNCTION (0.00 -> 1.00)         
+                                                                                    REGIONAL_WESTERN.NORTH_MELBOURNE_JUNCTION -> REGIONAL_WESTERN.NORTH_MELBOURNE_RRL (0.00 -> 1.00)    
+                                                                                    REGIONAL_WESTERN.NORTH_MELBOURNE_RRL -> REGIONAL_WESTERN.FOOTSCRAY (0.00 -> 1.00)                   
+Footscray -> Sunshine                     Southern Cross -> Ardeer                  REGIONAL_WESTERN.FOOTSCRAY -> REGIONAL_WESTERN.SUNSHINE_JUNCTION (0.00 -> 1.00)                     
+                                          Footscray -> Ardeer                       REGIONAL_WESTERN.SUNSHINE_JUNCTION -> REGIONAL_WESTERN.SUNSHINE_DEER_PARK (0.00 -> 1.00)            
+Sunshine -> Ardeer                        Southern Cross -> Ardeer                  REGIONAL_WESTERN.SUNSHINE_DEER_PARK -> REGIONAL_WESTERN.DEER_PARK (0.00 -> 0.50)                    
+                                          Footscray -> Ardeer                                                                                                                           
+                                          Sunshine -> Ardeer                                                                                                                            
+Ardeer -> Deer Park                       Ardeer -> Deer Park                       REGIONAL_WESTERN.SUNSHINE_DEER_PARK -> REGIONAL_WESTERN.DEER_PARK (0.50 -> 1.00)                    
+Deer Park -> Caroline Springs             Deer Park -> Caroline Springs             REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.BALLARAT (0.00 -> 0.14)                              
+Caroline Springs -> Rockbank              Caroline Springs -> Rockbank              REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.BALLARAT (0.14 -> 0.29)                              
+Rockbank -> Cobblebank                    Rockbank -> Cobblebank                    REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.BALLARAT (0.29 -> 0.43)                              
+Cobblebank -> Melton                      Cobblebank -> Melton                      REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.BALLARAT (0.43 -> 0.57)                              
+Melton -> Bacchus Marsh                   Melton -> Bacchus Marsh                   REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.BALLARAT (0.57 -> 0.71)                              
+Bacchus Marsh -> Ballan                   Bacchus Marsh -> Ballan                   REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.BALLARAT (0.71 -> 0.86)                              
+Ballan -> Ballarat                        Ballan -> Ballarat                        REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.BALLARAT (0.86 -> 1.00)                              
+Ballarat -> Creswick                      Ballarat -> Creswick                      REGIONAL_WESTERN.BALLARAT -> REGIONAL_WESTERN.MARYBOROUGH (0.00 -> 0.25)                            
+Creswick -> Clunes                        Creswick -> Clunes                        REGIONAL_WESTERN.BALLARAT -> REGIONAL_WESTERN.MARYBOROUGH (0.25 -> 0.50)                            
+Clunes -> Talbot                          Clunes -> Talbot                          REGIONAL_WESTERN.BALLARAT -> REGIONAL_WESTERN.MARYBOROUGH (0.50 -> 0.75)                            
+Talbot -> Maryborough                     Talbot -> Maryborough                     REGIONAL_WESTERN.BALLARAT -> REGIONAL_WESTERN.MARYBOROUGH (0.75 -> 1.00)                            
+Ballarat -> Wendouree                     Ballarat -> Wendouree                     REGIONAL_WESTERN.BALLARAT -> REGIONAL_WESTERN.ARARAT (0.00 -> 0.33)                                 
+Wendouree -> Beaufort                     Wendouree -> Beaufort                     REGIONAL_WESTERN.BALLARAT -> REGIONAL_WESTERN.ARARAT (0.33 -> 0.67)                                 
+Beaufort -> Ararat                        Beaufort -> Ararat                        REGIONAL_WESTERN.BALLARAT -> REGIONAL_WESTERN.ARARAT (0.67 -> 1.00)                                 
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+BELGRAVE
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+"The city" -> Richmond                    Flinders Street -> Richmond               BURNLEY.FLINDERS_STREET_DIRECT -> BURNLEY.RICHMOND (0.00 -> 1.00)                                   
+                                          Flinders Street -> Southern Cross         BURNLEY.FLINDERS_STREET_LOOP -> BURNLEY.SOUTHERN_CROSS (0.00 -> 1.00)                               
+                                          Southern Cross -> Flagstaff               BURNLEY.SOUTHERN_CROSS -> BURNLEY.FLAGSTAFF (0.00 -> 1.00)                                          
+                                          Flagstaff -> Melbourne Central            BURNLEY.FLAGSTAFF -> BURNLEY.MELBOURNE_CENTRAL (0.00 -> 1.00)                                       
+                                          Melbourne Central -> Parliament           BURNLEY.MELBOURNE_CENTRAL -> BURNLEY.PARLIAMENT (0.00 -> 1.00)                                      
+                                          Parliament -> Richmond                    BURNLEY.PARLIAMENT -> BURNLEY.RICHMOND (0.00 -> 1.00)                                               
+Richmond -> East Richmond                 Richmond -> East Richmond                 BURNLEY.RICHMOND -> BURNLEY.BURNLEY (0.00 -> 0.50)                                                  
+East Richmond -> Burnley                  East Richmond -> Burnley                  BURNLEY.RICHMOND -> BURNLEY.BURNLEY (0.50 -> 1.00)                                                  
+Burnley -> Hawthorn                       Burnley -> Hawthorn                       BURNLEY.BURNLEY -> BURNLEY.CAMBERWELL (0.00 -> 0.25)                                                
+Hawthorn -> Glenferrie                    Hawthorn -> Glenferrie                    BURNLEY.BURNLEY -> BURNLEY.CAMBERWELL (0.25 -> 0.50)                                                
+Glenferrie -> Auburn                      Glenferrie -> Auburn                      BURNLEY.BURNLEY -> BURNLEY.CAMBERWELL (0.50 -> 0.75)                                                
+Auburn -> Camberwell                      Auburn -> Camberwell                      BURNLEY.BURNLEY -> BURNLEY.CAMBERWELL (0.75 -> 1.00)                                                
+Camberwell -> East Camberwell             Camberwell -> East Camberwell             BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.00 -> 0.09)                                               
+East Camberwell -> Canterbury             East Camberwell -> Canterbury             BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.09 -> 0.18)                                               
+Canterbury -> Chatham                     Canterbury -> Chatham                     BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.18 -> 0.27)                                               
+Chatham -> Union                          Chatham -> Union                          BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.27 -> 0.36)                                               
+Union -> Box Hill                         Union -> Box Hill                         BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.36 -> 0.45)                                               
+Box Hill -> Laburnum                      Box Hill -> Laburnum                      BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.45 -> 0.55)                                               
+Laburnum -> Blackburn                     Laburnum -> Blackburn                     BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.55 -> 0.64)                                               
+Blackburn -> Nunawading                   Blackburn -> Nunawading                   BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.64 -> 0.73)                                               
+Nunawading -> Mitcham                     Nunawading -> Mitcham                     BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.73 -> 0.82)                                               
+Mitcham -> Heatherdale                    Mitcham -> Heatherdale                    BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.82 -> 0.91)                                               
+Heatherdale -> Ringwood                   Heatherdale -> Ringwood                   BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.91 -> 1.00)                                               
+Ringwood -> Heathmont                     Ringwood -> Heathmont                     BURNLEY.RINGWOOD -> BURNLEY.BELGRAVE (0.00 -> 0.13)                                                 
+Heathmont -> Bayswater                    Heathmont -> Bayswater                    BURNLEY.RINGWOOD -> BURNLEY.BELGRAVE (0.13 -> 0.25)                                                 
+Bayswater -> Boronia                      Bayswater -> Boronia                      BURNLEY.RINGWOOD -> BURNLEY.BELGRAVE (0.25 -> 0.38)                                                 
+Boronia -> Ferntree Gully                 Boronia -> Ferntree Gully                 BURNLEY.RINGWOOD -> BURNLEY.BELGRAVE (0.38 -> 0.50)                                                 
+Ferntree Gully -> Upper Ferntree Gully    Ferntree Gully -> Upper Ferntree Gully    BURNLEY.RINGWOOD -> BURNLEY.BELGRAVE (0.50 -> 0.63)                                                 
+Upper Ferntree Gully -> Upwey             Upper Ferntree Gully -> Upwey             BURNLEY.RINGWOOD -> BURNLEY.BELGRAVE (0.63 -> 0.75)                                                 
+Upwey -> Tecoma                           Upwey -> Tecoma                           BURNLEY.RINGWOOD -> BURNLEY.BELGRAVE (0.75 -> 0.88)                                                 
+Tecoma -> Belgrave                        Tecoma -> Belgrave                        BURNLEY.RINGWOOD -> BURNLEY.BELGRAVE (0.88 -> 1.00)                                                 
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+BENDIGO
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Southern Cross -> Footscray               Southern Cross -> Sunbury                 REGIONAL_WESTERN.SOUTHERN_CROSS -> REGIONAL_WESTERN.NORTH_MELBOURNE_JUNCTION (0.00 -> 1.00)         
+                                                                                    REGIONAL_WESTERN.NORTH_MELBOURNE_JUNCTION -> REGIONAL_WESTERN.NORTH_MELBOURNE_RRL (0.00 -> 1.00)    
+                                                                                    REGIONAL_WESTERN.NORTH_MELBOURNE_RRL -> REGIONAL_WESTERN.FOOTSCRAY (0.00 -> 1.00)                   
+Footscray -> Watergardens                 Southern Cross -> Sunbury                 REGIONAL_WESTERN.FOOTSCRAY -> REGIONAL_WESTERN.SUNSHINE_JUNCTION (0.00 -> 1.00)                     
+                                          Footscray -> Sunbury                      REGIONAL_WESTERN.SUNSHINE_JUNCTION -> REGIONAL_WESTERN.SUNSHINE_BENDIGO (0.00 -> 1.00)              
+                                                                                    REGIONAL_WESTERN.SUNSHINE_BENDIGO -> REGIONAL_WESTERN.WATERGARDENS (0.00 -> 1.00)                   
+Watergardens -> Sunbury                   Southern Cross -> Sunbury                 REGIONAL_WESTERN.WATERGARDENS -> REGIONAL_WESTERN.SUNBURY (0.00 -> 1.00)                            
+                                          Footscray -> Sunbury                                                                                                                          
+                                          Watergardens -> Sunbury                                                                                                                       
+Sunbury -> Clarkefield                    Sunbury -> Clarkefield                    REGIONAL_WESTERN.SUNBURY -> REGIONAL_WESTERN.BENDIGO (0.00 -> 0.10)                                 
+Clarkefield -> Riddells Creek             Clarkefield -> Riddells Creek             REGIONAL_WESTERN.SUNBURY -> REGIONAL_WESTERN.BENDIGO (0.10 -> 0.20)                                 
+Riddells Creek -> Gisborne                Riddells Creek -> Gisborne                REGIONAL_WESTERN.SUNBURY -> REGIONAL_WESTERN.BENDIGO (0.20 -> 0.30)                                 
+Gisborne -> Macedon                       Gisborne -> Macedon                       REGIONAL_WESTERN.SUNBURY -> REGIONAL_WESTERN.BENDIGO (0.30 -> 0.40)                                 
+Macedon -> Woodend                        Macedon -> Woodend                        REGIONAL_WESTERN.SUNBURY -> REGIONAL_WESTERN.BENDIGO (0.40 -> 0.50)                                 
+Woodend -> Kyneton                        Woodend -> Kyneton                        REGIONAL_WESTERN.SUNBURY -> REGIONAL_WESTERN.BENDIGO (0.50 -> 0.60)                                 
+Kyneton -> Malmsbury                      Kyneton -> Malmsbury                      REGIONAL_WESTERN.SUNBURY -> REGIONAL_WESTERN.BENDIGO (0.60 -> 0.70)                                 
+Malmsbury -> Castlemaine                  Malmsbury -> Castlemaine                  REGIONAL_WESTERN.SUNBURY -> REGIONAL_WESTERN.BENDIGO (0.70 -> 0.80)                                 
+Castlemaine -> Kangaroo Flat              Castlemaine -> Kangaroo Flat              REGIONAL_WESTERN.SUNBURY -> REGIONAL_WESTERN.BENDIGO (0.80 -> 0.90)                                 
+Kangaroo Flat -> Bendigo                  Kangaroo Flat -> Bendigo                  REGIONAL_WESTERN.SUNBURY -> REGIONAL_WESTERN.BENDIGO (0.90 -> 1.00)                                 
+Bendigo -> Epsom                          Bendigo -> Epsom                          REGIONAL_WESTERN.BENDIGO -> REGIONAL_WESTERN.ECHUCA (0.00 -> 0.17)                                  
+Epsom -> Huntly                           Epsom -> Huntly                           REGIONAL_WESTERN.BENDIGO -> REGIONAL_WESTERN.ECHUCA (0.17 -> 0.33)                                  
+Huntly -> Goornong                        Huntly -> Goornong                        REGIONAL_WESTERN.BENDIGO -> REGIONAL_WESTERN.ECHUCA (0.33 -> 0.50)                                  
+Goornong -> Elmore                        Goornong -> Elmore                        REGIONAL_WESTERN.BENDIGO -> REGIONAL_WESTERN.ECHUCA (0.50 -> 0.67)                                  
+Elmore -> Rochester                       Elmore -> Rochester                       REGIONAL_WESTERN.BENDIGO -> REGIONAL_WESTERN.ECHUCA (0.67 -> 0.83)                                  
+Rochester -> Echuca                       Rochester -> Echuca                       REGIONAL_WESTERN.BENDIGO -> REGIONAL_WESTERN.ECHUCA (0.83 -> 1.00)                                  
+Bendigo -> Eaglehawk                      Bendigo -> Eaglehawk                      REGIONAL_WESTERN.BENDIGO -> REGIONAL_WESTERN.SWAN_HILL (0.00 -> 0.17)                               
+Eaglehawk -> Raywood                      Eaglehawk -> Raywood                      REGIONAL_WESTERN.BENDIGO -> REGIONAL_WESTERN.SWAN_HILL (0.17 -> 0.33)                               
+Raywood -> Dingee                         Raywood -> Dingee                         REGIONAL_WESTERN.BENDIGO -> REGIONAL_WESTERN.SWAN_HILL (0.33 -> 0.50)                               
+Dingee -> Pyramid                         Dingee -> Pyramid                         REGIONAL_WESTERN.BENDIGO -> REGIONAL_WESTERN.SWAN_HILL (0.50 -> 0.67)                               
+Pyramid -> Kerang                         Pyramid -> Kerang                         REGIONAL_WESTERN.BENDIGO -> REGIONAL_WESTERN.SWAN_HILL (0.67 -> 0.83)                               
+Kerang -> Swan Hill                       Kerang -> Swan Hill                       REGIONAL_WESTERN.BENDIGO -> REGIONAL_WESTERN.SWAN_HILL (0.83 -> 1.00)                               
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+CRAIGIEBURN
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+"The city" -> North Melbourne             Flinders Street -> Southern Cross         NORTHERN.FLINDERS_STREET_DIRECT -> NORTHERN.SOUTHERN_CROSS (0.00 -> 1.00)                           
+                                          Southern Cross -> North Melbourne         NORTHERN.SOUTHERN_CROSS -> NORTHERN.NORTH_MELBOURNE (0.00 -> 1.00)                                  
+                                          Flinders Street -> Parliament             NORTHERN.FLAGSTAFF -> NORTHERN.NORTH_MELBOURNE (0.00 -> 1.00)                                       
+                                          Parliament -> Melbourne Central           NORTHERN.MELBOURNE_CENTRAL -> NORTHERN.FLAGSTAFF (0.00 -> 1.00)                                     
+                                          Melbourne Central -> Flagstaff            NORTHERN.PARLIAMENT -> NORTHERN.MELBOURNE_CENTRAL (0.00 -> 1.00)                                    
+                                          Flagstaff -> North Melbourne              NORTHERN.FLINDERS_STREET_LOOP -> NORTHERN.PARLIAMENT (0.00 -> 1.00)                                 
+North Melbourne -> Kensington             North Melbourne -> Kensington             NORTHERN.NORTH_MELBOURNE -> NORTHERN.BROADMEADOWS (0.00 -> 0.08)                                    
+Kensington -> Newmarket                   Kensington -> Newmarket                   NORTHERN.NORTH_MELBOURNE -> NORTHERN.BROADMEADOWS (0.08 -> 0.17)                                    
+Newmarket -> Ascot Vale                   Newmarket -> Ascot Vale                   NORTHERN.NORTH_MELBOURNE -> NORTHERN.BROADMEADOWS (0.17 -> 0.25)                                    
+Ascot Vale -> Moonee Ponds                Ascot Vale -> Moonee Ponds                NORTHERN.NORTH_MELBOURNE -> NORTHERN.BROADMEADOWS (0.25 -> 0.33)                                    
+Moonee Ponds -> Essendon                  Moonee Ponds -> Essendon                  NORTHERN.NORTH_MELBOURNE -> NORTHERN.BROADMEADOWS (0.33 -> 0.42)                                    
+Essendon -> Glenbervie                    Essendon -> Glenbervie                    NORTHERN.NORTH_MELBOURNE -> NORTHERN.BROADMEADOWS (0.42 -> 0.50)                                    
+Glenbervie -> Strathmore                  Glenbervie -> Strathmore                  NORTHERN.NORTH_MELBOURNE -> NORTHERN.BROADMEADOWS (0.50 -> 0.58)                                    
+Strathmore -> Pascoe Vale                 Strathmore -> Pascoe Vale                 NORTHERN.NORTH_MELBOURNE -> NORTHERN.BROADMEADOWS (0.58 -> 0.67)                                    
+Pascoe Vale -> Oak Park                   Pascoe Vale -> Oak Park                   NORTHERN.NORTH_MELBOURNE -> NORTHERN.BROADMEADOWS (0.67 -> 0.75)                                    
+Oak Park -> Glenroy                       Oak Park -> Glenroy                       NORTHERN.NORTH_MELBOURNE -> NORTHERN.BROADMEADOWS (0.75 -> 0.83)                                    
+Glenroy -> Jacana                         Glenroy -> Jacana                         NORTHERN.NORTH_MELBOURNE -> NORTHERN.BROADMEADOWS (0.83 -> 0.92)                                    
+Jacana -> Broadmeadows                    Jacana -> Broadmeadows                    NORTHERN.NORTH_MELBOURNE -> NORTHERN.BROADMEADOWS (0.92 -> 1.00)                                    
+Broadmeadows -> Coolaroo                  Broadmeadows -> Coolaroo                  NORTHERN.BROADMEADOWS -> NORTHERN.CRAIGIEBURN (0.00 -> 0.33)                                        
+Coolaroo -> Roxburgh Park                 Coolaroo -> Roxburgh Park                 NORTHERN.BROADMEADOWS -> NORTHERN.CRAIGIEBURN (0.33 -> 0.67)                                        
+Roxburgh Park -> Craigieburn              Roxburgh Park -> Craigieburn              NORTHERN.BROADMEADOWS -> NORTHERN.CRAIGIEBURN (0.67 -> 1.00)                                        
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+CRANBOURNE
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+"The city" -> Richmond                    Flinders Street -> Richmond               DANDENONG.FLINDERS_STREET_DIRECT -> DANDENONG.RICHMOND (0.00 -> 1.00)                               
+                                          Flinders Street -> Southern Cross         DANDENONG.FLINDERS_STREET_LOOP -> DANDENONG.SOUTHERN_CROSS (0.00 -> 1.00)                           
+                                          Southern Cross -> Flagstaff               DANDENONG.SOUTHERN_CROSS -> DANDENONG.FLAGSTAFF (0.00 -> 1.00)                                      
+                                          Flagstaff -> Melbourne Central            DANDENONG.FLAGSTAFF -> DANDENONG.MELBOURNE_CENTRAL (0.00 -> 1.00)                                   
+                                          Melbourne Central -> Parliament           DANDENONG.MELBOURNE_CENTRAL -> DANDENONG.PARLIAMENT (0.00 -> 1.00)                                  
+                                          Parliament -> Richmond                    DANDENONG.PARLIAMENT -> DANDENONG.RICHMOND (0.00 -> 1.00)                                           
+Richmond -> South Yarra                   Richmond -> South Yarra                   DANDENONG.RICHMOND -> DANDENONG.SOUTH_YARRA (0.00 -> 1.00)                                          
+South Yarra -> Caulfield                  South Yarra -> Caulfield                  DANDENONG.SOUTH_YARRA -> DANDENONG.CAULFIELD (0.00 -> 1.00)                                         
+Caulfield -> Carnegie                     Caulfield -> Carnegie                     DANDENONG.CAULFIELD -> DANDENONG.CLAYTON (0.00 -> 0.17)                                             
+Carnegie -> Murrumbeena                   Carnegie -> Murrumbeena                   DANDENONG.CAULFIELD -> DANDENONG.CLAYTON (0.17 -> 0.33)                                             
+Murrumbeena -> Hughesdale                 Murrumbeena -> Hughesdale                 DANDENONG.CAULFIELD -> DANDENONG.CLAYTON (0.33 -> 0.50)                                             
+Hughesdale -> Oakleigh                    Hughesdale -> Oakleigh                    DANDENONG.CAULFIELD -> DANDENONG.CLAYTON (0.50 -> 0.67)                                             
+Oakleigh -> Huntingdale                   Oakleigh -> Huntingdale                   DANDENONG.CAULFIELD -> DANDENONG.CLAYTON (0.67 -> 0.83)                                             
+Huntingdale -> Clayton                    Huntingdale -> Clayton                    DANDENONG.CAULFIELD -> DANDENONG.CLAYTON (0.83 -> 1.00)                                             
+Clayton -> Westall                        Clayton -> Westall                        DANDENONG.CLAYTON -> DANDENONG.DANDENONG (0.00 -> 0.17)                                             
+Westall -> Springvale                     Westall -> Springvale                     DANDENONG.CLAYTON -> DANDENONG.DANDENONG (0.17 -> 0.33)                                             
+Springvale -> Sandown Park                Springvale -> Sandown Park                DANDENONG.CLAYTON -> DANDENONG.DANDENONG (0.33 -> 0.50)                                             
+Sandown Park -> Noble Park                Sandown Park -> Noble Park                DANDENONG.CLAYTON -> DANDENONG.DANDENONG (0.50 -> 0.67)                                             
+Noble Park -> Yarraman                    Noble Park -> Yarraman                    DANDENONG.CLAYTON -> DANDENONG.DANDENONG (0.67 -> 0.83)                                             
+Yarraman -> Dandenong                     Yarraman -> Dandenong                     DANDENONG.CLAYTON -> DANDENONG.DANDENONG (0.83 -> 1.00)                                             
+Dandenong -> Lynbrook                     Dandenong -> Lynbrook                     DANDENONG.DANDENONG -> DANDENONG.CRANBOURNE (0.00 -> 0.33)                                          
+Lynbrook -> Merinda Park                  Lynbrook -> Merinda Park                  DANDENONG.DANDENONG -> DANDENONG.CRANBOURNE (0.33 -> 0.67)                                          
+Merinda Park -> Cranbourne                Merinda Park -> Cranbourne                DANDENONG.DANDENONG -> DANDENONG.CRANBOURNE (0.67 -> 1.00)                                          
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+FLEMINGTON RACECOURSE
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Flinders Street -> Southern Cross         Flinders Street -> Southern Cross                                                                                                             
+Southern Cross -> North Melbourne         Southern Cross -> North Melbourne                                                                                                             
+North Melbourne -> Showgrounds            North Melbourne -> Showgrounds                                                                                                                
+Showgrounds -> Flemington Racecourse      Showgrounds -> Flemington Racecourse                                                                                                          
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+FRANKSTON
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Flinders Street -> Richmond               Flinders Street -> Richmond               FRANKSTON.FLINDERS_STREET -> FRANKSTON.RICHMOND (0.00 -> 1.00)                                      
+Richmond -> South Yarra                   Richmond -> South Yarra                   FRANKSTON.RICHMOND -> FRANKSTON.SOUTH_YARRA (0.00 -> 1.00)                                          
+South Yarra -> Hawksburn                  South Yarra -> Hawksburn                  FRANKSTON.SOUTH_YARRA -> FRANKSTON.CAULFIELD (0.00 -> 0.20)                                         
+Hawksburn -> Toorak                       Hawksburn -> Toorak                       FRANKSTON.SOUTH_YARRA -> FRANKSTON.CAULFIELD (0.20 -> 0.40)                                         
+Toorak -> Armadale                        Toorak -> Armadale                        FRANKSTON.SOUTH_YARRA -> FRANKSTON.CAULFIELD (0.40 -> 0.60)                                         
+Armadale -> Malvern                       Armadale -> Malvern                       FRANKSTON.SOUTH_YARRA -> FRANKSTON.CAULFIELD (0.60 -> 0.80)                                         
+Malvern -> Caulfield                      Malvern -> Caulfield                      FRANKSTON.SOUTH_YARRA -> FRANKSTON.CAULFIELD (0.80 -> 1.00)                                         
+Caulfield -> Glen Huntly                  Caulfield -> Glen Huntly                  FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.00 -> 0.05)                                           
+Glen Huntly -> Ormond                     Glen Huntly -> Ormond                     FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.05 -> 0.10)                                           
+Ormond -> McKinnon                        Ormond -> McKinnon                        FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.10 -> 0.15)                                           
+McKinnon -> Bentleigh                     McKinnon -> Bentleigh                     FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.15 -> 0.20)                                           
+Bentleigh -> Patterson                    Bentleigh -> Patterson                    FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.20 -> 0.25)                                           
+Patterson -> Moorabbin                    Patterson -> Moorabbin                    FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.25 -> 0.30)                                           
+Moorabbin -> Highett                      Moorabbin -> Highett                      FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.30 -> 0.35)                                           
+Highett -> Southland                      Highett -> Southland                      FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.35 -> 0.40)                                           
+Southland -> Cheltenham                   Southland -> Cheltenham                   FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.40 -> 0.45)                                           
+Cheltenham -> Mentone                     Cheltenham -> Mentone                     FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.45 -> 0.50)                                           
+Mentone -> Parkdale                       Mentone -> Parkdale                       FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.50 -> 0.55)                                           
+Parkdale -> Mordialloc                    Parkdale -> Mordialloc                    FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.55 -> 0.60)                                           
+Mordialloc -> Aspendale                   Mordialloc -> Aspendale                   FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.60 -> 0.65)                                           
+Aspendale -> Edithvale                    Aspendale -> Edithvale                    FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.65 -> 0.70)                                           
+Edithvale -> Chelsea                      Edithvale -> Chelsea                      FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.70 -> 0.75)                                           
+Chelsea -> Bonbeach                       Chelsea -> Bonbeach                       FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.75 -> 0.80)                                           
+Bonbeach -> Carrum                        Bonbeach -> Carrum                        FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.80 -> 0.85)                                           
+Carrum -> Seaford                         Carrum -> Seaford                         FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.85 -> 0.90)                                           
+Seaford -> Kananook                       Seaford -> Kananook                       FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.90 -> 0.95)                                           
+Kananook -> Frankston                     Kananook -> Frankston                     FRANKSTON.CAULFIELD -> FRANKSTON.FRANKSTON (0.95 -> 1.00)                                           
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+GEELONG
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Southern Cross -> Footscray               Southern Cross -> Deer Park               REGIONAL_WESTERN.SOUTHERN_CROSS -> REGIONAL_WESTERN.NORTH_MELBOURNE_JUNCTION (0.00 -> 1.00)         
+                                                                                    REGIONAL_WESTERN.NORTH_MELBOURNE_JUNCTION -> REGIONAL_WESTERN.NORTH_MELBOURNE_RRL (0.00 -> 1.00)    
+                                                                                    REGIONAL_WESTERN.NORTH_MELBOURNE_RRL -> REGIONAL_WESTERN.FOOTSCRAY (0.00 -> 1.00)                   
+Footscray -> Sunshine                     Southern Cross -> Deer Park               REGIONAL_WESTERN.FOOTSCRAY -> REGIONAL_WESTERN.SUNSHINE_JUNCTION (0.00 -> 1.00)                     
+                                          Footscray -> Deer Park                    REGIONAL_WESTERN.SUNSHINE_JUNCTION -> REGIONAL_WESTERN.SUNSHINE_DEER_PARK (0.00 -> 1.00)            
+Sunshine -> Deer Park                     Southern Cross -> Deer Park               REGIONAL_WESTERN.SUNSHINE_DEER_PARK -> REGIONAL_WESTERN.DEER_PARK (0.00 -> 1.00)                    
+                                          Footscray -> Deer Park                                                                                                                        
+                                          Sunshine -> Deer Park                                                                                                                         
+Deer Park -> Tarneit                      Deer Park -> Tarneit                      REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.00 -> 0.06)                           
+Tarneit -> Wyndham Vale                   Tarneit -> Wyndham Vale                   REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.06 -> 0.11)                           
+Wyndham Vale -> Little River              Wyndham Vale -> Little River              REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.11 -> 0.17)                           
+Little River -> Lara                      Little River -> Lara                      REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.17 -> 0.22)                           
+Lara -> Corio                             Lara -> Corio                             REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.22 -> 0.28)                           
+Corio -> North Shore                      Corio -> North Shore                      REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.28 -> 0.33)                           
+North Shore -> North Geelong              North Shore -> North Geelong              REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.33 -> 0.39)                           
+North Geelong -> Geelong                  North Geelong -> Geelong                  REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.39 -> 0.44)                           
+Geelong -> South Geelong                  Geelong -> South Geelong                  REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.44 -> 0.50)                           
+South Geelong -> Marshall                 South Geelong -> Marshall                 REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.50 -> 0.56)                           
+Marshall -> Waurn Ponds                   Marshall -> Waurn Ponds                   REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.56 -> 0.61)                           
+Waurn Ponds -> Winchelsea                 Waurn Ponds -> Winchelsea                 REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.61 -> 0.67)                           
+Winchelsea -> Birregurra                  Winchelsea -> Birregurra                  REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.67 -> 0.72)                           
+Birregurra -> Colac                       Birregurra -> Colac                       REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.72 -> 0.78)                           
+Colac -> Camperdown                       Colac -> Camperdown                       REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.78 -> 0.83)                           
+Camperdown -> Terang                      Camperdown -> Terang                      REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.83 -> 0.89)                           
+Terang -> Sherwood Park                   Terang -> Sherwood Park                   REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.89 -> 0.94)                           
+Sherwood Park -> Warrnambool              Sherwood Park -> Warrnambool              REGIONAL_WESTERN.DEER_PARK -> REGIONAL_WESTERN.WARRNAMBOOL (0.94 -> 1.00)                           
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+GIPPSLAND
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Southern Cross -> Flinders Street         Southern Cross -> Pakenham                GIPPSLAND.SOUTHERN_CROSS -> GIPPSLAND.FLINDERS_STREET (0.00 -> 1.00)                                
+Flinders Street -> Richmond               Southern Cross -> Pakenham                GIPPSLAND.FLINDERS_STREET -> GIPPSLAND.RICHMOND (0.00 -> 1.00)                                      
+                                          Flinders Street -> Pakenham                                                                                                                   
+Richmond -> Caulfield                     Southern Cross -> Pakenham                GIPPSLAND.RICHMOND -> GIPPSLAND.SOUTH_YARRA (0.00 -> 1.00)                                          
+                                          Flinders Street -> Pakenham               GIPPSLAND.SOUTH_YARRA -> GIPPSLAND.CAULFIELD (0.00 -> 1.00)                                         
+                                          Richmond -> Pakenham                                                                                                                          
+Caulfield -> Clayton                      Southern Cross -> Pakenham                GIPPSLAND.CAULFIELD -> GIPPSLAND.CLAYTON (0.00 -> 1.00)                                             
+                                          Flinders Street -> Pakenham                                                                                                                   
+                                          Richmond -> Pakenham                                                                                                                          
+                                          Caulfield -> Pakenham                                                                                                                         
+Clayton -> Dandenong                      Southern Cross -> Pakenham                GIPPSLAND.CLAYTON -> GIPPSLAND.DANDENONG (0.00 -> 1.00)                                             
+                                          Flinders Street -> Pakenham                                                                                                                   
+                                          Richmond -> Pakenham                                                                                                                          
+                                          Caulfield -> Pakenham                                                                                                                         
+                                          Clayton -> Pakenham                                                                                                                           
+Dandenong -> Pakenham                     Southern Cross -> Pakenham                GIPPSLAND.DANDENONG -> GIPPSLAND.PAKENHAM (0.00 -> 1.00)                                            
+                                          Flinders Street -> Pakenham                                                                                                                   
+                                          Richmond -> Pakenham                                                                                                                          
+                                          Caulfield -> Pakenham                                                                                                                         
+                                          Clayton -> Pakenham                                                                                                                           
+                                          Dandenong -> Pakenham                                                                                                                         
+Pakenham -> Nar Nar Goon                  Pakenham -> Nar Nar Goon                  GIPPSLAND.PAKENHAM -> GIPPSLAND.EAST_PAKENHAM (0.00 -> 1.00)                                        
+                                                                                    GIPPSLAND.EAST_PAKENHAM -> GIPPSLAND.BAIRNSDALE (0.00 -> 0.06)                                      
+Nar Nar Goon -> Tynong                    Nar Nar Goon -> Tynong                    GIPPSLAND.EAST_PAKENHAM -> GIPPSLAND.BAIRNSDALE (0.06 -> 0.13)                                      
+Tynong -> Garfield                        Tynong -> Garfield                        GIPPSLAND.EAST_PAKENHAM -> GIPPSLAND.BAIRNSDALE (0.13 -> 0.19)                                      
+Garfield -> Bunyip                        Garfield -> Bunyip                        GIPPSLAND.EAST_PAKENHAM -> GIPPSLAND.BAIRNSDALE (0.19 -> 0.25)                                      
+Bunyip -> Longwarry                       Bunyip -> Longwarry                       GIPPSLAND.EAST_PAKENHAM -> GIPPSLAND.BAIRNSDALE (0.25 -> 0.31)                                      
+Longwarry -> Drouin                       Longwarry -> Drouin                       GIPPSLAND.EAST_PAKENHAM -> GIPPSLAND.BAIRNSDALE (0.31 -> 0.38)                                      
+Drouin -> Warragul                        Drouin -> Warragul                        GIPPSLAND.EAST_PAKENHAM -> GIPPSLAND.BAIRNSDALE (0.38 -> 0.44)                                      
+Warragul -> Yarragon                      Warragul -> Yarragon                      GIPPSLAND.EAST_PAKENHAM -> GIPPSLAND.BAIRNSDALE (0.44 -> 0.50)                                      
+Yarragon -> Trafalgar                     Yarragon -> Trafalgar                     GIPPSLAND.EAST_PAKENHAM -> GIPPSLAND.BAIRNSDALE (0.50 -> 0.56)                                      
+Trafalgar -> Moe                          Trafalgar -> Moe                          GIPPSLAND.EAST_PAKENHAM -> GIPPSLAND.BAIRNSDALE (0.56 -> 0.63)                                      
+Moe -> Morwell                            Moe -> Morwell                            GIPPSLAND.EAST_PAKENHAM -> GIPPSLAND.BAIRNSDALE (0.63 -> 0.69)                                      
+Morwell -> Traralgon                      Morwell -> Traralgon                      GIPPSLAND.EAST_PAKENHAM -> GIPPSLAND.BAIRNSDALE (0.69 -> 0.75)                                      
+Traralgon -> Rosedale                     Traralgon -> Rosedale                     GIPPSLAND.EAST_PAKENHAM -> GIPPSLAND.BAIRNSDALE (0.75 -> 0.81)                                      
+Rosedale -> Sale                          Rosedale -> Sale                          GIPPSLAND.EAST_PAKENHAM -> GIPPSLAND.BAIRNSDALE (0.81 -> 0.88)                                      
+Sale -> Stratford                         Sale -> Stratford                         GIPPSLAND.EAST_PAKENHAM -> GIPPSLAND.BAIRNSDALE (0.88 -> 0.94)                                      
+Stratford -> Bairnsdale                   Stratford -> Bairnsdale                   GIPPSLAND.EAST_PAKENHAM -> GIPPSLAND.BAIRNSDALE (0.94 -> 1.00)                                      
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+GLEN WAVERLEY
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+"The city" -> Richmond                    Flinders Street -> Richmond               BURNLEY.FLINDERS_STREET_DIRECT -> BURNLEY.RICHMOND (0.00 -> 1.00)                                   
+                                          Flinders Street -> Southern Cross         BURNLEY.FLINDERS_STREET_LOOP -> BURNLEY.SOUTHERN_CROSS (0.00 -> 1.00)                               
+                                          Southern Cross -> Flagstaff               BURNLEY.SOUTHERN_CROSS -> BURNLEY.FLAGSTAFF (0.00 -> 1.00)                                          
+                                          Flagstaff -> Melbourne Central            BURNLEY.FLAGSTAFF -> BURNLEY.MELBOURNE_CENTRAL (0.00 -> 1.00)                                       
+                                          Melbourne Central -> Parliament           BURNLEY.MELBOURNE_CENTRAL -> BURNLEY.PARLIAMENT (0.00 -> 1.00)                                      
+                                          Parliament -> Richmond                    BURNLEY.PARLIAMENT -> BURNLEY.RICHMOND (0.00 -> 1.00)                                               
+Richmond -> East Richmond                 Richmond -> East Richmond                 BURNLEY.RICHMOND -> BURNLEY.BURNLEY (0.00 -> 0.50)                                                  
+East Richmond -> Burnley                  East Richmond -> Burnley                  BURNLEY.RICHMOND -> BURNLEY.BURNLEY (0.50 -> 1.00)                                                  
+Burnley -> Heyington                      Burnley -> Heyington                      BURNLEY.BURNLEY -> BURNLEY.GLEN_WAVERLEY (0.00 -> 0.08)                                             
+Heyington -> Kooyong                      Heyington -> Kooyong                      BURNLEY.BURNLEY -> BURNLEY.GLEN_WAVERLEY (0.08 -> 0.17)                                             
+Kooyong -> Tooronga                       Kooyong -> Tooronga                       BURNLEY.BURNLEY -> BURNLEY.GLEN_WAVERLEY (0.17 -> 0.25)                                             
+Tooronga -> Gardiner                      Tooronga -> Gardiner                      BURNLEY.BURNLEY -> BURNLEY.GLEN_WAVERLEY (0.25 -> 0.33)                                             
+Gardiner -> Glen Iris                     Gardiner -> Glen Iris                     BURNLEY.BURNLEY -> BURNLEY.GLEN_WAVERLEY (0.33 -> 0.42)                                             
+Glen Iris -> Darling                      Glen Iris -> Darling                      BURNLEY.BURNLEY -> BURNLEY.GLEN_WAVERLEY (0.42 -> 0.50)                                             
+Darling -> East Malvern                   Darling -> East Malvern                   BURNLEY.BURNLEY -> BURNLEY.GLEN_WAVERLEY (0.50 -> 0.58)                                             
+East Malvern -> Holmesglen                East Malvern -> Holmesglen                BURNLEY.BURNLEY -> BURNLEY.GLEN_WAVERLEY (0.58 -> 0.67)                                             
+Holmesglen -> Jordanville                 Holmesglen -> Jordanville                 BURNLEY.BURNLEY -> BURNLEY.GLEN_WAVERLEY (0.67 -> 0.75)                                             
+Jordanville -> Mount Waverley             Jordanville -> Mount Waverley             BURNLEY.BURNLEY -> BURNLEY.GLEN_WAVERLEY (0.75 -> 0.83)                                             
+Mount Waverley -> Syndal                  Mount Waverley -> Syndal                  BURNLEY.BURNLEY -> BURNLEY.GLEN_WAVERLEY (0.83 -> 0.92)                                             
+Syndal -> Glen Waverley                   Syndal -> Glen Waverley                   BURNLEY.BURNLEY -> BURNLEY.GLEN_WAVERLEY (0.92 -> 1.00)                                             
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+HURSTBRIDGE
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+"The city" -> Jolimont                    Flinders Street -> Jolimont               CLIFTON_HILL.FLINDERS_STREET_DIRECT -> CLIFTON_HILL.JOLIMONT (0.00 -> 1.00)                         
+                                          Flinders Street -> Southern Cross         CLIFTON_HILL.FLINDERS_STREET_LOOP -> CLIFTON_HILL.SOUTHERN_CROSS (0.00 -> 1.00)                     
+                                          Southern Cross -> Flagstaff               CLIFTON_HILL.SOUTHERN_CROSS -> CLIFTON_HILL.FLAGSTAFF (0.00 -> 1.00)                                
+                                          Flagstaff -> Melbourne Central            CLIFTON_HILL.FLAGSTAFF -> CLIFTON_HILL.MELBOURNE_CENTRAL (0.00 -> 1.00)                             
+                                          Melbourne Central -> Parliament           CLIFTON_HILL.MELBOURNE_CENTRAL -> CLIFTON_HILL.PARLIAMENT (0.00 -> 1.00)                            
+                                          Parliament -> Jolimont                    CLIFTON_HILL.PARLIAMENT -> CLIFTON_HILL.JOLIMONT (0.00 -> 1.00)                                     
+Jolimont -> West Richmond                 Jolimont -> West Richmond                 CLIFTON_HILL.JOLIMONT -> CLIFTON_HILL.CLIFTON_HILL (0.00 -> 0.20)                                   
+West Richmond -> North Richmond           West Richmond -> North Richmond           CLIFTON_HILL.JOLIMONT -> CLIFTON_HILL.CLIFTON_HILL (0.20 -> 0.40)                                   
+North Richmond -> Collingwood             North Richmond -> Collingwood             CLIFTON_HILL.JOLIMONT -> CLIFTON_HILL.CLIFTON_HILL (0.40 -> 0.60)                                   
+Collingwood -> Victoria Park              Collingwood -> Victoria Park              CLIFTON_HILL.JOLIMONT -> CLIFTON_HILL.CLIFTON_HILL (0.60 -> 0.80)                                   
+Victoria Park -> Clifton Hill             Victoria Park -> Clifton Hill             CLIFTON_HILL.JOLIMONT -> CLIFTON_HILL.CLIFTON_HILL (0.80 -> 1.00)                                   
+Clifton Hill -> Westgarth                 Clifton Hill -> Westgarth                 CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.HURSTBRIDGE (0.00 -> 0.06)                                
+Westgarth -> Dennis                       Westgarth -> Dennis                       CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.HURSTBRIDGE (0.06 -> 0.12)                                
+Dennis -> Fairfield                       Dennis -> Fairfield                       CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.HURSTBRIDGE (0.12 -> 0.18)                                
+Fairfield -> Alphington                   Fairfield -> Alphington                   CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.HURSTBRIDGE (0.18 -> 0.24)                                
+Alphington -> Darebin                     Alphington -> Darebin                     CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.HURSTBRIDGE (0.24 -> 0.29)                                
+Darebin -> Ivanhoe                        Darebin -> Ivanhoe                        CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.HURSTBRIDGE (0.29 -> 0.35)                                
+Ivanhoe -> Eaglemont                      Ivanhoe -> Eaglemont                      CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.HURSTBRIDGE (0.35 -> 0.41)                                
+Eaglemont -> Heidelberg                   Eaglemont -> Heidelberg                   CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.HURSTBRIDGE (0.41 -> 0.47)                                
+Heidelberg -> Rosanna                     Heidelberg -> Rosanna                     CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.HURSTBRIDGE (0.47 -> 0.53)                                
+Rosanna -> Macleod                        Rosanna -> Macleod                        CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.HURSTBRIDGE (0.53 -> 0.59)                                
+Macleod -> Watsonia                       Macleod -> Watsonia                       CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.HURSTBRIDGE (0.59 -> 0.65)                                
+Watsonia -> Greensborough                 Watsonia -> Greensborough                 CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.HURSTBRIDGE (0.65 -> 0.71)                                
+Greensborough -> Montmorency              Greensborough -> Montmorency              CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.HURSTBRIDGE (0.71 -> 0.76)                                
+Montmorency -> Eltham                     Montmorency -> Eltham                     CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.HURSTBRIDGE (0.76 -> 0.82)                                
+Eltham -> Diamond Creek                   Eltham -> Diamond Creek                   CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.HURSTBRIDGE (0.82 -> 0.88)                                
+Diamond Creek -> Wattle Glen              Diamond Creek -> Wattle Glen              CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.HURSTBRIDGE (0.88 -> 0.94)                                
+Wattle Glen -> Hurstbridge                Wattle Glen -> Hurstbridge                CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.HURSTBRIDGE (0.94 -> 1.00)                                
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+LILYDALE
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+"The city" -> Richmond                    Flinders Street -> Richmond               BURNLEY.FLINDERS_STREET_DIRECT -> BURNLEY.RICHMOND (0.00 -> 1.00)                                   
+                                          Flinders Street -> Southern Cross         BURNLEY.FLINDERS_STREET_LOOP -> BURNLEY.SOUTHERN_CROSS (0.00 -> 1.00)                               
+                                          Southern Cross -> Flagstaff               BURNLEY.SOUTHERN_CROSS -> BURNLEY.FLAGSTAFF (0.00 -> 1.00)                                          
+                                          Flagstaff -> Melbourne Central            BURNLEY.FLAGSTAFF -> BURNLEY.MELBOURNE_CENTRAL (0.00 -> 1.00)                                       
+                                          Melbourne Central -> Parliament           BURNLEY.MELBOURNE_CENTRAL -> BURNLEY.PARLIAMENT (0.00 -> 1.00)                                      
+                                          Parliament -> Richmond                    BURNLEY.PARLIAMENT -> BURNLEY.RICHMOND (0.00 -> 1.00)                                               
+Richmond -> East Richmond                 Richmond -> East Richmond                 BURNLEY.RICHMOND -> BURNLEY.BURNLEY (0.00 -> 0.50)                                                  
+East Richmond -> Burnley                  East Richmond -> Burnley                  BURNLEY.RICHMOND -> BURNLEY.BURNLEY (0.50 -> 1.00)                                                  
+Burnley -> Hawthorn                       Burnley -> Hawthorn                       BURNLEY.BURNLEY -> BURNLEY.CAMBERWELL (0.00 -> 0.25)                                                
+Hawthorn -> Glenferrie                    Hawthorn -> Glenferrie                    BURNLEY.BURNLEY -> BURNLEY.CAMBERWELL (0.25 -> 0.50)                                                
+Glenferrie -> Auburn                      Glenferrie -> Auburn                      BURNLEY.BURNLEY -> BURNLEY.CAMBERWELL (0.50 -> 0.75)                                                
+Auburn -> Camberwell                      Auburn -> Camberwell                      BURNLEY.BURNLEY -> BURNLEY.CAMBERWELL (0.75 -> 1.00)                                                
+Camberwell -> East Camberwell             Camberwell -> East Camberwell             BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.00 -> 0.09)                                               
+East Camberwell -> Canterbury             East Camberwell -> Canterbury             BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.09 -> 0.18)                                               
+Canterbury -> Chatham                     Canterbury -> Chatham                     BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.18 -> 0.27)                                               
+Chatham -> Union                          Chatham -> Union                          BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.27 -> 0.36)                                               
+Union -> Box Hill                         Union -> Box Hill                         BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.36 -> 0.45)                                               
+Box Hill -> Laburnum                      Box Hill -> Laburnum                      BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.45 -> 0.55)                                               
+Laburnum -> Blackburn                     Laburnum -> Blackburn                     BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.55 -> 0.64)                                               
+Blackburn -> Nunawading                   Blackburn -> Nunawading                   BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.64 -> 0.73)                                               
+Nunawading -> Mitcham                     Nunawading -> Mitcham                     BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.73 -> 0.82)                                               
+Mitcham -> Heatherdale                    Mitcham -> Heatherdale                    BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.82 -> 0.91)                                               
+Heatherdale -> Ringwood                   Heatherdale -> Ringwood                   BURNLEY.CAMBERWELL -> BURNLEY.RINGWOOD (0.91 -> 1.00)                                               
+Ringwood -> Ringwood East                 Ringwood -> Ringwood East                 BURNLEY.RINGWOOD -> BURNLEY.LILYDALE (0.00 -> 0.25)                                                 
+Ringwood East -> Croydon                  Ringwood East -> Croydon                  BURNLEY.RINGWOOD -> BURNLEY.LILYDALE (0.25 -> 0.50)                                                 
+Croydon -> Mooroolbark                    Croydon -> Mooroolbark                    BURNLEY.RINGWOOD -> BURNLEY.LILYDALE (0.50 -> 0.75)                                                 
+Mooroolbark -> Lilydale                   Mooroolbark -> Lilydale                   BURNLEY.RINGWOOD -> BURNLEY.LILYDALE (0.75 -> 1.00)                                                 
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+MERNDA
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+"The city" -> Jolimont                    Flinders Street -> Jolimont               CLIFTON_HILL.FLINDERS_STREET_DIRECT -> CLIFTON_HILL.JOLIMONT (0.00 -> 1.00)                         
+                                          Flinders Street -> Southern Cross         CLIFTON_HILL.FLINDERS_STREET_LOOP -> CLIFTON_HILL.SOUTHERN_CROSS (0.00 -> 1.00)                     
+                                          Southern Cross -> Flagstaff               CLIFTON_HILL.SOUTHERN_CROSS -> CLIFTON_HILL.FLAGSTAFF (0.00 -> 1.00)                                
+                                          Flagstaff -> Melbourne Central            CLIFTON_HILL.FLAGSTAFF -> CLIFTON_HILL.MELBOURNE_CENTRAL (0.00 -> 1.00)                             
+                                          Melbourne Central -> Parliament           CLIFTON_HILL.MELBOURNE_CENTRAL -> CLIFTON_HILL.PARLIAMENT (0.00 -> 1.00)                            
+                                          Parliament -> Jolimont                    CLIFTON_HILL.PARLIAMENT -> CLIFTON_HILL.JOLIMONT (0.00 -> 1.00)                                     
+Jolimont -> West Richmond                 Jolimont -> West Richmond                 CLIFTON_HILL.JOLIMONT -> CLIFTON_HILL.CLIFTON_HILL (0.00 -> 0.20)                                   
+West Richmond -> North Richmond           West Richmond -> North Richmond           CLIFTON_HILL.JOLIMONT -> CLIFTON_HILL.CLIFTON_HILL (0.20 -> 0.40)                                   
+North Richmond -> Collingwood             North Richmond -> Collingwood             CLIFTON_HILL.JOLIMONT -> CLIFTON_HILL.CLIFTON_HILL (0.40 -> 0.60)                                   
+Collingwood -> Victoria Park              Collingwood -> Victoria Park              CLIFTON_HILL.JOLIMONT -> CLIFTON_HILL.CLIFTON_HILL (0.60 -> 0.80)                                   
+Victoria Park -> Clifton Hill             Victoria Park -> Clifton Hill             CLIFTON_HILL.JOLIMONT -> CLIFTON_HILL.CLIFTON_HILL (0.80 -> 1.00)                                   
+Clifton Hill -> Rushall                   Clifton Hill -> Rushall                   CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.00 -> 0.06)                                     
+Rushall -> Merri                          Rushall -> Merri                          CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.06 -> 0.11)                                     
+Merri -> Northcote                        Merri -> Northcote                        CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.11 -> 0.17)                                     
+Northcote -> Croxton                      Northcote -> Croxton                      CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.17 -> 0.22)                                     
+Croxton -> Thornbury                      Croxton -> Thornbury                      CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.22 -> 0.28)                                     
+Thornbury -> Bell                         Thornbury -> Bell                         CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.28 -> 0.33)                                     
+Bell -> Preston                           Bell -> Preston                           CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.33 -> 0.39)                                     
+Preston -> Regent                         Preston -> Regent                         CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.39 -> 0.44)                                     
+Regent -> Reservoir                       Regent -> Reservoir                       CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.44 -> 0.50)                                     
+Reservoir -> Ruthven                      Reservoir -> Ruthven                      CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.50 -> 0.56)                                     
+Ruthven -> Keon Park                      Ruthven -> Keon Park                      CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.56 -> 0.61)                                     
+Keon Park -> Thomastown                   Keon Park -> Thomastown                   CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.61 -> 0.67)                                     
+Thomastown -> Lalor                       Thomastown -> Lalor                       CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.67 -> 0.72)                                     
+Lalor -> Epping                           Lalor -> Epping                           CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.72 -> 0.78)                                     
+Epping -> South Morang                    Epping -> South Morang                    CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.78 -> 0.83)                                     
+South Morang -> Middle Gorge              South Morang -> Middle Gorge              CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.83 -> 0.89)                                     
+Middle Gorge -> Hawkstowe                 Middle Gorge -> Hawkstowe                 CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.89 -> 0.94)                                     
+Hawkstowe -> Mernda                       Hawkstowe -> Mernda                       CLIFTON_HILL.CLIFTON_HILL -> CLIFTON_HILL.MERNDA (0.94 -> 1.00)                                     
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+PAKENHAM
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+"The city" -> Richmond                    Flinders Street -> Richmond               DANDENONG.FLINDERS_STREET_DIRECT -> DANDENONG.RICHMOND (0.00 -> 1.00)                               
+                                          Flinders Street -> Southern Cross         DANDENONG.FLINDERS_STREET_LOOP -> DANDENONG.SOUTHERN_CROSS (0.00 -> 1.00)                           
+                                          Southern Cross -> Flagstaff               DANDENONG.SOUTHERN_CROSS -> DANDENONG.FLAGSTAFF (0.00 -> 1.00)                                      
+                                          Flagstaff -> Melbourne Central            DANDENONG.FLAGSTAFF -> DANDENONG.MELBOURNE_CENTRAL (0.00 -> 1.00)                                   
+                                          Melbourne Central -> Parliament           DANDENONG.MELBOURNE_CENTRAL -> DANDENONG.PARLIAMENT (0.00 -> 1.00)                                  
+                                          Parliament -> Richmond                    DANDENONG.PARLIAMENT -> DANDENONG.RICHMOND (0.00 -> 1.00)                                           
+Richmond -> South Yarra                   Richmond -> South Yarra                   DANDENONG.RICHMOND -> DANDENONG.SOUTH_YARRA (0.00 -> 1.00)                                          
+South Yarra -> Caulfield                  South Yarra -> Caulfield                  DANDENONG.SOUTH_YARRA -> DANDENONG.CAULFIELD (0.00 -> 1.00)                                         
+Caulfield -> Carnegie                     Caulfield -> Carnegie                     DANDENONG.CAULFIELD -> DANDENONG.CLAYTON (0.00 -> 0.17)                                             
+Carnegie -> Murrumbeena                   Carnegie -> Murrumbeena                   DANDENONG.CAULFIELD -> DANDENONG.CLAYTON (0.17 -> 0.33)                                             
+Murrumbeena -> Hughesdale                 Murrumbeena -> Hughesdale                 DANDENONG.CAULFIELD -> DANDENONG.CLAYTON (0.33 -> 0.50)                                             
+Hughesdale -> Oakleigh                    Hughesdale -> Oakleigh                    DANDENONG.CAULFIELD -> DANDENONG.CLAYTON (0.50 -> 0.67)                                             
+Oakleigh -> Huntingdale                   Oakleigh -> Huntingdale                   DANDENONG.CAULFIELD -> DANDENONG.CLAYTON (0.67 -> 0.83)                                             
+Huntingdale -> Clayton                    Huntingdale -> Clayton                    DANDENONG.CAULFIELD -> DANDENONG.CLAYTON (0.83 -> 1.00)                                             
+Clayton -> Westall                        Clayton -> Westall                        DANDENONG.CLAYTON -> DANDENONG.DANDENONG (0.00 -> 0.17)                                             
+Westall -> Springvale                     Westall -> Springvale                     DANDENONG.CLAYTON -> DANDENONG.DANDENONG (0.17 -> 0.33)                                             
+Springvale -> Sandown Park                Springvale -> Sandown Park                DANDENONG.CLAYTON -> DANDENONG.DANDENONG (0.33 -> 0.50)                                             
+Sandown Park -> Noble Park                Sandown Park -> Noble Park                DANDENONG.CLAYTON -> DANDENONG.DANDENONG (0.50 -> 0.67)                                             
+Noble Park -> Yarraman                    Noble Park -> Yarraman                    DANDENONG.CLAYTON -> DANDENONG.DANDENONG (0.67 -> 0.83)                                             
+Yarraman -> Dandenong                     Yarraman -> Dandenong                     DANDENONG.CLAYTON -> DANDENONG.DANDENONG (0.83 -> 1.00)                                             
+Dandenong -> Hallam                       Dandenong -> Hallam                       DANDENONG.DANDENONG -> DANDENONG.PAKENHAM (0.00 -> 0.14)                                            
+Hallam -> Narre Warren                    Hallam -> Narre Warren                    DANDENONG.DANDENONG -> DANDENONG.PAKENHAM (0.14 -> 0.29)                                            
+Narre Warren -> Berwick                   Narre Warren -> Berwick                   DANDENONG.DANDENONG -> DANDENONG.PAKENHAM (0.29 -> 0.43)                                            
+Berwick -> Beaconsfield                   Berwick -> Beaconsfield                   DANDENONG.DANDENONG -> DANDENONG.PAKENHAM (0.43 -> 0.57)                                            
+Beaconsfield -> Officer                   Beaconsfield -> Officer                   DANDENONG.DANDENONG -> DANDENONG.PAKENHAM (0.57 -> 0.71)                                            
+Officer -> Cardinia Road                  Officer -> Cardinia Road                  DANDENONG.DANDENONG -> DANDENONG.PAKENHAM (0.71 -> 0.86)                                            
+Cardinia Road -> Pakenham                 Cardinia Road -> Pakenham                 DANDENONG.DANDENONG -> DANDENONG.PAKENHAM (0.86 -> 1.00)                                            
+Pakenham -> East Pakenham                 Pakenham -> East Pakenham                 DANDENONG.PAKENHAM -> DANDENONG.EAST_PAKENHAM (0.00 -> 1.00)                                        
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+SANDRINGHAM
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Flinders Street -> Richmond               Flinders Street -> Richmond               SANDRINGHAM.FLINDERS_STREET -> SANDRINGHAM.RICHMOND (0.00 -> 1.00)                                  
+Richmond -> South Yarra                   Richmond -> South Yarra                   SANDRINGHAM.RICHMOND -> SANDRINGHAM.SOUTH_YARRA (0.00 -> 1.00)                                      
+South Yarra -> Prahran                    South Yarra -> Prahran                    SANDRINGHAM.SOUTH_YARRA -> SANDRINGHAM.SANDRINGHAM (0.00 -> 0.09)                                   
+Prahran -> Windsor                        Prahran -> Windsor                        SANDRINGHAM.SOUTH_YARRA -> SANDRINGHAM.SANDRINGHAM (0.09 -> 0.18)                                   
+Windsor -> Balaclava                      Windsor -> Balaclava                      SANDRINGHAM.SOUTH_YARRA -> SANDRINGHAM.SANDRINGHAM (0.18 -> 0.27)                                   
+Balaclava -> Ripponlea                    Balaclava -> Ripponlea                    SANDRINGHAM.SOUTH_YARRA -> SANDRINGHAM.SANDRINGHAM (0.27 -> 0.36)                                   
+Ripponlea -> Elsternwick                  Ripponlea -> Elsternwick                  SANDRINGHAM.SOUTH_YARRA -> SANDRINGHAM.SANDRINGHAM (0.36 -> 0.45)                                   
+Elsternwick -> Gardenvale                 Elsternwick -> Gardenvale                 SANDRINGHAM.SOUTH_YARRA -> SANDRINGHAM.SANDRINGHAM (0.45 -> 0.55)                                   
+Gardenvale -> North Brighton              Gardenvale -> North Brighton              SANDRINGHAM.SOUTH_YARRA -> SANDRINGHAM.SANDRINGHAM (0.55 -> 0.64)                                   
+North Brighton -> Middle Brighton         North Brighton -> Middle Brighton         SANDRINGHAM.SOUTH_YARRA -> SANDRINGHAM.SANDRINGHAM (0.64 -> 0.73)                                   
+Middle Brighton -> Brighton Beach         Middle Brighton -> Brighton Beach         SANDRINGHAM.SOUTH_YARRA -> SANDRINGHAM.SANDRINGHAM (0.73 -> 0.82)                                   
+Brighton Beach -> Hampton                 Brighton Beach -> Hampton                 SANDRINGHAM.SOUTH_YARRA -> SANDRINGHAM.SANDRINGHAM (0.82 -> 0.91)                                   
+Hampton -> Sandringham                    Hampton -> Sandringham                    SANDRINGHAM.SOUTH_YARRA -> SANDRINGHAM.SANDRINGHAM (0.91 -> 1.00)                                   
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+SEYMOUR
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Southern Cross -> North Melbourne         Southern Cross -> Donnybrook              REGIONAL_WESTERN.SOUTHERN_CROSS -> REGIONAL_WESTERN.NORTH_MELBOURNE_JUNCTION (0.00 -> 1.00)         
+                                                                                    REGIONAL_WESTERN.NORTH_MELBOURNE_JUNCTION -> REGIONAL_WESTERN.NORTH_MELBOURNE_SEYMOUR (0.00 -> 1.00)
+North Melbourne -> Broadmeadows           Southern Cross -> Donnybrook              REGIONAL_WESTERN.NORTH_MELBOURNE_SEYMOUR -> REGIONAL_WESTERN.BROADMEADOWS (0.00 -> 1.00)            
+                                          North Melbourne -> Donnybrook                                                                                                                 
+Broadmeadows -> Craigieburn               Southern Cross -> Donnybrook              REGIONAL_WESTERN.BROADMEADOWS -> REGIONAL_WESTERN.CRAIGIEBURN (0.00 -> 1.00)                        
+                                          North Melbourne -> Donnybrook                                                                                                                 
+                                          Broadmeadows -> Donnybrook                                                                                                                    
+Craigieburn -> Donnybrook                 Southern Cross -> Donnybrook              REGIONAL_WESTERN.CRAIGIEBURN -> REGIONAL_WESTERN.SEYMOUR (0.00 -> 0.13)                             
+                                          North Melbourne -> Donnybrook                                                                                                                 
+                                          Broadmeadows -> Donnybrook                                                                                                                    
+                                          Craigieburn -> Donnybrook                                                                                                                     
+Donnybrook -> Wallan                      Donnybrook -> Wallan                      REGIONAL_WESTERN.CRAIGIEBURN -> REGIONAL_WESTERN.SEYMOUR (0.13 -> 0.25)                             
+Wallan -> Heathcote Junction              Wallan -> Heathcote Junction              REGIONAL_WESTERN.CRAIGIEBURN -> REGIONAL_WESTERN.SEYMOUR (0.25 -> 0.38)                             
+Heathcote Junction -> Wandong             Heathcote Junction -> Wandong             REGIONAL_WESTERN.CRAIGIEBURN -> REGIONAL_WESTERN.SEYMOUR (0.38 -> 0.50)                             
+Wandong -> Kilmore East                   Wandong -> Kilmore East                   REGIONAL_WESTERN.CRAIGIEBURN -> REGIONAL_WESTERN.SEYMOUR (0.50 -> 0.63)                             
+Kilmore East -> Broadford                 Kilmore East -> Broadford                 REGIONAL_WESTERN.CRAIGIEBURN -> REGIONAL_WESTERN.SEYMOUR (0.63 -> 0.75)                             
+Broadford -> Tallarook                    Broadford -> Tallarook                    REGIONAL_WESTERN.CRAIGIEBURN -> REGIONAL_WESTERN.SEYMOUR (0.75 -> 0.88)                             
+Tallarook -> Seymour                      Tallarook -> Seymour                      REGIONAL_WESTERN.CRAIGIEBURN -> REGIONAL_WESTERN.SEYMOUR (0.88 -> 1.00)                             
+Seymour -> Avenel                         Seymour -> Avenel                         REGIONAL_WESTERN.SEYMOUR -> REGIONAL_WESTERN.ALBURY (0.00 -> 0.11)                                  
+Avenel -> Euroa                           Avenel -> Euroa                           REGIONAL_WESTERN.SEYMOUR -> REGIONAL_WESTERN.ALBURY (0.11 -> 0.22)                                  
+Euroa -> Violet Town                      Euroa -> Violet Town                      REGIONAL_WESTERN.SEYMOUR -> REGIONAL_WESTERN.ALBURY (0.22 -> 0.33)                                  
+Violet Town -> Benalla                    Violet Town -> Benalla                    REGIONAL_WESTERN.SEYMOUR -> REGIONAL_WESTERN.ALBURY (0.33 -> 0.44)                                  
+Benalla -> Wangaratta                     Benalla -> Wangaratta                     REGIONAL_WESTERN.SEYMOUR -> REGIONAL_WESTERN.ALBURY (0.44 -> 0.56)                                  
+Wangaratta -> Springhurst                 Wangaratta -> Springhurst                 REGIONAL_WESTERN.SEYMOUR -> REGIONAL_WESTERN.ALBURY (0.56 -> 0.67)                                  
+Springhurst -> Chiltern                   Springhurst -> Chiltern                   REGIONAL_WESTERN.SEYMOUR -> REGIONAL_WESTERN.ALBURY (0.67 -> 0.78)                                  
+Chiltern -> Wodonga                       Chiltern -> Wodonga                       REGIONAL_WESTERN.SEYMOUR -> REGIONAL_WESTERN.ALBURY (0.78 -> 0.89)                                  
+Wodonga -> Albury                         Wodonga -> Albury                         REGIONAL_WESTERN.SEYMOUR -> REGIONAL_WESTERN.ALBURY (0.89 -> 1.00)                                  
+Seymour -> Nagambie                       Seymour -> Nagambie                       REGIONAL_WESTERN.SEYMOUR -> REGIONAL_WESTERN.SHEPPARTON (0.00 -> 0.25)                              
+Nagambie -> Murchison East                Nagambie -> Murchison East                REGIONAL_WESTERN.SEYMOUR -> REGIONAL_WESTERN.SHEPPARTON (0.25 -> 0.50)                              
+Murchison East -> Mooroopna               Murchison East -> Mooroopna               REGIONAL_WESTERN.SEYMOUR -> REGIONAL_WESTERN.SHEPPARTON (0.50 -> 0.75)                              
+Mooroopna -> Shepparton                   Mooroopna -> Shepparton                   REGIONAL_WESTERN.SEYMOUR -> REGIONAL_WESTERN.SHEPPARTON (0.75 -> 1.00)                              
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+STONY POINT
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Frankston -> Leawarra                     Frankston -> Leawarra                     STONY_POINT.FRANKSTON -> STONY_POINT.STONY_POINT (0.00 -> 0.11)                                     
+Leawarra -> Baxter                        Leawarra -> Baxter                        STONY_POINT.FRANKSTON -> STONY_POINT.STONY_POINT (0.11 -> 0.22)                                     
+Baxter -> Somerville                      Baxter -> Somerville                      STONY_POINT.FRANKSTON -> STONY_POINT.STONY_POINT (0.22 -> 0.33)                                     
+Somerville -> Tyabb                       Somerville -> Tyabb                       STONY_POINT.FRANKSTON -> STONY_POINT.STONY_POINT (0.33 -> 0.44)                                     
+Tyabb -> Hastings                         Tyabb -> Hastings                         STONY_POINT.FRANKSTON -> STONY_POINT.STONY_POINT (0.44 -> 0.56)                                     
+Hastings -> Bittern                       Hastings -> Bittern                       STONY_POINT.FRANKSTON -> STONY_POINT.STONY_POINT (0.56 -> 0.67)                                     
+Bittern -> Morradoo                       Bittern -> Morradoo                       STONY_POINT.FRANKSTON -> STONY_POINT.STONY_POINT (0.67 -> 0.78)                                     
+Morradoo -> Crib Point                    Morradoo -> Crib Point                    STONY_POINT.FRANKSTON -> STONY_POINT.STONY_POINT (0.78 -> 0.89)                                     
+Crib Point -> Stony Point                 Crib Point -> Stony Point                 STONY_POINT.FRANKSTON -> STONY_POINT.STONY_POINT (0.89 -> 1.00)                                     
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+SUNBURY
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+"The city" -> North Melbourne             Flinders Street -> Southern Cross         NORTHERN.FLINDERS_STREET_DIRECT -> NORTHERN.SOUTHERN_CROSS (0.00 -> 1.00)                           
+                                          Southern Cross -> North Melbourne         NORTHERN.SOUTHERN_CROSS -> NORTHERN.NORTH_MELBOURNE (0.00 -> 1.00)                                  
+                                          Flinders Street -> Parliament             NORTHERN.FLAGSTAFF -> NORTHERN.NORTH_MELBOURNE (0.00 -> 1.00)                                       
+                                          Parliament -> Melbourne Central           NORTHERN.MELBOURNE_CENTRAL -> NORTHERN.FLAGSTAFF (0.00 -> 1.00)                                     
+                                          Melbourne Central -> Flagstaff            NORTHERN.PARLIAMENT -> NORTHERN.MELBOURNE_CENTRAL (0.00 -> 1.00)                                    
+                                          Flagstaff -> North Melbourne              NORTHERN.FLINDERS_STREET_LOOP -> NORTHERN.PARLIAMENT (0.00 -> 1.00)                                 
+North Melbourne -> Footscray              North Melbourne -> Footscray              NORTHERN.NORTH_MELBOURNE -> NORTHERN.FOOTSCRAY (0.00 -> 1.00)                                       
+Footscray -> Middle Footscray             Footscray -> Middle Footscray             NORTHERN.FOOTSCRAY -> NORTHERN.SUNSHINE_JUNCTION (0.00 -> 0.25)                                     
+Middle Footscray -> West Footscray        Middle Footscray -> West Footscray        NORTHERN.FOOTSCRAY -> NORTHERN.SUNSHINE_JUNCTION (0.25 -> 0.50)                                     
+West Footscray -> Tottenham               West Footscray -> Tottenham               NORTHERN.FOOTSCRAY -> NORTHERN.SUNSHINE_JUNCTION (0.50 -> 0.75)                                     
+Tottenham -> Sunshine                     Tottenham -> Sunshine                     NORTHERN.FOOTSCRAY -> NORTHERN.SUNSHINE_JUNCTION (0.75 -> 1.00)                                     
+                                                                                    NORTHERN.SUNSHINE_JUNCTION -> NORTHERN.SUNSHINE (0.00 -> 1.00)                                      
+Sunshine -> Albion                        Sunshine -> Albion                        NORTHERN.SUNSHINE -> NORTHERN.WATERGARDENS (0.00 -> 0.20)                                           
+Albion -> Ginifer                         Albion -> Ginifer                         NORTHERN.SUNSHINE -> NORTHERN.WATERGARDENS (0.20 -> 0.40)                                           
+Ginifer -> St Albans                      Ginifer -> St Albans                      NORTHERN.SUNSHINE -> NORTHERN.WATERGARDENS (0.40 -> 0.60)                                           
+St Albans -> Keilor Plains                St Albans -> Keilor Plains                NORTHERN.SUNSHINE -> NORTHERN.WATERGARDENS (0.60 -> 0.80)                                           
+Keilor Plains -> Watergardens             Keilor Plains -> Watergardens             NORTHERN.SUNSHINE -> NORTHERN.WATERGARDENS (0.80 -> 1.00)                                           
+Watergardens -> Diggers Rest              Watergardens -> Diggers Rest              NORTHERN.WATERGARDENS -> NORTHERN.SUNBURY (0.00 -> 0.50)                                            
+Diggers Rest -> Sunbury                   Diggers Rest -> Sunbury                   NORTHERN.WATERGARDENS -> NORTHERN.SUNBURY (0.50 -> 1.00)                                            
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+UPFIELD
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+"The city" -> North Melbourne             Flinders Street -> Southern Cross         NORTHERN.FLINDERS_STREET_DIRECT -> NORTHERN.SOUTHERN_CROSS (0.00 -> 1.00)                           
+                                          Southern Cross -> North Melbourne         NORTHERN.SOUTHERN_CROSS -> NORTHERN.NORTH_MELBOURNE (0.00 -> 1.00)                                  
+                                          Flinders Street -> Parliament             NORTHERN.FLAGSTAFF -> NORTHERN.NORTH_MELBOURNE (0.00 -> 1.00)                                       
+                                          Parliament -> Melbourne Central           NORTHERN.MELBOURNE_CENTRAL -> NORTHERN.FLAGSTAFF (0.00 -> 1.00)                                     
+                                          Melbourne Central -> Flagstaff            NORTHERN.PARLIAMENT -> NORTHERN.MELBOURNE_CENTRAL (0.00 -> 1.00)                                    
+                                          Flagstaff -> North Melbourne              NORTHERN.FLINDERS_STREET_LOOP -> NORTHERN.PARLIAMENT (0.00 -> 1.00)                                 
+North Melbourne -> Macaulay               North Melbourne -> Macaulay               NORTHERN.NORTH_MELBOURNE -> NORTHERN.UPFIELD (0.00 -> 0.08)                                         
+Macaulay -> Flemington Bridge             Macaulay -> Flemington Bridge             NORTHERN.NORTH_MELBOURNE -> NORTHERN.UPFIELD (0.08 -> 0.15)                                         
+Flemington Bridge -> Royal Park           Flemington Bridge -> Royal Park           NORTHERN.NORTH_MELBOURNE -> NORTHERN.UPFIELD (0.15 -> 0.23)                                         
+Royal Park -> Jewell                      Royal Park -> Jewell                      NORTHERN.NORTH_MELBOURNE -> NORTHERN.UPFIELD (0.23 -> 0.31)                                         
+Jewell -> Brunswick                       Jewell -> Brunswick                       NORTHERN.NORTH_MELBOURNE -> NORTHERN.UPFIELD (0.31 -> 0.38)                                         
+Brunswick -> Anstey                       Brunswick -> Anstey                       NORTHERN.NORTH_MELBOURNE -> NORTHERN.UPFIELD (0.38 -> 0.46)                                         
+Anstey -> Moreland                        Anstey -> Moreland                        NORTHERN.NORTH_MELBOURNE -> NORTHERN.UPFIELD (0.46 -> 0.54)                                         
+Moreland -> Coburg                        Moreland -> Coburg                        NORTHERN.NORTH_MELBOURNE -> NORTHERN.UPFIELD (0.54 -> 0.62)                                         
+Coburg -> Batman                          Coburg -> Batman                          NORTHERN.NORTH_MELBOURNE -> NORTHERN.UPFIELD (0.62 -> 0.69)                                         
+Batman -> Merlynston                      Batman -> Merlynston                      NORTHERN.NORTH_MELBOURNE -> NORTHERN.UPFIELD (0.69 -> 0.77)                                         
+Merlynston -> Fawkner                     Merlynston -> Fawkner                     NORTHERN.NORTH_MELBOURNE -> NORTHERN.UPFIELD (0.77 -> 0.85)                                         
+Fawkner -> Gowrie                         Fawkner -> Gowrie                         NORTHERN.NORTH_MELBOURNE -> NORTHERN.UPFIELD (0.85 -> 0.92)                                         
+Gowrie -> Upfield                         Gowrie -> Upfield                         NORTHERN.NORTH_MELBOURNE -> NORTHERN.UPFIELD (0.92 -> 1.00)                                         
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+WERRIBEE
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Flinders Street -> Southern Cross         Flinders Street -> Southern Cross         NEWPORT.FLINDERS_STREET -> NEWPORT.SOUTHERN_CROSS (0.00 -> 1.00)                                    
+Southern Cross -> North Melbourne         Southern Cross -> North Melbourne         NEWPORT.SOUTHERN_CROSS -> NEWPORT.NORTH_MELBOURNE (0.00 -> 1.00)                                    
+North Melbourne -> South Kensington       North Melbourne -> South Kensington       NEWPORT.NORTH_MELBOURNE -> NEWPORT.FOOTSCRAY (0.00 -> 0.50)                                         
+South Kensington -> Footscray             South Kensington -> Footscray             NEWPORT.NORTH_MELBOURNE -> NEWPORT.FOOTSCRAY (0.50 -> 1.00)                                         
+Footscray -> Seddon                       Footscray -> Seddon                       NEWPORT.FOOTSCRAY -> NEWPORT.NEWPORT (0.00 -> 0.25)                                                 
+Seddon -> Yarraville                      Seddon -> Yarraville                      NEWPORT.FOOTSCRAY -> NEWPORT.NEWPORT (0.25 -> 0.50)                                                 
+Yarraville -> Spotswood                   Yarraville -> Spotswood                   NEWPORT.FOOTSCRAY -> NEWPORT.NEWPORT (0.50 -> 0.75)                                                 
+Spotswood -> Newport                      Spotswood -> Newport                      NEWPORT.FOOTSCRAY -> NEWPORT.NEWPORT (0.75 -> 1.00)                                                 
+Newport -> Laverton                       Newport -> Seaholme                       NEWPORT.NEWPORT -> NEWPORT.LAVERTON_LOOP (0.00 -> 1.00)                                             
+                                          Seaholme -> Altona                        NEWPORT.NEWPORT -> NEWPORT.LAVERTON_EXPRESS (0.00 -> 1.00)                                          
+                                          Altona -> Westona                                                                                                                             
+                                          Westona -> Laverton                                                                                                                           
+                                          Newport -> Laverton                                                                                                                           
+Laverton -> Aircraft                      Laverton -> Aircraft                      NEWPORT.LAVERTON_LOOP -> NEWPORT.WERRIBEE (0.00 -> 0.25)                                            
+Aircraft -> Williams Landing              Aircraft -> Williams Landing              NEWPORT.LAVERTON_LOOP -> NEWPORT.WERRIBEE (0.25 -> 0.50)                                            
+Williams Landing -> Hoppers Crossing      Williams Landing -> Hoppers Crossing      NEWPORT.LAVERTON_LOOP -> NEWPORT.WERRIBEE (0.50 -> 0.75)                                            
+Hoppers Crossing -> Werribee              Hoppers Crossing -> Werribee              NEWPORT.LAVERTON_LOOP -> NEWPORT.WERRIBEE (0.75 -> 1.00)                                            
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+WILLIAMSTOWN
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Flinders Street -> Southern Cross         Flinders Street -> Southern Cross         NEWPORT.FLINDERS_STREET -> NEWPORT.SOUTHERN_CROSS (0.00 -> 1.00)                                    
+Southern Cross -> North Melbourne         Southern Cross -> North Melbourne         NEWPORT.SOUTHERN_CROSS -> NEWPORT.NORTH_MELBOURNE (0.00 -> 1.00)                                    
+North Melbourne -> South Kensington       North Melbourne -> South Kensington       NEWPORT.NORTH_MELBOURNE -> NEWPORT.FOOTSCRAY (0.00 -> 0.50)                                         
+South Kensington -> Footscray             South Kensington -> Footscray             NEWPORT.NORTH_MELBOURNE -> NEWPORT.FOOTSCRAY (0.50 -> 1.00)                                         
+Footscray -> Seddon                       Footscray -> Seddon                       NEWPORT.FOOTSCRAY -> NEWPORT.NEWPORT (0.00 -> 0.25)                                                 
+Seddon -> Yarraville                      Seddon -> Yarraville                      NEWPORT.FOOTSCRAY -> NEWPORT.NEWPORT (0.25 -> 0.50)                                                 
+Yarraville -> Spotswood                   Yarraville -> Spotswood                   NEWPORT.FOOTSCRAY -> NEWPORT.NEWPORT (0.50 -> 0.75)                                                 
+Spotswood -> Newport                      Spotswood -> Newport                      NEWPORT.FOOTSCRAY -> NEWPORT.NEWPORT (0.75 -> 1.00)                                                 
+Newport -> North Williamstown             Newport -> North Williamstown             NEWPORT.NEWPORT -> NEWPORT.WILLIAMSTOWN (0.00 -> 0.33)                                              
+North Williamstown -> Williamstown Beach  North Williamstown -> Williamstown Beach  NEWPORT.NEWPORT -> NEWPORT.WILLIAMSTOWN (0.33 -> 0.67)                                              
+Williamstown Beach -> Williamstown        Williamstown Beach -> Williamstown        NEWPORT.NEWPORT -> NEWPORT.WILLIAMSTOWN (0.67 -> 1.00)                                              
 
 
-
-[BALLARAT LINE]
-
-All route graph pairs:
-  Southern Cross -> Ardeer
-  Footscray -> Ardeer
-  Sunshine -> Ardeer
-  Ardeer -> Deer Park
-  Deer Park -> Caroline Springs
-  Caroline Springs -> Rockbank
-  Rockbank -> Cobblebank
-  Cobblebank -> Melton
-  Melton -> Bacchus Marsh
-  Bacchus Marsh -> Ballan
-  Ballan -> Ballarat
-  Ballarat -> Creswick
-  Creswick -> Clunes
-  Clunes -> Talbot
-  Talbot -> Maryborough
-  Ballarat -> Wendouree
-  Wendouree -> Beaufort
-  Beaufort -> Ararat
-
-Line shape edges:
-  Southern Cross -> Footscray: [Southern Cross -> Ardeer]
-  Footscray -> Sunshine: [Southern Cross -> Ardeer, Footscray -> Ardeer]
-  Sunshine -> Ardeer: [Southern Cross -> Ardeer, Footscray -> Ardeer, Sunshine -> Ardeer]
-  Ardeer -> Deer Park: [Ardeer -> Deer Park]
-  Deer Park -> Caroline Springs: [Deer Park -> Caroline Springs]
-  Caroline Springs -> Rockbank: [Caroline Springs -> Rockbank]
-  Rockbank -> Cobblebank: [Rockbank -> Cobblebank]
-  Cobblebank -> Melton: [Cobblebank -> Melton]
-  Melton -> Bacchus Marsh: [Melton -> Bacchus Marsh]
-  Bacchus Marsh -> Ballan: [Bacchus Marsh -> Ballan]
-  Ballan -> Ballarat: [Ballan -> Ballarat]
-  Ballarat -> Creswick: [Ballarat -> Creswick]
-  Creswick -> Clunes: [Creswick -> Clunes]
-  Clunes -> Talbot: [Clunes -> Talbot]
-  Talbot -> Maryborough: [Talbot -> Maryborough]
-  Ballarat -> Wendouree: [Ballarat -> Wendouree]
-  Wendouree -> Beaufort: [Wendouree -> Beaufort]
-  Beaufort -> Ararat: [Beaufort -> Ararat]
-
-
-
-[BELGRAVE LINE]
-
-All route graph pairs:
-  Flinders Street -> Richmond
-  Flinders Street -> Southern Cross
-  Southern Cross -> Flagstaff
-  Flagstaff -> Melbourne Central
-  Melbourne Central -> Parliament
-  Parliament -> Richmond
-  Richmond -> East Richmond
-  East Richmond -> Burnley
-  Burnley -> Hawthorn
-  Hawthorn -> Glenferrie
-  Glenferrie -> Auburn
-  Auburn -> Camberwell
-  Camberwell -> East Camberwell
-  East Camberwell -> Canterbury
-  Canterbury -> Chatham
-  Chatham -> Union
-  Union -> Box Hill
-  Box Hill -> Laburnum
-  Laburnum -> Blackburn
-  Blackburn -> Nunawading
-  Nunawading -> Mitcham
-  Mitcham -> Heatherdale
-  Heatherdale -> Ringwood
-  Ringwood -> Heathmont
-  Heathmont -> Bayswater
-  Bayswater -> Boronia
-  Boronia -> Ferntree Gully
-  Ferntree Gully -> Upper Ferntree Gully
-  Upper Ferntree Gully -> Upwey
-  Upwey -> Tecoma
-  Tecoma -> Belgrave
-
-Line shape edges:
-  "The city" -> Richmond: [Flinders Street -> Richmond, Flinders Street -> Southern Cross, Southern Cross -> Flagstaff, Flagstaff -> Melbourne Central, Melbourne Central -> Parliament, Parliament -> Richmond]
-  Richmond -> East Richmond: [Richmond -> East Richmond]
-  East Richmond -> Burnley: [East Richmond -> Burnley]
-  Burnley -> Hawthorn: [Burnley -> Hawthorn]
-  Hawthorn -> Glenferrie: [Hawthorn -> Glenferrie]
-  Glenferrie -> Auburn: [Glenferrie -> Auburn]
-  Auburn -> Camberwell: [Auburn -> Camberwell]
-  Camberwell -> East Camberwell: [Camberwell -> East Camberwell]
-  East Camberwell -> Canterbury: [East Camberwell -> Canterbury]
-  Canterbury -> Chatham: [Canterbury -> Chatham]
-  Chatham -> Union: [Chatham -> Union]
-  Union -> Box Hill: [Union -> Box Hill]
-  Box Hill -> Laburnum: [Box Hill -> Laburnum]
-  Laburnum -> Blackburn: [Laburnum -> Blackburn]
-  Blackburn -> Nunawading: [Blackburn -> Nunawading]
-  Nunawading -> Mitcham: [Nunawading -> Mitcham]
-  Mitcham -> Heatherdale: [Mitcham -> Heatherdale]
-  Heatherdale -> Ringwood: [Heatherdale -> Ringwood]
-  Ringwood -> Heathmont: [Ringwood -> Heathmont]
-  Heathmont -> Bayswater: [Heathmont -> Bayswater]
-  Bayswater -> Boronia: [Bayswater -> Boronia]
-  Boronia -> Ferntree Gully: [Boronia -> Ferntree Gully]
-  Ferntree Gully -> Upper Ferntree Gully: [Ferntree Gully -> Upper Ferntree Gully]
-  Upper Ferntree Gully -> Upwey: [Upper Ferntree Gully -> Upwey]
-  Upwey -> Tecoma: [Upwey -> Tecoma]
-  Tecoma -> Belgrave: [Tecoma -> Belgrave]
-
-
-
-[BENDIGO LINE]
-
-All route graph pairs:
-  Southern Cross -> Sunbury
-  Footscray -> Sunbury
-  Watergardens -> Sunbury
-  Sunbury -> Clarkefield
-  Clarkefield -> Riddells Creek
-  Riddells Creek -> Gisborne
-  Gisborne -> Macedon
-  Macedon -> Woodend
-  Woodend -> Kyneton
-  Kyneton -> Malmsbury
-  Malmsbury -> Castlemaine
-  Castlemaine -> Kangaroo Flat
-  Kangaroo Flat -> Bendigo
-  Bendigo -> Epsom
-  Epsom -> Huntly
-  Huntly -> Goornong
-  Goornong -> Elmore
-  Elmore -> Rochester
-  Rochester -> Echuca
-  Bendigo -> Eaglehawk
-  Eaglehawk -> Raywood
-  Raywood -> Dingee
-  Dingee -> Pyramid
-  Pyramid -> Kerang
-  Kerang -> Swan Hill
-
-Line shape edges:
-  Southern Cross -> Footscray: [Southern Cross -> Sunbury]
-  Footscray -> Watergardens: [Southern Cross -> Sunbury, Footscray -> Sunbury]
-  Watergardens -> Sunbury: [Southern Cross -> Sunbury, Footscray -> Sunbury, Watergardens -> Sunbury]
-  Sunbury -> Clarkefield: [Sunbury -> Clarkefield]
-  Clarkefield -> Riddells Creek: [Clarkefield -> Riddells Creek]
-  Riddells Creek -> Gisborne: [Riddells Creek -> Gisborne]
-  Gisborne -> Macedon: [Gisborne -> Macedon]
-  Macedon -> Woodend: [Macedon -> Woodend]
-  Woodend -> Kyneton: [Woodend -> Kyneton]
-  Kyneton -> Malmsbury: [Kyneton -> Malmsbury]
-  Malmsbury -> Castlemaine: [Malmsbury -> Castlemaine]
-  Castlemaine -> Kangaroo Flat: [Castlemaine -> Kangaroo Flat]
-  Kangaroo Flat -> Bendigo: [Kangaroo Flat -> Bendigo]
-  Bendigo -> Epsom: [Bendigo -> Epsom]
-  Epsom -> Huntly: [Epsom -> Huntly]
-  Huntly -> Goornong: [Huntly -> Goornong]
-  Goornong -> Elmore: [Goornong -> Elmore]
-  Elmore -> Rochester: [Elmore -> Rochester]
-  Rochester -> Echuca: [Rochester -> Echuca]
-  Bendigo -> Eaglehawk: [Bendigo -> Eaglehawk]
-  Eaglehawk -> Raywood: [Eaglehawk -> Raywood]
-  Raywood -> Dingee: [Raywood -> Dingee]
-  Dingee -> Pyramid: [Dingee -> Pyramid]
-  Pyramid -> Kerang: [Pyramid -> Kerang]
-  Kerang -> Swan Hill: [Kerang -> Swan Hill]
-
-
-
-[CRAIGIEBURN LINE]
-
-All route graph pairs:
-  Flinders Street -> Southern Cross
-  Southern Cross -> North Melbourne
-  Flinders Street -> Parliament
-  Parliament -> Melbourne Central
-  Melbourne Central -> Flagstaff
-  Flagstaff -> North Melbourne
-  North Melbourne -> Kensington
-  Kensington -> Newmarket
-  Newmarket -> Ascot Vale
-  Ascot Vale -> Moonee Ponds
-  Moonee Ponds -> Essendon
-  Essendon -> Glenbervie
-  Glenbervie -> Strathmore
-  Strathmore -> Pascoe Vale
-  Pascoe Vale -> Oak Park
-  Oak Park -> Glenroy
-  Glenroy -> Jacana
-  Jacana -> Broadmeadows
-  Broadmeadows -> Coolaroo
-  Coolaroo -> Roxburgh Park
-  Roxburgh Park -> Craigieburn
-
-Line shape edges:
-  "The city" -> North Melbourne: [Flinders Street -> Southern Cross, Southern Cross -> North Melbourne, Flinders Street -> Parliament, Parliament -> Melbourne Central, Melbourne Central -> Flagstaff, Flagstaff -> North Melbourne]
-  North Melbourne -> Kensington: [North Melbourne -> Kensington]
-  Kensington -> Newmarket: [Kensington -> Newmarket]
-  Newmarket -> Ascot Vale: [Newmarket -> Ascot Vale]
-  Ascot Vale -> Moonee Ponds: [Ascot Vale -> Moonee Ponds]
-  Moonee Ponds -> Essendon: [Moonee Ponds -> Essendon]
-  Essendon -> Glenbervie: [Essendon -> Glenbervie]
-  Glenbervie -> Strathmore: [Glenbervie -> Strathmore]
-  Strathmore -> Pascoe Vale: [Strathmore -> Pascoe Vale]
-  Pascoe Vale -> Oak Park: [Pascoe Vale -> Oak Park]
-  Oak Park -> Glenroy: [Oak Park -> Glenroy]
-  Glenroy -> Jacana: [Glenroy -> Jacana]
-  Jacana -> Broadmeadows: [Jacana -> Broadmeadows]
-  Broadmeadows -> Coolaroo: [Broadmeadows -> Coolaroo]
-  Coolaroo -> Roxburgh Park: [Coolaroo -> Roxburgh Park]
-  Roxburgh Park -> Craigieburn: [Roxburgh Park -> Craigieburn]
-
-
-
-[CRANBOURNE LINE]
-
-All route graph pairs:
-  Flinders Street -> Richmond
-  Flinders Street -> Southern Cross
-  Southern Cross -> Flagstaff
-  Flagstaff -> Melbourne Central
-  Melbourne Central -> Parliament
-  Parliament -> Richmond
-  Richmond -> South Yarra
-  South Yarra -> Caulfield
-  Caulfield -> Carnegie
-  Carnegie -> Murrumbeena
-  Murrumbeena -> Hughesdale
-  Hughesdale -> Oakleigh
-  Oakleigh -> Huntingdale
-  Huntingdale -> Clayton
-  Clayton -> Westall
-  Westall -> Springvale
-  Springvale -> Sandown Park
-  Sandown Park -> Noble Park
-  Noble Park -> Yarraman
-  Yarraman -> Dandenong
-  Dandenong -> Lynbrook
-  Lynbrook -> Merinda Park
-  Merinda Park -> Cranbourne
-
-Line shape edges:
-  "The city" -> Richmond: [Flinders Street -> Richmond, Flinders Street -> Southern Cross, Southern Cross -> Flagstaff, Flagstaff -> Melbourne Central, Melbourne Central -> Parliament, Parliament -> Richmond]
-  Richmond -> South Yarra: [Richmond -> South Yarra]
-  South Yarra -> Caulfield: [South Yarra -> Caulfield]
-  Caulfield -> Carnegie: [Caulfield -> Carnegie]
-  Carnegie -> Murrumbeena: [Carnegie -> Murrumbeena]
-  Murrumbeena -> Hughesdale: [Murrumbeena -> Hughesdale]
-  Hughesdale -> Oakleigh: [Hughesdale -> Oakleigh]
-  Oakleigh -> Huntingdale: [Oakleigh -> Huntingdale]
-  Huntingdale -> Clayton: [Huntingdale -> Clayton]
-  Clayton -> Westall: [Clayton -> Westall]
-  Westall -> Springvale: [Westall -> Springvale]
-  Springvale -> Sandown Park: [Springvale -> Sandown Park]
-  Sandown Park -> Noble Park: [Sandown Park -> Noble Park]
-  Noble Park -> Yarraman: [Noble Park -> Yarraman]
-  Yarraman -> Dandenong: [Yarraman -> Dandenong]
-  Dandenong -> Lynbrook: [Dandenong -> Lynbrook]
-  Lynbrook -> Merinda Park: [Lynbrook -> Merinda Park]
-  Merinda Park -> Cranbourne: [Merinda Park -> Cranbourne]
-
-
-
-[FLEMINGTON RACECOURSE LINE]
-
-All route graph pairs:
-  Flinders Street -> Southern Cross
-  Southern Cross -> North Melbourne
-  North Melbourne -> Showgrounds
-  Showgrounds -> Flemington Racecourse
-
-Line shape edges:
-  Flinders Street -> Southern Cross: [Flinders Street -> Southern Cross]
-  Southern Cross -> North Melbourne: [Southern Cross -> North Melbourne]
-  North Melbourne -> Showgrounds: [North Melbourne -> Showgrounds]
-  Showgrounds -> Flemington Racecourse: [Showgrounds -> Flemington Racecourse]
-
-
-
-[FRANKSTON LINE]
-
-All route graph pairs:
-  Flinders Street -> Richmond
-  Richmond -> South Yarra
-  South Yarra -> Hawksburn
-  Hawksburn -> Toorak
-  Toorak -> Armadale
-  Armadale -> Malvern
-  Malvern -> Caulfield
-  Caulfield -> Glen Huntly
-  Glen Huntly -> Ormond
-  Ormond -> McKinnon
-  McKinnon -> Bentleigh
-  Bentleigh -> Patterson
-  Patterson -> Moorabbin
-  Moorabbin -> Highett
-  Highett -> Southland
-  Southland -> Cheltenham
-  Cheltenham -> Mentone
-  Mentone -> Parkdale
-  Parkdale -> Mordialloc
-  Mordialloc -> Aspendale
-  Aspendale -> Edithvale
-  Edithvale -> Chelsea
-  Chelsea -> Bonbeach
-  Bonbeach -> Carrum
-  Carrum -> Seaford
-  Seaford -> Kananook
-  Kananook -> Frankston
-
-Line shape edges:
-  Flinders Street -> Richmond: [Flinders Street -> Richmond]
-  Richmond -> South Yarra: [Richmond -> South Yarra]
-  South Yarra -> Hawksburn: [South Yarra -> Hawksburn]
-  Hawksburn -> Toorak: [Hawksburn -> Toorak]
-  Toorak -> Armadale: [Toorak -> Armadale]
-  Armadale -> Malvern: [Armadale -> Malvern]
-  Malvern -> Caulfield: [Malvern -> Caulfield]
-  Caulfield -> Glen Huntly: [Caulfield -> Glen Huntly]
-  Glen Huntly -> Ormond: [Glen Huntly -> Ormond]
-  Ormond -> McKinnon: [Ormond -> McKinnon]
-  McKinnon -> Bentleigh: [McKinnon -> Bentleigh]
-  Bentleigh -> Patterson: [Bentleigh -> Patterson]
-  Patterson -> Moorabbin: [Patterson -> Moorabbin]
-  Moorabbin -> Highett: [Moorabbin -> Highett]
-  Highett -> Southland: [Highett -> Southland]
-  Southland -> Cheltenham: [Southland -> Cheltenham]
-  Cheltenham -> Mentone: [Cheltenham -> Mentone]
-  Mentone -> Parkdale: [Mentone -> Parkdale]
-  Parkdale -> Mordialloc: [Parkdale -> Mordialloc]
-  Mordialloc -> Aspendale: [Mordialloc -> Aspendale]
-  Aspendale -> Edithvale: [Aspendale -> Edithvale]
-  Edithvale -> Chelsea: [Edithvale -> Chelsea]
-  Chelsea -> Bonbeach: [Chelsea -> Bonbeach]
-  Bonbeach -> Carrum: [Bonbeach -> Carrum]
-  Carrum -> Seaford: [Carrum -> Seaford]
-  Seaford -> Kananook: [Seaford -> Kananook]
-  Kananook -> Frankston: [Kananook -> Frankston]
-
-
-
-[GEELONG LINE]
-
-All route graph pairs:
-  Southern Cross -> Deer Park
-  Footscray -> Deer Park
-  Sunshine -> Deer Park
-  Deer Park -> Tarneit
-  Tarneit -> Wyndham Vale
-  Wyndham Vale -> Little River
-  Little River -> Lara
-  Lara -> Corio
-  Corio -> North Shore
-  North Shore -> North Geelong
-  North Geelong -> Geelong
-  Geelong -> South Geelong
-  South Geelong -> Marshall
-  Marshall -> Waurn Ponds
-  Waurn Ponds -> Winchelsea
-  Winchelsea -> Birregurra
-  Birregurra -> Colac
-  Colac -> Camperdown
-  Camperdown -> Terang
-  Terang -> Sherwood Park
-  Sherwood Park -> Warrnambool
-
-Line shape edges:
-  Southern Cross -> Footscray: [Southern Cross -> Deer Park]
-  Footscray -> Sunshine: [Southern Cross -> Deer Park, Footscray -> Deer Park]
-  Sunshine -> Deer Park: [Southern Cross -> Deer Park, Footscray -> Deer Park, Sunshine -> Deer Park]
-  Deer Park -> Tarneit: [Deer Park -> Tarneit]
-  Tarneit -> Wyndham Vale: [Tarneit -> Wyndham Vale]
-  Wyndham Vale -> Little River: [Wyndham Vale -> Little River]
-  Little River -> Lara: [Little River -> Lara]
-  Lara -> Corio: [Lara -> Corio]
-  Corio -> North Shore: [Corio -> North Shore]
-  North Shore -> North Geelong: [North Shore -> North Geelong]
-  North Geelong -> Geelong: [North Geelong -> Geelong]
-  Geelong -> South Geelong: [Geelong -> South Geelong]
-  South Geelong -> Marshall: [South Geelong -> Marshall]
-  Marshall -> Waurn Ponds: [Marshall -> Waurn Ponds]
-  Waurn Ponds -> Winchelsea: [Waurn Ponds -> Winchelsea]
-  Winchelsea -> Birregurra: [Winchelsea -> Birregurra]
-  Birregurra -> Colac: [Birregurra -> Colac]
-  Colac -> Camperdown: [Colac -> Camperdown]
-  Camperdown -> Terang: [Camperdown -> Terang]
-  Terang -> Sherwood Park: [Terang -> Sherwood Park]
-  Sherwood Park -> Warrnambool: [Sherwood Park -> Warrnambool]
-
-
-
-[GIPPSLAND LINE]
-
-All route graph pairs:
-  Southern Cross -> Pakenham
-  Flinders Street -> Pakenham
-  Richmond -> Pakenham
-  Caulfield -> Pakenham
-  Clayton -> Pakenham
-  Dandenong -> Pakenham
-  Pakenham -> Nar Nar Goon
-  Nar Nar Goon -> Tynong
-  Tynong -> Garfield
-  Garfield -> Bunyip
-  Bunyip -> Longwarry
-  Longwarry -> Drouin
-  Drouin -> Warragul
-  Warragul -> Yarragon
-  Yarragon -> Trafalgar
-  Trafalgar -> Moe
-  Moe -> Morwell
-  Morwell -> Traralgon
-  Traralgon -> Rosedale
-  Rosedale -> Sale
-  Sale -> Stratford
-  Stratford -> Bairnsdale
-
-Line shape edges:
-  Southern Cross -> Flinders Street: [Southern Cross -> Pakenham]
-  Flinders Street -> Richmond: [Southern Cross -> Pakenham, Flinders Street -> Pakenham]
-  Richmond -> Caulfield: [Southern Cross -> Pakenham, Flinders Street -> Pakenham, Richmond -> Pakenham]
-  Caulfield -> Clayton: [Southern Cross -> Pakenham, Flinders Street -> Pakenham, Richmond -> Pakenham, Caulfield -> Pakenham]
-  Clayton -> Dandenong: [Southern Cross -> Pakenham, Flinders Street -> Pakenham, Richmond -> Pakenham, Caulfield -> Pakenham, Clayton -> Pakenham]
-  Dandenong -> Pakenham: [Southern Cross -> Pakenham, Flinders Street -> Pakenham, Richmond -> Pakenham, Caulfield -> Pakenham, Clayton -> Pakenham, Dandenong -> Pakenham]
-  Pakenham -> Nar Nar Goon: [Pakenham -> Nar Nar Goon]
-  Nar Nar Goon -> Tynong: [Nar Nar Goon -> Tynong]
-  Tynong -> Garfield: [Tynong -> Garfield]
-  Garfield -> Bunyip: [Garfield -> Bunyip]
-  Bunyip -> Longwarry: [Bunyip -> Longwarry]
-  Longwarry -> Drouin: [Longwarry -> Drouin]
-  Drouin -> Warragul: [Drouin -> Warragul]
-  Warragul -> Yarragon: [Warragul -> Yarragon]
-  Yarragon -> Trafalgar: [Yarragon -> Trafalgar]
-  Trafalgar -> Moe: [Trafalgar -> Moe]
-  Moe -> Morwell: [Moe -> Morwell]
-  Morwell -> Traralgon: [Morwell -> Traralgon]
-  Traralgon -> Rosedale: [Traralgon -> Rosedale]
-  Rosedale -> Sale: [Rosedale -> Sale]
-  Sale -> Stratford: [Sale -> Stratford]
-  Stratford -> Bairnsdale: [Stratford -> Bairnsdale]
-
-
-
-[GLEN WAVERLEY LINE]
-
-All route graph pairs:
-  Flinders Street -> Richmond
-  Flinders Street -> Southern Cross
-  Southern Cross -> Flagstaff
-  Flagstaff -> Melbourne Central
-  Melbourne Central -> Parliament
-  Parliament -> Richmond
-  Richmond -> East Richmond
-  East Richmond -> Burnley
-  Burnley -> Heyington
-  Heyington -> Kooyong
-  Kooyong -> Tooronga
-  Tooronga -> Gardiner
-  Gardiner -> Glen Iris
-  Glen Iris -> Darling
-  Darling -> East Malvern
-  East Malvern -> Holmesglen
-  Holmesglen -> Jordanville
-  Jordanville -> Mount Waverley
-  Mount Waverley -> Syndal
-  Syndal -> Glen Waverley
-
-Line shape edges:
-  "The city" -> Richmond: [Flinders Street -> Richmond, Flinders Street -> Southern Cross, Southern Cross -> Flagstaff, Flagstaff -> Melbourne Central, Melbourne Central -> Parliament, Parliament -> Richmond]
-  Richmond -> East Richmond: [Richmond -> East Richmond]
-  East Richmond -> Burnley: [East Richmond -> Burnley]
-  Burnley -> Heyington: [Burnley -> Heyington]
-  Heyington -> Kooyong: [Heyington -> Kooyong]
-  Kooyong -> Tooronga: [Kooyong -> Tooronga]
-  Tooronga -> Gardiner: [Tooronga -> Gardiner]
-  Gardiner -> Glen Iris: [Gardiner -> Glen Iris]
-  Glen Iris -> Darling: [Glen Iris -> Darling]
-  Darling -> East Malvern: [Darling -> East Malvern]
-  East Malvern -> Holmesglen: [East Malvern -> Holmesglen]
-  Holmesglen -> Jordanville: [Holmesglen -> Jordanville]
-  Jordanville -> Mount Waverley: [Jordanville -> Mount Waverley]
-  Mount Waverley -> Syndal: [Mount Waverley -> Syndal]
-  Syndal -> Glen Waverley: [Syndal -> Glen Waverley]
-
-
-
-[HURSTBRIDGE LINE]
-
-All route graph pairs:
-  Flinders Street -> Jolimont
-  Flinders Street -> Southern Cross
-  Southern Cross -> Flagstaff
-  Flagstaff -> Melbourne Central
-  Melbourne Central -> Parliament
-  Parliament -> Jolimont
-  Jolimont -> West Richmond
-  West Richmond -> North Richmond
-  North Richmond -> Collingwood
-  Collingwood -> Victoria Park
-  Victoria Park -> Clifton Hill
-  Clifton Hill -> Westgarth
-  Westgarth -> Dennis
-  Dennis -> Fairfield
-  Fairfield -> Alphington
-  Alphington -> Darebin
-  Darebin -> Ivanhoe
-  Ivanhoe -> Eaglemont
-  Eaglemont -> Heidelberg
-  Heidelberg -> Rosanna
-  Rosanna -> Macleod
-  Macleod -> Watsonia
-  Watsonia -> Greensborough
-  Greensborough -> Montmorency
-  Montmorency -> Eltham
-  Eltham -> Diamond Creek
-  Diamond Creek -> Wattle Glen
-  Wattle Glen -> Hurstbridge
-
-Line shape edges:
-  "The city" -> Jolimont: [Flinders Street -> Jolimont, Flinders Street -> Southern Cross, Southern Cross -> Flagstaff, Flagstaff -> Melbourne Central, Melbourne Central -> Parliament, Parliament -> Jolimont]
-  Jolimont -> West Richmond: [Jolimont -> West Richmond]
-  West Richmond -> North Richmond: [West Richmond -> North Richmond]
-  North Richmond -> Collingwood: [North Richmond -> Collingwood]
-  Collingwood -> Victoria Park: [Collingwood -> Victoria Park]
-  Victoria Park -> Clifton Hill: [Victoria Park -> Clifton Hill]
-  Clifton Hill -> Westgarth: [Clifton Hill -> Westgarth]
-  Westgarth -> Dennis: [Westgarth -> Dennis]
-  Dennis -> Fairfield: [Dennis -> Fairfield]
-  Fairfield -> Alphington: [Fairfield -> Alphington]
-  Alphington -> Darebin: [Alphington -> Darebin]
-  Darebin -> Ivanhoe: [Darebin -> Ivanhoe]
-  Ivanhoe -> Eaglemont: [Ivanhoe -> Eaglemont]
-  Eaglemont -> Heidelberg: [Eaglemont -> Heidelberg]
-  Heidelberg -> Rosanna: [Heidelberg -> Rosanna]
-  Rosanna -> Macleod: [Rosanna -> Macleod]
-  Macleod -> Watsonia: [Macleod -> Watsonia]
-  Watsonia -> Greensborough: [Watsonia -> Greensborough]
-  Greensborough -> Montmorency: [Greensborough -> Montmorency]
-  Montmorency -> Eltham: [Montmorency -> Eltham]
-  Eltham -> Diamond Creek: [Eltham -> Diamond Creek]
-  Diamond Creek -> Wattle Glen: [Diamond Creek -> Wattle Glen]
-  Wattle Glen -> Hurstbridge: [Wattle Glen -> Hurstbridge]
-
-
-
-[LILYDALE LINE]
-
-All route graph pairs:
-  Flinders Street -> Richmond
-  Flinders Street -> Southern Cross
-  Southern Cross -> Flagstaff
-  Flagstaff -> Melbourne Central
-  Melbourne Central -> Parliament
-  Parliament -> Richmond
-  Richmond -> East Richmond
-  East Richmond -> Burnley
-  Burnley -> Hawthorn
-  Hawthorn -> Glenferrie
-  Glenferrie -> Auburn
-  Auburn -> Camberwell
-  Camberwell -> East Camberwell
-  East Camberwell -> Canterbury
-  Canterbury -> Chatham
-  Chatham -> Union
-  Union -> Box Hill
-  Box Hill -> Laburnum
-  Laburnum -> Blackburn
-  Blackburn -> Nunawading
-  Nunawading -> Mitcham
-  Mitcham -> Heatherdale
-  Heatherdale -> Ringwood
-  Ringwood -> Ringwood East
-  Ringwood East -> Croydon
-  Croydon -> Mooroolbark
-  Mooroolbark -> Lilydale
-
-Line shape edges:
-  "The city" -> Richmond: [Flinders Street -> Richmond, Flinders Street -> Southern Cross, Southern Cross -> Flagstaff, Flagstaff -> Melbourne Central, Melbourne Central -> Parliament, Parliament -> Richmond]
-  Richmond -> East Richmond: [Richmond -> East Richmond]
-  East Richmond -> Burnley: [East Richmond -> Burnley]
-  Burnley -> Hawthorn: [Burnley -> Hawthorn]
-  Hawthorn -> Glenferrie: [Hawthorn -> Glenferrie]
-  Glenferrie -> Auburn: [Glenferrie -> Auburn]
-  Auburn -> Camberwell: [Auburn -> Camberwell]
-  Camberwell -> East Camberwell: [Camberwell -> East Camberwell]
-  East Camberwell -> Canterbury: [East Camberwell -> Canterbury]
-  Canterbury -> Chatham: [Canterbury -> Chatham]
-  Chatham -> Union: [Chatham -> Union]
-  Union -> Box Hill: [Union -> Box Hill]
-  Box Hill -> Laburnum: [Box Hill -> Laburnum]
-  Laburnum -> Blackburn: [Laburnum -> Blackburn]
-  Blackburn -> Nunawading: [Blackburn -> Nunawading]
-  Nunawading -> Mitcham: [Nunawading -> Mitcham]
-  Mitcham -> Heatherdale: [Mitcham -> Heatherdale]
-  Heatherdale -> Ringwood: [Heatherdale -> Ringwood]
-  Ringwood -> Ringwood East: [Ringwood -> Ringwood East]
-  Ringwood East -> Croydon: [Ringwood East -> Croydon]
-  Croydon -> Mooroolbark: [Croydon -> Mooroolbark]
-  Mooroolbark -> Lilydale: [Mooroolbark -> Lilydale]
-
-
-
-[MERNDA LINE]
-
-All route graph pairs:
-  Flinders Street -> Jolimont
-  Flinders Street -> Southern Cross
-  Southern Cross -> Flagstaff
-  Flagstaff -> Melbourne Central
-  Melbourne Central -> Parliament
-  Parliament -> Jolimont
-  Jolimont -> West Richmond
-  West Richmond -> North Richmond
-  North Richmond -> Collingwood
-  Collingwood -> Victoria Park
-  Victoria Park -> Clifton Hill
-  Clifton Hill -> Rushall
-  Rushall -> Merri
-  Merri -> Northcote
-  Northcote -> Croxton
-  Croxton -> Thornbury
-  Thornbury -> Bell
-  Bell -> Preston
-  Preston -> Regent
-  Regent -> Reservoir
-  Reservoir -> Ruthven
-  Ruthven -> Keon Park
-  Keon Park -> Thomastown
-  Thomastown -> Lalor
-  Lalor -> Epping
-  Epping -> South Morang
-  South Morang -> Middle Gorge
-  Middle Gorge -> Hawkstowe
-  Hawkstowe -> Mernda
-
-Line shape edges:
-  "The city" -> Jolimont: [Flinders Street -> Jolimont, Flinders Street -> Southern Cross, Southern Cross -> Flagstaff, Flagstaff -> Melbourne Central, Melbourne Central -> Parliament, Parliament -> Jolimont]
-  Jolimont -> West Richmond: [Jolimont -> West Richmond]
-  West Richmond -> North Richmond: [West Richmond -> North Richmond]
-  North Richmond -> Collingwood: [North Richmond -> Collingwood]
-  Collingwood -> Victoria Park: [Collingwood -> Victoria Park]
-  Victoria Park -> Clifton Hill: [Victoria Park -> Clifton Hill]
-  Clifton Hill -> Rushall: [Clifton Hill -> Rushall]
-  Rushall -> Merri: [Rushall -> Merri]
-  Merri -> Northcote: [Merri -> Northcote]
-  Northcote -> Croxton: [Northcote -> Croxton]
-  Croxton -> Thornbury: [Croxton -> Thornbury]
-  Thornbury -> Bell: [Thornbury -> Bell]
-  Bell -> Preston: [Bell -> Preston]
-  Preston -> Regent: [Preston -> Regent]
-  Regent -> Reservoir: [Regent -> Reservoir]
-  Reservoir -> Ruthven: [Reservoir -> Ruthven]
-  Ruthven -> Keon Park: [Ruthven -> Keon Park]
-  Keon Park -> Thomastown: [Keon Park -> Thomastown]
-  Thomastown -> Lalor: [Thomastown -> Lalor]
-  Lalor -> Epping: [Lalor -> Epping]
-  Epping -> South Morang: [Epping -> South Morang]
-  South Morang -> Middle Gorge: [South Morang -> Middle Gorge]
-  Middle Gorge -> Hawkstowe: [Middle Gorge -> Hawkstowe]
-  Hawkstowe -> Mernda: [Hawkstowe -> Mernda]
-
-
-
-[PAKENHAM LINE]
-
-All route graph pairs:
-  Flinders Street -> Richmond
-  Flinders Street -> Southern Cross
-  Southern Cross -> Flagstaff
-  Flagstaff -> Melbourne Central
-  Melbourne Central -> Parliament
-  Parliament -> Richmond
-  Richmond -> South Yarra
-  South Yarra -> Caulfield
-  Caulfield -> Carnegie
-  Carnegie -> Murrumbeena
-  Murrumbeena -> Hughesdale
-  Hughesdale -> Oakleigh
-  Oakleigh -> Huntingdale
-  Huntingdale -> Clayton
-  Clayton -> Westall
-  Westall -> Springvale
-  Springvale -> Sandown Park
-  Sandown Park -> Noble Park
-  Noble Park -> Yarraman
-  Yarraman -> Dandenong
-  Dandenong -> Hallam
-  Hallam -> Narre Warren
-  Narre Warren -> Berwick
-  Berwick -> Beaconsfield
-  Beaconsfield -> Officer
-  Officer -> Cardinia Road
-  Cardinia Road -> Pakenham
-  Pakenham -> East Pakenham
-
-Line shape edges:
-  "The city" -> Richmond: [Flinders Street -> Richmond, Flinders Street -> Southern Cross, Southern Cross -> Flagstaff, Flagstaff -> Melbourne Central, Melbourne Central -> Parliament, Parliament -> Richmond]
-  Richmond -> South Yarra: [Richmond -> South Yarra]
-  South Yarra -> Caulfield: [South Yarra -> Caulfield]
-  Caulfield -> Carnegie: [Caulfield -> Carnegie]
-  Carnegie -> Murrumbeena: [Carnegie -> Murrumbeena]
-  Murrumbeena -> Hughesdale: [Murrumbeena -> Hughesdale]
-  Hughesdale -> Oakleigh: [Hughesdale -> Oakleigh]
-  Oakleigh -> Huntingdale: [Oakleigh -> Huntingdale]
-  Huntingdale -> Clayton: [Huntingdale -> Clayton]
-  Clayton -> Westall: [Clayton -> Westall]
-  Westall -> Springvale: [Westall -> Springvale]
-  Springvale -> Sandown Park: [Springvale -> Sandown Park]
-  Sandown Park -> Noble Park: [Sandown Park -> Noble Park]
-  Noble Park -> Yarraman: [Noble Park -> Yarraman]
-  Yarraman -> Dandenong: [Yarraman -> Dandenong]
-  Dandenong -> Hallam: [Dandenong -> Hallam]
-  Hallam -> Narre Warren: [Hallam -> Narre Warren]
-  Narre Warren -> Berwick: [Narre Warren -> Berwick]
-  Berwick -> Beaconsfield: [Berwick -> Beaconsfield]
-  Beaconsfield -> Officer: [Beaconsfield -> Officer]
-  Officer -> Cardinia Road: [Officer -> Cardinia Road]
-  Cardinia Road -> Pakenham: [Cardinia Road -> Pakenham]
-  Pakenham -> East Pakenham: [Pakenham -> East Pakenham]
-
-
-
-[SANDRINGHAM LINE]
-
-All route graph pairs:
-  Flinders Street -> Richmond
-  Richmond -> South Yarra
-  South Yarra -> Prahran
-  Prahran -> Windsor
-  Windsor -> Balaclava
-  Balaclava -> Ripponlea
-  Ripponlea -> Elsternwick
-  Elsternwick -> Gardenvale
-  Gardenvale -> North Brighton
-  North Brighton -> Middle Brighton
-  Middle Brighton -> Brighton Beach
-  Brighton Beach -> Hampton
-  Hampton -> Sandringham
-
-Line shape edges:
-  Flinders Street -> Richmond: [Flinders Street -> Richmond]
-  Richmond -> South Yarra: [Richmond -> South Yarra]
-  South Yarra -> Prahran: [South Yarra -> Prahran]
-  Prahran -> Windsor: [Prahran -> Windsor]
-  Windsor -> Balaclava: [Windsor -> Balaclava]
-  Balaclava -> Ripponlea: [Balaclava -> Ripponlea]
-  Ripponlea -> Elsternwick: [Ripponlea -> Elsternwick]
-  Elsternwick -> Gardenvale: [Elsternwick -> Gardenvale]
-  Gardenvale -> North Brighton: [Gardenvale -> North Brighton]
-  North Brighton -> Middle Brighton: [North Brighton -> Middle Brighton]
-  Middle Brighton -> Brighton Beach: [Middle Brighton -> Brighton Beach]
-  Brighton Beach -> Hampton: [Brighton Beach -> Hampton]
-  Hampton -> Sandringham: [Hampton -> Sandringham]
-
-
-
-[SEYMOUR LINE]
-
-All route graph pairs:
-  Southern Cross -> Donnybrook
-  North Melbourne -> Donnybrook
-  Broadmeadows -> Donnybrook
-  Craigieburn -> Donnybrook
-  Donnybrook -> Wallan
-  Wallan -> Heathcote Junction
-  Heathcote Junction -> Wandong
-  Wandong -> Kilmore East
-  Kilmore East -> Broadford
-  Broadford -> Tallarook
-  Tallarook -> Seymour
-  Seymour -> Avenel
-  Avenel -> Euroa
-  Euroa -> Violet Town
-  Violet Town -> Benalla
-  Benalla -> Wangaratta
-  Wangaratta -> Springhurst
-  Springhurst -> Chiltern
-  Chiltern -> Wodonga
-  Wodonga -> Albury
-  Seymour -> Nagambie
-  Nagambie -> Murchison East
-  Murchison East -> Mooroopna
-  Mooroopna -> Shepparton
-
-Line shape edges:
-  Southern Cross -> North Melbourne: [Southern Cross -> Donnybrook]
-  North Melbourne -> Broadmeadows: [Southern Cross -> Donnybrook, North Melbourne -> Donnybrook]
-  Broadmeadows -> Craigieburn: [Southern Cross -> Donnybrook, North Melbourne -> Donnybrook, Broadmeadows -> Donnybrook]
-  Craigieburn -> Donnybrook: [Southern Cross -> Donnybrook, North Melbourne -> Donnybrook, Broadmeadows -> Donnybrook, Craigieburn -> Donnybrook]
-  Donnybrook -> Wallan: [Donnybrook -> Wallan]
-  Wallan -> Heathcote Junction: [Wallan -> Heathcote Junction]
-  Heathcote Junction -> Wandong: [Heathcote Junction -> Wandong]
-  Wandong -> Kilmore East: [Wandong -> Kilmore East]
-  Kilmore East -> Broadford: [Kilmore East -> Broadford]
-  Broadford -> Tallarook: [Broadford -> Tallarook]
-  Tallarook -> Seymour: [Tallarook -> Seymour]
-  Seymour -> Avenel: [Seymour -> Avenel]
-  Avenel -> Euroa: [Avenel -> Euroa]
-  Euroa -> Violet Town: [Euroa -> Violet Town]
-  Violet Town -> Benalla: [Violet Town -> Benalla]
-  Benalla -> Wangaratta: [Benalla -> Wangaratta]
-  Wangaratta -> Springhurst: [Wangaratta -> Springhurst]
-  Springhurst -> Chiltern: [Springhurst -> Chiltern]
-  Chiltern -> Wodonga: [Chiltern -> Wodonga]
-  Wodonga -> Albury: [Wodonga -> Albury]
-  Seymour -> Nagambie: [Seymour -> Nagambie]
-  Nagambie -> Murchison East: [Nagambie -> Murchison East]
-  Murchison East -> Mooroopna: [Murchison East -> Mooroopna]
-  Mooroopna -> Shepparton: [Mooroopna -> Shepparton]
-
-
-
-[STONY POINT LINE]
-
-All route graph pairs:
-  Frankston -> Leawarra
-  Leawarra -> Baxter
-  Baxter -> Somerville
-  Somerville -> Tyabb
-  Tyabb -> Hastings
-  Hastings -> Bittern
-  Bittern -> Morradoo
-  Morradoo -> Crib Point
-  Crib Point -> Stony Point
-
-Line shape edges:
-  Frankston -> Leawarra: [Frankston -> Leawarra]
-  Leawarra -> Baxter: [Leawarra -> Baxter]
-  Baxter -> Somerville: [Baxter -> Somerville]
-  Somerville -> Tyabb: [Somerville -> Tyabb]
-  Tyabb -> Hastings: [Tyabb -> Hastings]
-  Hastings -> Bittern: [Hastings -> Bittern]
-  Bittern -> Morradoo: [Bittern -> Morradoo]
-  Morradoo -> Crib Point: [Morradoo -> Crib Point]
-  Crib Point -> Stony Point: [Crib Point -> Stony Point]
-
-
-
-[SUNBURY LINE]
-
-All route graph pairs:
-  Flinders Street -> Southern Cross
-  Southern Cross -> North Melbourne
-  Flinders Street -> Parliament
-  Parliament -> Melbourne Central
-  Melbourne Central -> Flagstaff
-  Flagstaff -> North Melbourne
-  North Melbourne -> Footscray
-  Footscray -> Middle Footscray
-  Middle Footscray -> West Footscray
-  West Footscray -> Tottenham
-  Tottenham -> Sunshine
-  Sunshine -> Albion
-  Albion -> Ginifer
-  Ginifer -> St Albans
-  St Albans -> Keilor Plains
-  Keilor Plains -> Watergardens
-  Watergardens -> Diggers Rest
-  Diggers Rest -> Sunbury
-
-Line shape edges:
-  "The city" -> North Melbourne: [Flinders Street -> Southern Cross, Southern Cross -> North Melbourne, Flinders Street -> Parliament, Parliament -> Melbourne Central, Melbourne Central -> Flagstaff, Flagstaff -> North Melbourne]
-  North Melbourne -> Footscray: [North Melbourne -> Footscray]
-  Footscray -> Middle Footscray: [Footscray -> Middle Footscray]
-  Middle Footscray -> West Footscray: [Middle Footscray -> West Footscray]
-  West Footscray -> Tottenham: [West Footscray -> Tottenham]
-  Tottenham -> Sunshine: [Tottenham -> Sunshine]
-  Sunshine -> Albion: [Sunshine -> Albion]
-  Albion -> Ginifer: [Albion -> Ginifer]
-  Ginifer -> St Albans: [Ginifer -> St Albans]
-  St Albans -> Keilor Plains: [St Albans -> Keilor Plains]
-  Keilor Plains -> Watergardens: [Keilor Plains -> Watergardens]
-  Watergardens -> Diggers Rest: [Watergardens -> Diggers Rest]
-  Diggers Rest -> Sunbury: [Diggers Rest -> Sunbury]
-
-
-
-[UPFIELD LINE]
-
-All route graph pairs:
-  Flinders Street -> Southern Cross
-  Southern Cross -> North Melbourne
-  Flinders Street -> Parliament
-  Parliament -> Melbourne Central
-  Melbourne Central -> Flagstaff
-  Flagstaff -> North Melbourne
-  North Melbourne -> Macaulay
-  Macaulay -> Flemington Bridge
-  Flemington Bridge -> Royal Park
-  Royal Park -> Jewell
-  Jewell -> Brunswick
-  Brunswick -> Anstey
-  Anstey -> Moreland
-  Moreland -> Coburg
-  Coburg -> Batman
-  Batman -> Merlynston
-  Merlynston -> Fawkner
-  Fawkner -> Gowrie
-  Gowrie -> Upfield
-
-Line shape edges:
-  "The city" -> North Melbourne: [Flinders Street -> Southern Cross, Southern Cross -> North Melbourne, Flinders Street -> Parliament, Parliament -> Melbourne Central, Melbourne Central -> Flagstaff, Flagstaff -> North Melbourne]
-  North Melbourne -> Macaulay: [North Melbourne -> Macaulay]
-  Macaulay -> Flemington Bridge: [Macaulay -> Flemington Bridge]
-  Flemington Bridge -> Royal Park: [Flemington Bridge -> Royal Park]
-  Royal Park -> Jewell: [Royal Park -> Jewell]
-  Jewell -> Brunswick: [Jewell -> Brunswick]
-  Brunswick -> Anstey: [Brunswick -> Anstey]
-  Anstey -> Moreland: [Anstey -> Moreland]
-  Moreland -> Coburg: [Moreland -> Coburg]
-  Coburg -> Batman: [Coburg -> Batman]
-  Batman -> Merlynston: [Batman -> Merlynston]
-  Merlynston -> Fawkner: [Merlynston -> Fawkner]
-  Fawkner -> Gowrie: [Fawkner -> Gowrie]
-  Gowrie -> Upfield: [Gowrie -> Upfield]
-
-
-
-[WERRIBEE LINE]
-
-All route graph pairs:
-  Flinders Street -> Southern Cross
-  Southern Cross -> North Melbourne
-  North Melbourne -> South Kensington
-  South Kensington -> Footscray
-  Footscray -> Seddon
-  Seddon -> Yarraville
-  Yarraville -> Spotswood
-  Spotswood -> Newport
-  Newport -> Seaholme
-  Seaholme -> Altona
-  Altona -> Westona
-  Westona -> Laverton
-  Newport -> Laverton
-  Laverton -> Aircraft
-  Aircraft -> Williams Landing
-  Williams Landing -> Hoppers Crossing
-  Hoppers Crossing -> Werribee
-
-Line shape edges:
-  Flinders Street -> Southern Cross: [Flinders Street -> Southern Cross]
-  Southern Cross -> North Melbourne: [Southern Cross -> North Melbourne]
-  North Melbourne -> South Kensington: [North Melbourne -> South Kensington]
-  South Kensington -> Footscray: [South Kensington -> Footscray]
-  Footscray -> Seddon: [Footscray -> Seddon]
-  Seddon -> Yarraville: [Seddon -> Yarraville]
-  Yarraville -> Spotswood: [Yarraville -> Spotswood]
-  Spotswood -> Newport: [Spotswood -> Newport]
-  Newport -> Laverton: [Newport -> Seaholme, Seaholme -> Altona, Altona -> Westona, Westona -> Laverton, Newport -> Laverton]
-  Laverton -> Aircraft: [Laverton -> Aircraft]
-  Aircraft -> Williams Landing: [Aircraft -> Williams Landing]
-  Williams Landing -> Hoppers Crossing: [Williams Landing -> Hoppers Crossing]
-  Hoppers Crossing -> Werribee: [Hoppers Crossing -> Werribee]
-
-
-
-[WILLIAMSTOWN LINE]
-
-All route graph pairs:
-  Flinders Street -> Southern Cross
-  Southern Cross -> North Melbourne
-  North Melbourne -> South Kensington
-  South Kensington -> Footscray
-  Footscray -> Seddon
-  Seddon -> Yarraville
-  Yarraville -> Spotswood
-  Spotswood -> Newport
-  Newport -> North Williamstown
-  North Williamstown -> Williamstown Beach
-  Williamstown Beach -> Williamstown
-
-Line shape edges:
-  Flinders Street -> Southern Cross: [Flinders Street -> Southern Cross]
-  Southern Cross -> North Melbourne: [Southern Cross -> North Melbourne]
-  North Melbourne -> South Kensington: [North Melbourne -> South Kensington]
-  South Kensington -> Footscray: [South Kensington -> Footscray]
-  Footscray -> Seddon: [Footscray -> Seddon]
-  Seddon -> Yarraville: [Seddon -> Yarraville]
-  Yarraville -> Spotswood: [Yarraville -> Spotswood]
-  Spotswood -> Newport: [Spotswood -> Newport]
-  Newport -> North Williamstown: [Newport -> North Williamstown]
-  North Williamstown -> Williamstown Beach: [North Williamstown -> Williamstown Beach]
-  Williamstown Beach -> Williamstown: [Williamstown Beach -> Williamstown]
 "
 `;

--- a/tests/server/entry-point/data/line-routes.test.ts
+++ b/tests/server/entry-point/data/line-routes.test.ts
@@ -3,48 +3,112 @@ import { lines } from "@/server/entry-point/data/lines";
 import { stations } from "@/server/entry-point/data/stations";
 import {
   LineShape,
+  LineShapeEdge,
   LineShapeNode,
 } from "@/server/data/line/line-routes/line-shape";
+import { Line } from "@/server/data/line/line";
+import { StationPair } from "@/server/data/line/line-routes/station-pair";
+import { MapSegment } from "@/server/data/map-segment";
+import * as map from "@/shared/map-node-ids";
 
 describe("Melbourne default line route edges", () => {
+  type Table = {
+    header: string;
+    table: [string, string, string][];
+  };
+
   it("should match the snapshot", () => {
+    const output = `\n\n\n${outputLines(lines.all())}\n\n`;
+    expect(output).toMatchSnapshot();
+  });
+
+  function outputLines(lines: Line[]) {
     let output = "";
 
-    for (const line of lines.all()) {
+    const tables = lines.map((x) => ({ header: x.name, table: getTable(x) }));
+    const column1Width = getColumnWidth(tables, 0);
+    const column2Width = getColumnWidth(tables, 1);
+    const column3Width = getColumnWidth(tables, 2);
+    const totalWidth = column1Width + column2Width + column3Width + 4;
+
+    for (const table of tables) {
       if (output !== "") {
-        output += "\n\n";
-      }
-      output += "\n";
-
-      output += `[${line.name.toUpperCase()} LINE]\n`;
-      output += `\nAll route graph pairs:\n`;
-      for (const edge of line.route.getAllRouteGraphPairs()) {
-        const a = stations.require(edge.a).name;
-        const b = stations.require(edge.b).name;
-        output += `  ${a} -> ${b}\n`;
+        output += "\n";
       }
 
-      // Cheating a bit here :)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const lineShape: LineShape = (line.route as any)._shape;
-
-      output += `\nLine shape edges:\n`;
-      for (const edge of lineShape.edges) {
-        const a = formatLineShapeNode(edge.from);
-        const b = formatLineShapeNode(edge.to);
-
-        const pairs = edge.data.routeGraphPairs.map((pair) => {
-          const a = stations.require(pair.a).name;
-          const b = stations.require(pair.b).name;
-          return `${a} -> ${b}`;
-        });
-
-        output += `  ${a} -> ${b}: [${pairs.join(", ")}]\n`;
+      output += `${"-".repeat(totalWidth)}\n`;
+      output += `${table.header.toUpperCase()}\n`;
+      output += `${"-".repeat(totalWidth)}\n`;
+      for (const row of table.table) {
+        const column1 = row[0].padEnd(column1Width);
+        const column2 = row[1].padEnd(column2Width);
+        const column3 = row[2].padEnd(column3Width);
+        output += `${column1}  ${column2}  ${column3}\n`;
       }
     }
 
-    expect(output).toMatchSnapshot();
-  });
+    return output;
+  }
+
+  function getColumnWidth(tables: Table[], column: number) {
+    return Math.max(
+      ...tables.flatMap((x) => x.table.map((x) => x[column].length)),
+    );
+  }
+
+  function getTable(line: Line) {
+    const rows: [string, string, string][] = [];
+
+    // Cheating a bit here :)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const lineShape: LineShape = (line.route as any)._shape;
+
+    for (const edge of lineShape.edges) {
+      rows.push(...rowsForFormatLineShapeEdge(edge));
+    }
+
+    return rows;
+  }
+
+  function rowsForFormatLineShapeEdge(
+    edge: LineShapeEdge,
+  ): [string, string, string][] {
+    const title = formatLineShapeEdgeTitle(edge);
+    const routeGraphEdges = edge.data.routeGraphPairs.map((x) =>
+      formatRouteGraphPair(x),
+    );
+    const mapSegments = edge.data.mapSegments.map((x) => formatMapSegment(x));
+
+    const rowCount = Math.max(1, routeGraphEdges.length, mapSegments.length);
+    const rows: [string, string, string][] = [];
+    for (let i = 0; i < rowCount; i++) {
+      const column1 = i === 0 ? title : "";
+      const column2 = i < routeGraphEdges.length ? routeGraphEdges[i] : "";
+      const column3 = i < mapSegments.length ? mapSegments[i] : "";
+      rows.push([column1, column2, column3]);
+    }
+    return rows;
+  }
+
+  function formatLineShapeEdgeTitle(edge: LineShapeEdge) {
+    const a = formatLineShapeNode(edge.from);
+    const b = formatLineShapeNode(edge.to);
+    return `${a} -> ${b}`;
+  }
+
+  function formatRouteGraphPair(edge: StationPair) {
+    const a = stations.require(edge.a).name;
+    const b = stations.require(edge.b).name;
+    return `${a} -> ${b}`;
+  }
+
+  function formatMapSegment(edge: MapSegment) {
+    const a = formatMapNode(edge.mapNodeA);
+    const b = formatMapNode(edge.mapNodeB);
+    const min = edge.percentage.min.toFixed(2);
+    const max = edge.percentage.max.toFixed(2);
+    return `${a} -> ${b} (${min} -> ${max})`;
+  }
 
   function formatLineShapeNode(boundary: LineShapeNode) {
     if (boundary === "the-city") {
@@ -52,5 +116,16 @@ describe("Melbourne default line route edges", () => {
     } else {
       return stations.require(boundary).name;
     }
+  }
+
+  function formatMapNode(searchNodeId: number): string {
+    for (const [group, groupNodes] of Object.entries(map)) {
+      for (const [node, nodeId] of Object.entries(groupNodes)) {
+        if (nodeId === searchNodeId) {
+          return `${group}.${node}`;
+        }
+      }
+    }
+    return `Unknown node "${searchNodeId}"`;
   }
 });


### PR DESCRIPTION
### Changes

- Adds map segments to each line shape edge, so that we can convert phrases like "Caulfield to Dandenong" into the appropriate list of map segments.

---

_**Note:** This PR is just a refactor of `<Map>` code, in preparation for map highlighting. There is no change in behaviour. I have quite a few changes I'd like to make to this map code (even putting highlighting aside), but I'm taking an incremental approach with several small PRs, rather than one giant one._

_I figure it's OK to skip review for this series of map highlighting PRs (especially when they're just refactors), as I don't think anyone here is super familiar with the `<Map>` code anyway, and there wasn't any interaction on the initial `<Map>` PRs. But that said, I'm still happy to open them up for review first if people are keen, so let me know if you'd prefer that._