### PR TITLE
Validating disruptions

### DIFF
--- a/pages/admin/alerts/+data.ts
+++ b/pages/admin/alerts/+data.ts
@@ -1,7 +1,7 @@
 import { PageContext } from "vike/types";
-import { ALERTS } from "@/server/database/models/models";
 import { JsonSerializable } from "@/shared/json-serializable";
 import { AlertPreview } from "@/shared/types/alert-data";
+import { AlertRepository } from "@/server/database-repository/alert-repository";
 
 export type Data = {
   alerts: AlertPreview;
@@ -12,9 +12,9 @@ export async function data(
 ): Promise<Data & JsonSerializable> {
   const { app } = pageContext.custom;
 
-  const alerts = await app.database
-    .of(ALERTS)
-    .find({ where: { processedAt: null } });
+  const alerts = await AlertRepository.getRepository(app).listAlerts({
+    state: ["new"],
+  });
 
   return {
     alerts: alerts.map((alert) => ({

--- a/pages/admin/alerts/@id/+data.ts
+++ b/pages/admin/alerts/@id/+data.ts
@@ -1,5 +1,4 @@
 import { PageContext } from "vike/types";
-import { ALERTS } from "@/server/database/models/models";
 import { JsonSerializable } from "@/shared/json-serializable";
 import { AlertData } from "@/server/data/alert";
 import { App } from "@/server/app";
@@ -9,6 +8,7 @@ import sanitizeHtml from "sanitize-html";
 import { formatDate } from "@/server/data/disruption/period/utils/utils";
 import { AlertProcessingContextData } from "@/shared/types/alert-processing-context-data";
 import { formatLineShapeNode } from "@/server/data/disruption/writeup/utils";
+import { AlertRepository } from "@/server/database-repository/alert-repository";
 
 type UrlPreview = { html: string } | { error: string };
 
@@ -70,7 +70,7 @@ export async function data(
   } = pageContext;
 
   const id = routeParams.id;
-  const alert = await app.database.of(ALERTS).get(id);
+  const alert = await AlertRepository.getRepository(app).getAlert(id);
 
   if (alert == null) {
     return { alert: null };

--- a/pages/disruption/@id/+data.ts
+++ b/pages/disruption/@id/+data.ts
@@ -8,7 +8,7 @@ import { Line } from "@/server/data/line/line";
 import { parseIntNull } from "@dan-schel/js-utils";
 import { SerializedMapHighlighting } from "@/shared/types/map-data";
 import { MapHighlighting } from "@/server/data/disruption/map-highlighting/map-highlighting";
-import { DISRUPTIONS } from "@/server/database/models/models";
+import { DisruptionRepository } from "@/server/database-repository/disruption-repository";
 
 export type Data = {
   disruption: {
@@ -33,7 +33,9 @@ export async function data(
   const back = determineBackBehaviour(app, urlParsed);
   const id = routeParams.id;
 
-  const disruption = await app.database.of(DISRUPTIONS).get(id);
+  const disruption = await DisruptionRepository.getRepository(
+    app,
+  ).getDisruption({ id, valid: true });
   if (disruption == null) {
     return { disruption: null, back };
   }

--- a/pages/disruption/@id/+data.ts
+++ b/pages/disruption/@id/+data.ts
@@ -35,7 +35,7 @@ export async function data(
 
   const disruption = await DisruptionRepository.getRepository(
     app,
-  ).getDisruption({ id, valid: true });
+  ).getDisruption({ id });
   if (disruption == null) {
     return { disruption: null, back };
   }

--- a/pages/index/+guard.ts
+++ b/pages/index/+guard.ts
@@ -6,5 +6,7 @@ export function guard(pageContext: PageContext): ReturnType<GuardSync> {
 
   // `render` preserves the url as '/' but requires extra logic in
   // `NavBarOrchestrator` to handle when the tab is active
-  throw render(`/${settings.startPage}`);
+  throw render(
+    `/${settings.startPage}?${new URLSearchParams(pageContext.urlParsed.search).toString()}`,
+  );
 }

--- a/pages/line/@id/+data.ts
+++ b/pages/line/@id/+data.ts
@@ -58,7 +58,6 @@ export async function data(
       lines: [line.id],
       period: new TimeRange(app.time.now(), null),
       priority: ["high", "medium", "low", "very-low"],
-      valid: true,
     })
   ).sort(
     (a, b) =>

--- a/pages/overview/+Page.tsx
+++ b/pages/overview/+Page.tsx
@@ -16,7 +16,13 @@ import { DisruptionButton } from "@/pages/overview/DisruptionButton";
 import { Select } from "@/components/common/Select";
 
 export default function Page() {
-  const { disruptions, suburban, regional, mapHighlighting } = useData<Data>();
+  const {
+    disruptions,
+    suburban,
+    regional,
+    mapHighlighting,
+    occuring: period,
+  } = useData<Data>();
 
   const [mapMode, setMapMode] = React.useState<MapMode>("show-disruptions");
 
@@ -43,10 +49,18 @@ export default function Page() {
               value={mapMode}
               onChange={setMapMode}
             />
-            {/* TODO: Determine/implement time range options. */}
             <Select
-              options={[{ label: "right now", value: "now" }]}
-              onChange={() => {}}
+              value={period}
+              options={[
+                { label: "right now", value: "now" },
+                { label: "today", value: "today" },
+                { label: "next 7 days", value: "week" },
+              ]}
+              onChange={(value) => {
+                window.location.search = new URLSearchParams({
+                  occuring: value,
+                }).toString();
+              }}
             />
           </Row>
           <Spacer h="4" />

--- a/pages/overview/+Page.tsx
+++ b/pages/overview/+Page.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useData } from "vike-react/useData";
-
 import { Data } from "@/pages/overview/+data";
 
 import { Lines } from "@/pages/overview/Lines";
@@ -16,13 +15,8 @@ import { DisruptionButton } from "@/pages/overview/DisruptionButton";
 import { Select } from "@/components/common/Select";
 
 export default function Page() {
-  const {
-    disruptions,
-    suburban,
-    regional,
-    mapHighlighting,
-    occuring: period,
-  } = useData<Data>();
+  const { disruptions, suburban, regional, mapHighlighting, occuring } =
+    useData<Data>();
 
   const [mapMode, setMapMode] = React.useState<MapMode>("show-disruptions");
 
@@ -50,7 +44,7 @@ export default function Page() {
               onChange={setMapMode}
             />
             <Select
-              value={period}
+              value={occuring}
               options={[
                 { label: "right now", value: "now" },
                 { label: "today", value: "today" },

--- a/pages/overview/+data.ts
+++ b/pages/overview/+data.ts
@@ -68,7 +68,6 @@ export async function data(
               )
             : app.time.now(),
       types: getTypesFromSettings(settings.enabledCategories),
-      valid: true,
     })
   ).map((x) => ({
     disruption: x,

--- a/server/data/disruption/data/bus-replacements-disruption-data.ts
+++ b/server/data/disruption/data/bus-replacements-disruption-data.ts
@@ -34,6 +34,10 @@ export class BusReplacementsDisruptionData extends DisruptionDataBase {
     };
   }
 
+  inspect(): string {
+    return JSON.stringify(this.toBson(), undefined, 2);
+  }
+
   getImpactedLines(_app: App): readonly number[] {
     return unique(this.sections.map((x) => x.line));
   }
@@ -48,5 +52,11 @@ export class BusReplacementsDisruptionData extends DisruptionDataBase {
 
   getMapHighlighter(): MapHighlighter {
     return new SectionMapHighlighter(this.sections);
+  }
+
+  validate(app: App): boolean {
+    return this.sections.every((section) =>
+      app.lines.get(section.line)?.route.isValidSection(section),
+    );
   }
 }

--- a/server/data/disruption/data/custom-disruption-data.ts
+++ b/server/data/disruption/data/custom-disruption-data.ts
@@ -13,6 +13,7 @@ import { SimpleRouteGraphModifier } from "@/server/data/disruption/route-graph-m
 import { CustomMapHighlighter } from "@/server/data/disruption/map-highlighting/custom-map-highlighter";
 import { MapHighlighting } from "@/server/data/disruption/map-highlighting/map-highlighting";
 import { MapHighlighter } from "@/server/data/disruption/map-highlighting/map-highlighter";
+import { App } from "@/server/app";
 
 /**
  * Used in edge cases where the normal disruption types we have don't cut it.
@@ -61,6 +62,10 @@ export class CustomDisruptionData extends DisruptionDataBase {
     };
   }
 
+  inspect(): string {
+    return JSON.stringify(this.toBson(), undefined, 2);
+  }
+
   getImpactedLines(): readonly number[] {
     return this.impactedLines;
   }
@@ -75,5 +80,9 @@ export class CustomDisruptionData extends DisruptionDataBase {
 
   getMapHighlighter(): MapHighlighter {
     return new CustomMapHighlighter(this.highlighting);
+  }
+
+  validate(app: App): boolean {
+    return this.impactedLines.every((line) => app.lines.has(line));
   }
 }

--- a/server/data/disruption/data/delays-disruption-data.ts
+++ b/server/data/disruption/data/delays-disruption-data.ts
@@ -41,6 +41,10 @@ export class DelaysDisruptionData extends DisruptionDataBase {
         new DelaysDisruptionData(x.stationId, x.delayInMinutes, x.sections),
     );
 
+  inspect(): string {
+    return JSON.stringify(this.toBson(), undefined, 2);
+  }
+
   toBson(): z.input<typeof DelaysDisruptionData.bson> {
     return {
       type: "delays",
@@ -66,5 +70,13 @@ export class DelaysDisruptionData extends DisruptionDataBase {
 
   getMapHighlighter(): MapHighlighter {
     return new DelayMapHighlighter(this.sections, [this.stationId]);
+  }
+
+  validate(app: App): boolean {
+    return (
+      this.sections.every((section) =>
+        app.lines.get(section.line)?.route.isValidSection(section),
+      ) && app.stations.has(this.stationId)
+    );
   }
 }

--- a/server/data/disruption/data/disruption-data-base.ts
+++ b/server/data/disruption/data/disruption-data-base.ts
@@ -5,8 +5,10 @@ import { DisruptionWriteupAuthor } from "@/server/data/disruption/writeup/disrup
 
 /** Stores the data inherent to this particular type of disruption. */
 export abstract class DisruptionDataBase {
+  abstract inspect(): string;
   abstract getImpactedLines(app: App): readonly number[];
   abstract getWriteupAuthor(): DisruptionWriteupAuthor;
   abstract getRouteGraphModifier(): RouteGraphModifier;
   abstract getMapHighlighter(): MapHighlighter;
+  abstract validate(app: App): boolean;
 }

--- a/server/data/disruption/data/no-trains-running-disruption-data.ts
+++ b/server/data/disruption/data/no-trains-running-disruption-data.ts
@@ -37,6 +37,10 @@ export class NoTrainsRunningDisruptionData extends DisruptionDataBase {
     };
   }
 
+  inspect(): string {
+    return JSON.stringify(this.toBson(), undefined, 2);
+  }
+
   getImpactedLines(_app: App): readonly number[] {
     return unique(this.sections.map((x) => x.line));
   }
@@ -51,5 +55,11 @@ export class NoTrainsRunningDisruptionData extends DisruptionDataBase {
 
   getMapHighlighter(): MapHighlighter {
     return new SectionMapHighlighter(this.sections);
+  }
+
+  validate(app: App): boolean {
+    return this.sections.every((section) =>
+      app.lines.get(section.line)?.route.isValidSection(section),
+    );
   }
 }

--- a/server/data/disruption/data/station-closure-disruption-data.ts
+++ b/server/data/disruption/data/station-closure-disruption-data.ts
@@ -31,6 +31,10 @@ export class StationClosureDisruptionData extends DisruptionDataBase {
     };
   }
 
+  inspect(): string {
+    return JSON.stringify(this.toBson(), undefined, 2);
+  }
+
   getImpactedLines(app: App): readonly number[] {
     return app.lines.whichStopAt(this.stationId).map((x) => x.id);
   }
@@ -45,5 +49,9 @@ export class StationClosureDisruptionData extends DisruptionDataBase {
 
   getMapHighlighter(): MapHighlighter {
     return new StationMapHighlighter([this.stationId]);
+  }
+
+  validate(app: App): boolean {
+    return app.stations.has(this.stationId);
   }
 }

--- a/server/database-repository/alert-repository.ts
+++ b/server/database-repository/alert-repository.ts
@@ -1,0 +1,51 @@
+import { App } from "@/server/app";
+import { Alert } from "@/server/data/alert";
+import { AlertModel } from "@/server/database/models/alert";
+import { ALERTS } from "@/server/database/models/models";
+import { Repository } from "@dan-schel/db";
+
+type ListAlertFilter = {
+  ids?: Alert["id"][];
+  state?: ("new" | "processed" | "ignored" | "updated")[];
+};
+
+export class AlertRepository {
+  private static repository: AlertRepository;
+  private database: Repository<AlertModel>;
+
+  constructor(app: App) {
+    this.database = app.database.of(ALERTS);
+  }
+
+  static getRepository(app: App): AlertRepository {
+    if (!this.repository) {
+      this.repository = new AlertRepository(app);
+    }
+
+    return this.repository;
+  }
+
+  async listAlerts({ ids, state }: ListAlertFilter) {
+    return (await this.database.all())
+      .filter(this._filterByIds(ids))
+      .filter(this._filterByState(state));
+  }
+
+  async getAlert(id: Alert["id"]) {
+    return await this.database.get(id);
+  }
+
+  private _filterByIds(ids: ListAlertFilter["ids"]) {
+    return function (alert: Alert) {
+      if (!ids) return true;
+      return ids.includes(alert.id);
+    };
+  }
+
+  private _filterByState(state: ListAlertFilter["state"]) {
+    return function (alert: Alert) {
+      if (!state) return true;
+      return state.includes(alert.getState());
+    };
+  }
+}

--- a/server/database-repository/disruption-repository.ts
+++ b/server/database-repository/disruption-repository.ts
@@ -40,7 +40,7 @@ export class DisruptionRepository {
     types,
     period,
     priority,
-    valid,
+    valid = true,
   }: ListDisruptionFilter) {
     return (await this.database.all())
       .filter(this._filterByLines(lines))
@@ -50,7 +50,7 @@ export class DisruptionRepository {
       .filter(this._filterByValidity(valid));
   }
 
-  async getDisruption({ id, valid }: GetDisruptionFilter) {
+  async getDisruption({ id, valid = true }: GetDisruptionFilter) {
     const disruption = await this.database.get(id);
 
     if (valid === undefined || !disruption) return disruption;

--- a/server/database-repository/disruption-repository.ts
+++ b/server/database-repository/disruption-repository.ts
@@ -1,0 +1,107 @@
+import { App } from "@/server/app";
+import { Disruption } from "@/server/data/disruption/disruption";
+import { TimeRange } from "@/server/data/disruption/period/utils/time-range";
+import { LineStatusIndicatorPriority } from "@/server/data/disruption/writeup/disruption-writeup";
+import { DisruptionModel } from "@/server/database/models/disruption";
+import { DISRUPTIONS } from "@/server/database/models/models";
+import { DisruptionType } from "@/shared/types/disruption";
+import { Repository } from "@dan-schel/db";
+
+type ListDisruptionFilter = {
+  lines?: number[];
+  types?: DisruptionType[];
+  period?: TimeRange | Date;
+  priority?: LineStatusIndicatorPriority[];
+  valid?: boolean;
+};
+
+type GetDisruptionFilter = {
+  id: Disruption["id"];
+  valid?: boolean;
+};
+
+export class DisruptionRepository {
+  private static respository: DisruptionRepository;
+  private database: Repository<DisruptionModel>;
+
+  private constructor(private app: App) {
+    this.database = app.database.of(DISRUPTIONS);
+  }
+
+  static getRepository(app: App): DisruptionRepository {
+    if (!this.respository) {
+      this.respository = new DisruptionRepository(app);
+    }
+    return this.respository;
+  }
+
+  async listDisruptions({
+    lines,
+    types,
+    period,
+    priority,
+    valid,
+  }: ListDisruptionFilter) {
+    return (await this.database.all())
+      .filter(this._filterByLines(lines))
+      .filter(this._filterByType(types))
+      .filter(this._filterByPeriod(period))
+      .filter(this._filterByPriority(priority))
+      .filter(this._filterByValidity(valid));
+  }
+
+  async getDisruption({ id, valid }: GetDisruptionFilter) {
+    const disruption = await this.database.get(id);
+
+    if (valid === undefined || !disruption) return disruption;
+
+    return this._filterByValidity(valid)(disruption) ? disruption : null;
+  }
+
+  private _filterByLines(lines: ListDisruptionFilter["lines"]) {
+    const app = this.app;
+    return function (disruption: Disruption) {
+      if (!lines) return true;
+      return (
+        new Set(disruption.data.getImpactedLines(app)).intersection(
+          new Set(lines),
+        ).size > 0
+      );
+    };
+  }
+
+  private _filterByType(type: ListDisruptionFilter["types"]) {
+    return function (disruption: Disruption) {
+      if (!type) return true;
+      return type.includes(disruption.data.toBson().type);
+    };
+  }
+
+  private _filterByPeriod(period: ListDisruptionFilter["period"]) {
+    return function (disruption: Disruption) {
+      if (!period) return true;
+      return period instanceof Date
+        ? disruption.period.occursAt(period)
+        : disruption.period.intersects(period);
+    };
+  }
+
+  private _filterByPriority(priority: ListDisruptionFilter["priority"]) {
+    const app = this.app;
+    return function (disruption: Disruption) {
+      if (!priority) return true;
+      return priority.includes(
+        disruption.data.getWriteupAuthor().write(app, disruption)
+          .lineStatusIndicator.priority,
+      );
+    };
+  }
+
+  private _filterByValidity(valid: ListDisruptionFilter["valid"]) {
+    const app = this.app;
+    return function (disruption: Disruption) {
+      if (valid === undefined) return true;
+      return valid === disruption.data.validate(app);
+    };
+  }
+}

--- a/shared/types/disruption.ts
+++ b/shared/types/disruption.ts
@@ -1,0 +1,7 @@
+export type DisruptionType =
+  | "custom"
+  | "station-closure"
+  | "bus-replacements"
+  | "delays"
+  | "no-city-loop"
+  | "no-trains-running";


### PR DESCRIPTION
Updates all disruption data classes to have a validation function to filter viewable data.
- Validation is only used to check that the values that were provided in the constructor are still valid/exist.
- `inspect()` currently returns JSON formatted string like below
```
{
  "type": "bus-replacements",
  "sections": [
    {
      "line": 17,
      "a": 104,
      "b": 200
    }
  ]
}
```

### New place to fetch disruptions and alerts from
Due to limitations of the database fetching and filtering by nested objects, we need a different way to filter the data we display. Where possible, data will be queried directly from the database but in instances where that is not possible (e.g. getting disruption by type), that filtering will be achieved by fetching all entries and then applying filter(s) on the server side.

With this implementation, the overview page now has the option to filter results by different time ranges and also allows us to start respecting the users' settings for which types of disruptions to display. 


> At the time of writing, works on the UI on the admin side is in progress for us to view and manage all disruptions stored on the database.