### PR TITLE
Remove old alerts when unpublished by PTV

### DIFF
--- a/server/alert-source/fake-alert-source.ts
+++ b/server/alert-source/fake-alert-source.ts
@@ -3,7 +3,13 @@ import { AlertSource } from "@/server/alert-source/alert-source";
 
 // For testing purposes.
 export class FakeAlertSource extends AlertSource {
+  private _alerts: Disruption[] = [];
+
+  setAlerts(alerts: Disruption[]) {
+    this._alerts = alerts;
+  }
+
   async fetchDisruptions(): Promise<Disruption[]> {
-    return [];
+    return this._alerts;
   }
 }

--- a/server/database/lib/general/database.ts
+++ b/server/database/lib/general/database.ts
@@ -72,6 +72,11 @@ export abstract class Repository<Model extends DatabaseModel> {
     }
     return items[0];
   }
+
+  /** Returns all records in this repository. */
+  async all(): Promise<DataOf<Model>[]> {
+    return this.find({});
+  }
 }
 
 export abstract class MigrationHandler {

--- a/server/task/tasks/populate-inbox-queue-task.ts
+++ b/server/task/tasks/populate-inbox-queue-task.ts
@@ -4,6 +4,7 @@ import { ALERTS } from "@/server/database/models/models";
 import { IntervalScheduler } from "@/server/task/lib/interval-scheduler";
 import { Task } from "@/server/task/lib/task";
 import { TaskScheduler } from "@/server/task/lib/task-scheduler";
+import { Disruption } from "@/types/disruption";
 
 /**
  * Fetches fresh alerts from the alert source, and writes all unseen alerts to
@@ -23,37 +24,60 @@ export class PopulateInboxQueueTask extends Task {
   async execute(app: App): Promise<void> {
     try {
       const disruptions = await app.alertSource.fetchDisruptions();
-
-      for (const disruption of disruptions) {
-        const existing = await app.database
-          .of(ALERTS)
-          .get(disruption.disruption_id.toString());
-
-        if (existing != null) return;
-
-        const alerts = new Alert(
-          disruption.disruption_id.toString(),
-          new AlertData(
-            disruption.title,
-            disruption.description,
-            disruption.url,
-            new Date(disruption.from_date),
-            disruption.to_date ? new Date(disruption.to_date) : null,
-            disruption.routes.map((route) => route.route_id),
-            disruption.stops.map((stop) => stop.stop_id),
-          ),
-          null,
-          app.time.now(),
-          null,
-          null,
-          false,
-          null,
-        );
-        await app.database.of(ALERTS).create(alerts);
-      }
+      const alerts = await app.database.of(ALERTS).all();
+      this._addNewAlerts(app, disruptions, alerts);
+      this._cleanupOldAlerts(app, disruptions, alerts);
     } catch (error) {
-      console.warn("Failed to populate unprocessed alerts.");
+      console.warn("Failed to process incoming alerts.");
       console.warn(error);
     }
+  }
+
+  private async _addNewAlerts(
+    app: App,
+    disruptions: Disruption[],
+    alerts: Alert[],
+  ) {
+    for (const disruption of disruptions) {
+      const id = disruption.disruption_id.toString();
+      if (alerts.some((x) => x.id === id)) continue;
+
+      const alert = new Alert(
+        id,
+        this._createAlertData(disruption),
+        null,
+        app.time.now(),
+        null,
+        null,
+        false,
+        null,
+      );
+
+      await app.database.of(ALERTS).create(alert);
+    }
+  }
+
+  private async _cleanupOldAlerts(
+    app: App,
+    disruptions: Disruption[],
+    alerts: Alert[],
+  ) {
+    for (const alert of alerts) {
+      if (!disruptions.some((d) => d.disruption_id.toString() === alert.id)) {
+        await app.database.of(ALERTS).delete(alert.id);
+      }
+    }
+  }
+
+  private _createAlertData(disruption: Disruption) {
+    return new AlertData(
+      disruption.title,
+      disruption.description,
+      disruption.url,
+      new Date(disruption.from_date),
+      disruption.to_date ? new Date(disruption.to_date) : null,
+      disruption.routes.map((route) => route.route_id),
+      disruption.stops.map((stop) => stop.stop_id),
+    );
   }
 }

--- a/server/task/tasks/populate-inbox-queue-task.ts
+++ b/server/task/tasks/populate-inbox-queue-task.ts
@@ -28,7 +28,7 @@ export class PopulateInboxQueueTask extends Task {
       this._addNewAlerts(app, disruptions, alerts);
       this._cleanupOldAlerts(app, disruptions, alerts);
     } catch (error) {
-      console.warn("Failed to process incoming alerts.");
+      console.warn("Failed to populate unprocessed alerts.");
       console.warn(error);
     }
   }

--- a/tests/server/task/tasks/populate-inbox-queue-task.test.ts
+++ b/tests/server/task/tasks/populate-inbox-queue-task.test.ts
@@ -1,0 +1,51 @@
+import { ALERTS } from "@/server/database/models/models";
+import { PopulateInboxQueueTask } from "@/server/task/tasks/populate-inbox-queue-task";
+import {
+  alert1,
+  alert2,
+  ptvDisruption1,
+  ptvDisruption2,
+} from "@/tests/server/task/tasks/populate-inbox-queue-task/sample-alerts";
+import { createTestApp } from "@/tests/server/utils";
+import { describe, expect, it } from "vitest";
+
+describe("PopulateInboxQueueTask", () => {
+  describe("#execute", () => {
+    it("does nothing when no change to alerts have occurred", async () => {
+      const { app, db, alertSource } = createTestApp();
+      const task = new PopulateInboxQueueTask();
+      alertSource.setAlerts([ptvDisruption1]);
+      await db.of(ALERTS).create(alert1);
+
+      await task.execute(app);
+
+      const alerts = await db.of(ALERTS).all();
+      expect(alerts).toStrictEqual([alert1]);
+    });
+
+    it("adds unseen alerts to the database", async () => {
+      const { app, db, alertSource } = createTestApp();
+      const task = new PopulateInboxQueueTask();
+      alertSource.setAlerts([ptvDisruption1, ptvDisruption2]);
+      await db.of(ALERTS).create(alert1);
+
+      await task.execute(app);
+
+      const alerts = await db.of(ALERTS).all();
+      expect(alerts).toStrictEqual([alert1, alert2]);
+    });
+
+    it("cleans up old alerts once they disappear from the source", async () => {
+      const { app, db, alertSource } = createTestApp();
+      const task = new PopulateInboxQueueTask();
+      alertSource.setAlerts([ptvDisruption1]);
+      await db.of(ALERTS).create(alert1);
+      await db.of(ALERTS).create(alert2);
+
+      await task.execute(app);
+
+      const alerts = await db.of(ALERTS).all();
+      expect(alerts).toStrictEqual([alert1]);
+    });
+  });
+});

--- a/tests/server/task/tasks/populate-inbox-queue-task/sample-alerts.ts
+++ b/tests/server/task/tasks/populate-inbox-queue-task/sample-alerts.ts
@@ -1,0 +1,103 @@
+import { Alert, AlertData } from "@/server/data/alert";
+import { Disruption } from "@/types/disruption";
+
+export const ptvDisruption1: Disruption = {
+  disruption_id: 333750,
+  title:
+    "Sunbury Line: Buses replace trains from 1am Saturday 26 April to last service Sunday 27 April 2025",
+  url: "http://ptv.vic.gov.au/live-travel-updates/article/sunbury-line-buses-replace-trains-from-1am-saturday-26-april-to-last-service-sunday-27-april-2025",
+  description:
+    "Buses replace trains between North Melbourne and Sunbury from 1am Saturday 26 April to last service Sunday 27 April, due to Metro Tunnel works.",
+  disruption_status: "Current",
+  disruption_type: "Planned Works",
+  published_on: "2025-04-10T10:39:03Z",
+  last_updated: "2025-04-25T20:26:02Z",
+  from_date: "2025-04-25T15:00:00Z",
+  to_date: "2025-04-27T17:00:00Z",
+  routes: [
+    {
+      route_type: 0,
+      route_id: 14,
+      route_name: "Sunbury",
+      route_number: "",
+      route_gtfs_id: "2-SUY",
+      direction: null,
+    },
+  ],
+  stops: [],
+  colour: "#ffd500",
+  display_on_board: true,
+  display_status: true,
+};
+
+export const ptvDisruption2: Disruption = {
+  disruption_id: 327738,
+  title:
+    "Due to construction works, customers at Hastings Station will not be able to use myki devices to Touch on / Touch off and perform Top ups until further notice.",
+  url: "http://ptv.vic.gov.au/live-travel-updates/",
+  description:
+    "Due to construction works, customers at Hastings Station will not be able to use myki devices to Touch on / Touch off and perform Top ups until further notice.",
+  disruption_status: "Current",
+  disruption_type: "Power outage",
+  published_on: "2024-12-25T10:15:38Z",
+  last_updated: "2024-12-25T10:15:39Z",
+  from_date: "2024-12-25T10:08:00Z",
+  to_date: null,
+  routes: [
+    {
+      route_type: 0,
+      route_id: 13,
+      route_name: "Stony Point",
+      route_number: "",
+      route_gtfs_id: "2-STY",
+      direction: null,
+    },
+  ],
+  stops: [
+    {
+      stop_id: 1088,
+      stop_name: "Hastings ",
+    },
+  ],
+  colour: "#ffd500",
+  display_on_board: false,
+  display_status: false,
+};
+
+export const alert1 = new Alert(
+  "333750",
+  new AlertData(
+    "Sunbury Line: Buses replace trains from 1am Saturday 26 April to last service Sunday 27 April 2025",
+    "Buses replace trains between North Melbourne and Sunbury from 1am Saturday 26 April to last service Sunday 27 April, due to Metro Tunnel works.",
+    "http://ptv.vic.gov.au/live-travel-updates/article/sunbury-line-buses-replace-trains-from-1am-saturday-26-april-to-last-service-sunday-27-april-2025",
+    new Date("2025-04-25T15:00:00Z"),
+    new Date("2025-04-27T17:00:00Z"),
+    [14],
+    [],
+  ),
+  null,
+  new Date("2025-01-01T00:00:00Z"),
+  null,
+  null,
+  false,
+  null,
+);
+
+export const alert2 = new Alert(
+  "327738",
+  new AlertData(
+    "Due to construction works, customers at Hastings Station will not be able to use myki devices to Touch on / Touch off and perform Top ups until further notice.",
+    "Due to construction works, customers at Hastings Station will not be able to use myki devices to Touch on / Touch off and perform Top ups until further notice.",
+    "http://ptv.vic.gov.au/live-travel-updates/",
+    new Date("2024-12-25T10:08:00Z"),
+    null,
+    [13],
+    [1088],
+  ),
+  null,
+  new Date("2025-01-01T00:00:00Z"),
+  null,
+  null,
+  false,
+  null,
+);


### PR DESCRIPTION
- Update `PopulateInboxQueueTask` to also remove alerts once PTV is no longer publishing them.
  - (The beta deploy has 43 pages of alerts, but most are expired now! 😅)
- Add tests, and fix [a bug](https://github.com/dan-schel/train-disruptions/blob/4b4e50397023f489a2e1938a00361d43a5a5a98d/server/task/tasks/populate-inbox-queue-task.ts#L32) that caused processing to stop as soon as the first existing alert was found.
