### PR TITLE
Map highlighting (Part 9: Render icon at highlighted stations)

### DIFF
--- a/components/map/renderer/coloring-strategy/coloring-strategy.ts
+++ b/components/map/renderer/coloring-strategy/coloring-strategy.ts
@@ -19,7 +19,7 @@ export class SegmentColoring {
 
 export abstract class ColoringStrategy {
   constructor(
-    private readonly geometry: Geometry,
+    private readonly _geometry: Geometry,
     private readonly _mapHighlighting: SerializedMapHighlighting,
   ) {}
 
@@ -30,7 +30,7 @@ export abstract class ColoringStrategy {
   protected _getNodeHighlightingCoverage(
     nodeId: number,
   ): "full" | "partial" | "zero" {
-    const segments = this.geometry.getSegmentsInvolving(nodeId);
+    const segments = this._geometry.getSegmentsInvolving(nodeId);
     const highlightedCount = segments.reduce((acc, segment) => {
       const highlighting = this._getHighlightingFor(segment);
       if (highlighting.some((h) => this._highlightsNode(h, nodeId))) {

--- a/components/map/renderer/dimensions/flexi-point.ts
+++ b/components/map/renderer/dimensions/flexi-point.ts
@@ -71,6 +71,13 @@ export class FlexiPoint {
     return `${minX} ${minY} ${maxX} ${maxY}`;
   }
 
+  static midpoint(a: FlexiPoint, b: FlexiPoint): FlexiPoint {
+    return new FlexiPoint(
+      new Point((a.min.x + b.min.x) / 2, (a.min.y + b.min.y) / 2),
+      new Point((a.max.x + b.max.x) / 2, (a.max.y + b.max.y) / 2),
+    );
+  }
+
   static fromString(s: string) {
     const parsed = s
       .split(" ")

--- a/components/map/renderer/renderer.ts
+++ b/components/map/renderer/renderer.ts
@@ -8,6 +8,8 @@ import { Interchange } from "@/components/map/renderer/interchange";
 import { Segment } from "@/components/map/renderer/segment";
 import {
   getColors,
+  iconRadius,
+  iconStrokeWidth,
   interchangeBorderWidth,
   interchangeThickLineWidth,
   interchangeThinLineWidth,
@@ -298,9 +300,9 @@ export class Renderer {
     const { x, y } = point.amplify(this._amplification);
     ctx.fillStyle = this._css.foreground;
     ctx.strokeStyle = this._css["on-foreground"];
-    ctx.lineWidth = 1;
+    ctx.lineWidth = iconStrokeWidth;
     ctx.beginPath();
-    ctx.ellipse(x, y, 8, 8, 0, 0, Math.PI * 2);
+    ctx.ellipse(x, y, iconRadius, iconRadius, 0, 0, Math.PI * 2);
     ctx.fill();
     ctx.stroke();
 

--- a/components/map/renderer/renderer.ts
+++ b/components/map/renderer/renderer.ts
@@ -292,7 +292,7 @@ export class Renderer {
     const ctx = this._ctx;
 
     const { x, y } = point.amplify(this._amplification);
-    ctx.fillStyle = this._css.foreground;
+    ctx.fillStyle = this._css["foreground-strong"];
     ctx.strokeStyle = this._css["on-foreground"];
     ctx.lineWidth = iconStrokeWidth;
     ctx.beginPath();

--- a/components/map/renderer/renderer.ts
+++ b/components/map/renderer/renderer.ts
@@ -17,7 +17,10 @@ import {
   terminusLineWidth,
   viewportPadding,
 } from "@/components/map/renderer/utils";
-import { SerializedMapHighlighting } from "@/shared/types/map-data";
+import {
+  SerializedHighlightedMapPoint,
+  SerializedMapHighlighting,
+} from "@/shared/types/map-data";
 
 // Canvas has `backingStorePixelRatio`, but Typescript doesn't know about it for
 // some reason. (Probably the target "ES____" version we're using idk.)
@@ -139,6 +142,10 @@ export class Renderer {
       this._renderInterchange(interchange);
     }
 
+    for (const highlightedPoint of this._highlighting?.points ?? []) {
+      this._renderHighlightedPoint(highlightedPoint);
+    }
+
     ctx.restore();
   }
 
@@ -196,6 +203,63 @@ export class Renderer {
     }
   }
 
+  private _renderHighlightedPoint(
+    highlightedPoint: SerializedHighlightedMapPoint,
+  ) {
+    const positionA = this._getPosition(
+      highlightedPoint.segmentANodeA,
+      highlightedPoint.segmentANodeB,
+      highlightedPoint.percentage,
+    );
+    const positionB = this._getPosition(
+      highlightedPoint.segmentBNodeA,
+      highlightedPoint.segmentBNodeB,
+      highlightedPoint.percentage,
+    );
+
+    if (positionA == null || positionB == null) {
+      return;
+    }
+
+    const point = FlexiPoint.midpoint(positionA, positionB);
+    this._renderIcon(point, highlightedPoint.style);
+  }
+
+  private _getPosition(
+    nodeA: number,
+    nodeB: number,
+    percentage: number,
+  ): FlexiPoint | null {
+    if (nodeA !== nodeB) {
+      const effectiveNodeA = Math.min(nodeA, nodeB);
+      const effectiveNodeB = Math.max(nodeA, nodeB);
+      const effectivePercentage = nodeA < nodeB ? percentage : 1 - percentage;
+
+      const segment = this._geometry.segments.find(
+        (x) =>
+          x.startNodeId === effectiveNodeA && x.endNodeId === effectiveNodeB,
+      );
+
+      if (segment == null) {
+        return null;
+      }
+
+      return segment.pointAt(this._amplification, effectivePercentage);
+    } else {
+      const segment = this._geometry.segments.find(
+        (x) => x.startNodeId === nodeA || x.endNodeId === nodeA,
+      );
+
+      if (segment == null) {
+        return null;
+      }
+
+      return segment.startNodeId === nodeA
+        ? segment.pointAt(this._amplification, 0)
+        : segment.pointAt(this._amplification, 1);
+    }
+  }
+
   private _renderPath(
     points: readonly FlexiPoint[],
     lineWidth: number,
@@ -223,5 +287,32 @@ export class Renderer {
     }
 
     ctx.stroke();
+  }
+
+  private _renderIcon(
+    point: FlexiPoint,
+    iconType: SerializedHighlightedMapPoint["style"],
+  ) {
+    const ctx = this._ctx;
+
+    const { x, y } = point.amplify(this._amplification);
+    ctx.fillStyle = this._css.foreground;
+    ctx.strokeStyle = this._css["on-foreground"];
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.ellipse(x, y, 8, 8, 0, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+
+    if (iconType === "standard") {
+      ctx.lineCap = "round";
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.moveTo(x - 2.5, y - 2.5);
+      ctx.lineTo(x + 2.5, y + 2.5);
+      ctx.moveTo(x + 2.5, y - 2.5);
+      ctx.lineTo(x - 2.5, y + 2.5);
+      ctx.stroke();
+    }
   }
 }

--- a/components/map/renderer/renderer.ts
+++ b/components/map/renderer/renderer.ts
@@ -241,20 +241,14 @@ export class Renderer {
         (x) =>
           x.startNodeId === effectiveNodeA && x.endNodeId === effectiveNodeB,
       );
-
-      if (segment == null) {
-        return null;
-      }
+      if (segment == null) return null;
 
       return segment.pointAt(this._amplification, effectivePercentage);
     } else {
       const segment = this._geometry.segments.find(
         (x) => x.startNodeId === nodeA || x.endNodeId === nodeA,
       );
-
-      if (segment == null) {
-        return null;
-      }
+      if (segment == null) return null;
 
       return segment.startNodeId === nodeA
         ? segment.pointAt(this._amplification, 0)

--- a/components/map/renderer/utils.ts
+++ b/components/map/renderer/utils.ts
@@ -23,7 +23,9 @@ export type MapColor =
   | LineColor
   | "interchange-stroke"
   | "interchange-fill"
-  | "ghost-line";
+  | "ghost-line"
+  | "foreground"
+  | "on-foreground";
 
 export type MapCssColors = Record<MapColor, string>;
 
@@ -42,5 +44,7 @@ export function getColors(): MapCssColors {
     "interchange-fill": css.getPropertyValue("--color-interchange-fill"),
     "interchange-stroke": css.getPropertyValue("--color-interchange-stroke"),
     "ghost-line": css.getPropertyValue("--color-soft-border"),
+    foreground: css.getPropertyValue("--color-foreground"),
+    "on-foreground": css.getPropertyValue("--color-background"),
   };
 }

--- a/components/map/renderer/utils.ts
+++ b/components/map/renderer/utils.ts
@@ -3,6 +3,8 @@ export const interchangeThinLineWidth = 1;
 export const interchangeThickLineWidth = 4;
 export const interchangeBorderWidth = 1;
 export const terminusLineWidth = 3;
+export const iconRadius = 8;
+export const iconStrokeWidth = 1;
 
 export const viewportPadding = 10;
 

--- a/components/map/renderer/utils.ts
+++ b/components/map/renderer/utils.ts
@@ -26,7 +26,7 @@ export type MapColor =
   | "interchange-stroke"
   | "interchange-fill"
   | "ghost-line"
-  | "foreground"
+  | "foreground-strong"
   | "on-foreground";
 
 export type MapCssColors = Record<MapColor, string>;
@@ -46,7 +46,7 @@ export function getColors(): MapCssColors {
     "interchange-fill": css.getPropertyValue("--color-interchange-fill"),
     "interchange-stroke": css.getPropertyValue("--color-interchange-stroke"),
     "ghost-line": css.getPropertyValue("--color-soft-border"),
-    foreground: css.getPropertyValue("--color-foreground"),
+    "foreground-strong": css.getPropertyValue("--color-foreground-strong"),
     "on-foreground": css.getPropertyValue("--color-background"),
   };
 }

--- a/server/data/disruption/data/station-closure-disruption-data.ts
+++ b/server/data/disruption/data/station-closure-disruption-data.ts
@@ -6,7 +6,7 @@ import { RouteGraphModifier } from "@/server/data/disruption/route-graph-modifie
 import { StationClosureRouteGraphModifier } from "@/server/data/disruption/route-graph-modifier/station-closure-route-graph-modifier";
 import { App } from "@/server/app";
 import { MapHighlighter } from "@/server/data/disruption/map-highlighting/map-highlighter";
-import { EmptyMapHighlighter } from "@/server/data/disruption/map-highlighting/empty-map-highlighter";
+import { StationMapHighlighter } from "@/server/data/disruption/map-highlighting/station-map-highlighter";
 
 /**
  * A single station is closed. (Trains may be continuing to run express through
@@ -44,7 +44,6 @@ export class StationClosureDisruptionData extends DisruptionDataBase {
   }
 
   getMapHighlighter(): MapHighlighter {
-    // TODO: Use a highlighter to mark the station on the map.
-    return new EmptyMapHighlighter();
+    return new StationMapHighlighter([this.stationId]);
   }
 }

--- a/server/data/disruption/map-highlighting/station-map-highlighter.ts
+++ b/server/data/disruption/map-highlighting/station-map-highlighter.ts
@@ -1,0 +1,22 @@
+import { App } from "@/server/app";
+import { MapHighlighter } from "@/server/data/disruption/map-highlighting/map-highlighter";
+import {
+  HighlightedPoint,
+  MapHighlighting,
+} from "@/server/data/disruption/map-highlighting/map-highlighting";
+import { nonNull } from "@dan-schel/js-utils";
+
+export class StationMapHighlighter extends MapHighlighter {
+  constructor(private readonly _stationIds: number[]) {
+    super();
+  }
+
+  getHighlighting(app: App): MapHighlighting {
+    const points = this._stationIds
+      .map((x) => app.stations.require(x).mapLocation)
+      .filter(nonNull)
+      .map((x) => new HighlightedPoint(x, "standard"));
+
+    return new MapHighlighting([], points);
+  }
+}


### PR DESCRIPTION
- Render ❌ icon on the map at the location of a station closure.

<img width="400" src="https://github.com/user-attachments/assets/11f880df-1492-4f74-a73e-1819515f2fbe">
