### PR TITLE
Have renovate pin versions in package.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
   "prHourlyLimit": 10,
   "prConcurrentLimit": 500,
   "lockFileMaintenance": { "enabled": true },
+  "rangeStrategy": "pin",
   "packageRules": [
     {
       "matchCurrentVersion": ">=1.0.0",


### PR DESCRIPTION
- Update renovate config to pin package versions in package.json.
- Makes it easier to see which version of a package is actually installed (will match package-lock.json).