### PR TITLE
Bugfix for updated alert state

### DIFF
--- a/server/task/tasks/populate-inbox-queue-task.ts
+++ b/server/task/tasks/populate-inbox-queue-task.ts
@@ -152,7 +152,11 @@ export class PopulateInboxQueueTask extends Task {
                 this._createAlertData(disruption),
                 alert.updatedData,
                 app.time.now(),
-                newDisruption ? app.time.now() : alert.processedAt,
+                newDisruption
+                  ? app.time.now()
+                  : existingDisruption?.curation === "automatic"
+                    ? null
+                    : alert.processedAt,
                 alert.updatedAt,
                 alert.ignoreFutureUpdates,
                 alert.deleteAt,


### PR DESCRIPTION
Fixes a bug where alerts remained `processed` if it was successfully parsed with old data but fails with new data.