### PR TITLE
Add API for ignoring alerts

### DIFF
--- a/pages/admin/alerts/@id/+Page.tsx
+++ b/pages/admin/alerts/@id/+Page.tsx
@@ -11,9 +11,28 @@ import { Spacer } from "@/components/core/Spacer";
 import { disruptionPeriodQuestion } from "@/components/alert-processing/disruption-period/disruption-period-question";
 import { DisruptionPeriodInput } from "@/shared/types/alert-processing/disruption-period-input";
 import { Questionnaire } from "@/components/question";
+import { SimpleButton } from "@/components/common/SimpleButton";
+import { usePageContext } from "vike-react/usePageContext";
+import axios from "axios";
+import { navigate } from "vike/client/router";
+import { With } from "@/components/core/With";
 
 export default function Page() {
+  const { id } = usePageContext().routeParams;
   const { alert } = useData<Data>();
+
+  async function handleIgnore() {
+    if (alert == null) return;
+
+    try {
+      await axios.post(`/api/admin/alert-processing/ignore/${id}`, {
+        permanently: false,
+      });
+      navigate("/admin/alerts");
+    } catch {
+      window.alert("Failed to ignore alert.");
+    }
+  }
 
   return (
     <Column>
@@ -36,6 +55,9 @@ export default function Page() {
                   // eslint-disable-next-line no-console
                   onSubmit={(p: DisruptionPeriodInput) => console.log(p)}
                 />
+                <With className="self-start">
+                  <SimpleButton onClick={handleIgnore} text="Ignore" />
+                </With>
               </Column>
             </Column>
           ) : (

--- a/server/data/alert.ts
+++ b/server/data/alert.ts
@@ -48,6 +48,51 @@ export class Alert {
       return "processed";
     }
   }
+
+  processed() {
+    return this._with({
+      processedAt: new Date(),
+      ignoreFutureUpdates: false,
+    });
+  }
+
+  ignored() {
+    return this._with({
+      processedAt: new Date(),
+      ignoreFutureUpdates: true,
+    });
+  }
+
+  private _with({
+    id,
+    data,
+    updatedData,
+    appearedAt,
+    processedAt,
+    updatedAt,
+    ignoreFutureUpdates,
+    deleteAt,
+  }: {
+    id?: string;
+    data?: AlertData;
+    updatedData?: AlertData | null;
+    appearedAt?: Date;
+    processedAt?: Date | null;
+    updatedAt?: Date | null;
+    ignoreFutureUpdates?: boolean;
+    deleteAt?: Date | null;
+  }) {
+    return new Alert(
+      id ?? this.id,
+      data ?? this.data,
+      updatedData !== undefined ? updatedData : this.updatedData,
+      appearedAt ?? this.appearedAt,
+      processedAt !== undefined ? processedAt : this.processedAt,
+      updatedAt !== undefined ? updatedAt : this.updatedAt,
+      ignoreFutureUpdates ?? this.ignoreFutureUpdates,
+      deleteAt !== undefined ? deleteAt : this.deleteAt,
+    );
+  }
 }
 
 /**

--- a/server/routes/admin/admin.ts
+++ b/server/routes/admin/admin.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { App } from "@/server/app";
+import { isAuthenticated } from "@/server/routes/middleware/authentication";
+import { createAlertProcessingRouter } from "@/server/routes/admin/alert-processing/alert-processing";
+import { createUsersRouter } from "@/server/routes/admin/users";
+
+export function createAdminRouter(app: App) {
+  const router = Router();
+  router.use(isAuthenticated);
+  router.use("/alert-processing", createAlertProcessingRouter(app));
+  router.use("/users", createUsersRouter(app));
+  return router;
+}

--- a/server/routes/admin/alert-processing/alert-processing.ts
+++ b/server/routes/admin/alert-processing/alert-processing.ts
@@ -1,0 +1,39 @@
+import { Router } from "express";
+import { validateMiddleware } from "@/server/routes/middleware/validate";
+import { App } from "@/server/app";
+
+export function createAlertProcessingRouter(_app: App) {
+  const router = Router();
+
+  // Process an alert
+  router.post(
+    "/process",
+    validateMiddleware({
+      // params: z.whatever(),
+      // query: z.whatever(),
+      // body: z.whatever(),
+    }),
+    async (_, res) => {
+      res.json({
+        // stuff
+      });
+    },
+  );
+
+  // Ignore an alert
+  router.post(
+    "/ignore",
+    validateMiddleware({
+      // params: z.whatever(),
+      // query: z.whatever(),
+      // body: z.whatever(),
+    }),
+    async (_, res) => {
+      res.json({
+        // stuff
+      });
+    },
+  );
+
+  return router;
+}

--- a/server/routes/admin/alert-processing/alert-processing.ts
+++ b/server/routes/admin/alert-processing/alert-processing.ts
@@ -1,37 +1,62 @@
 import { Router } from "express";
 import { validateMiddleware } from "@/server/routes/middleware/validate";
 import { App } from "@/server/app";
+import z from "zod";
+import { ALERTS } from "@/server/database/models/models";
 
-export function createAlertProcessingRouter(_app: App) {
+export function createAlertProcessingRouter(app: App) {
   const router = Router();
 
-  // Process an alert
   router.post(
     "/process",
     validateMiddleware({
+      // TODO: [DS] Implement validation.
       // params: z.whatever(),
       // query: z.whatever(),
       // body: z.whatever(),
     }),
-    async (_, res) => {
+    async (req, res) => {
+      // TODO: [DS] Implement processing API.
+
       res.json({
         // stuff
       });
     },
   );
 
-  // Ignore an alert
   router.post(
-    "/ignore",
+    "/ignore/:id",
     validateMiddleware({
-      // params: z.whatever(),
-      // query: z.whatever(),
-      // body: z.whatever(),
+      params: z.object({
+        id: z.string(),
+      }),
+      body: z.object({
+        permanently: z.boolean(),
+      }),
     }),
-    async (_, res) => {
-      res.json({
-        // stuff
-      });
+    async (req, res) => {
+      const id = req.params.id;
+      const alert = await app.database.of(ALERTS).get(id);
+
+      if (alert == null) {
+        res.sendStatus(404);
+        return;
+      }
+
+      if (alert.getState() !== "new") {
+        res.status(400).json({
+          error: "Alert already processed/ignored",
+        });
+        return;
+      }
+
+      if (req.body.permanently) {
+        await app.database.of(ALERTS).update(alert.ignored());
+      } else {
+        await app.database.of(ALERTS).update(alert.processed());
+      }
+
+      res.sendStatus(200);
     },
   );
 

--- a/server/routes/admin/users.ts
+++ b/server/routes/admin/users.ts
@@ -7,18 +7,15 @@ import { uuid } from "@dan-schel/js-utils";
 import { Admin } from "@/server/database/models/admin";
 import { ADMINS } from "@/server/database/models/models";
 import { validateMiddleware } from "@/server/routes/middleware/validate";
-import { isAuthenticated } from "@/server/routes/middleware/authentication";
 
-export function createAdminRouter(app: App) {
-  const adminRouter = Router();
-
-  adminRouter.use(isAuthenticated);
+export function createUsersRouter(app: App) {
+  const router = Router();
 
   /**
    * Creates a new admin user and sends them their crendentials via Discord
    */
-  adminRouter.post(
-    "/users",
+  router.post(
+    "/",
     validateMiddleware({
       body: z.object({
         id: z.string().nonempty(),
@@ -80,8 +77,8 @@ export function createAdminRouter(app: App) {
   /**
    * Update the current users's account details
    */
-  adminRouter.put(
-    "/users/:id",
+  router.put(
+    "/:id",
     validateMiddleware({
       body: z.object({
         username: z.string(),
@@ -136,8 +133,8 @@ export function createAdminRouter(app: App) {
   /**
    * Deletes a user
    */
-  adminRouter.delete(
-    "/users/:id",
+  router.delete(
+    "/:id",
     validateMiddleware({
       params: z.object({
         id: z.string(),
@@ -168,7 +165,7 @@ export function createAdminRouter(app: App) {
     },
   );
 
-  return adminRouter;
+  return router;
 }
 
 // Not intended on being complicated, users should change their password when once they login

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -4,7 +4,7 @@ import { errorHandler } from "@/server/routes/middleware/error";
 import { App } from "@/server/app";
 import { createDisruptionRouter } from "@/server/routes/disruptions";
 import { createAuthRouter } from "@/server/routes/auth";
-import { createAdminRouter } from "@/server/routes/admin";
+import { createAdminRouter } from "@/server/routes/admin/admin";
 
 // CORS enabled to prevent API abuse from origins outside our domain(s)
 const domains = ["http://localhost:3000", "https://beta.isitbuses.com"];


### PR DESCRIPTION
- Add API endpoint `/api/admin/alert-processing/ignore/:id` for ignoring alerts.
- Add "Ignore" button to alert processing page.
- Move `/api/admin/users` APIs to a separate router.